### PR TITLE
Also build metrics packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,16 @@ clean:  ## clean up temporary files
 build: clean  ## build the packages to be deployed to PyPI
 	cp LICENCE NOTICE packages/ref
 	cp LICENCE NOTICE packages/ref-core
+	cp LICENCE NOTICE packages/ref-metrics-example
+	cp LICENCE NOTICE packages/ref-metrics-esmvaltool
+	cp LICENCE NOTICE packages/ref-metrics-ilamb
+	cp LICENCE NOTICE packages/ref-metrics-pmp
 	uv build --package cmip_ref --no-sources
 	uv build --package cmip_ref_core --no-sources
+	uv build --package cmip_ref_metrics_example --no-sources
+	uv build --package cmip_ref_metrics_esmvaltool --no-sources
+	uv build --package cmip_ref_metrics_ilamb --no-sources
+	uv build --package cmip_ref_metrics_pmp --no-sources
 
 .PHONY: ruff-fixes
 ruff-fixes:  ## fix the code using ruff

--- a/changelog/81.feature.md
+++ b/changelog/81.feature.md
@@ -1,0 +1,1 @@
+Added metrics packages to build command.


### PR DESCRIPTION
## Description

In order to publish our packages through conda-forge #80, it would be useful to have all packages available on PyPI first. This adds the metrics packages to the build command. @lewisjared Is that sufficient to publish those on PyPI?

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
