### PR TITLE
Fix CMIP-REF -> Climate-REF renaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Example of an environment file for the CMIP-REF project
+# Example of an environment file for the CLIMATE-REF project
 # This allows for running the project in a development environment outside of a container
 
 CELERY_BROKER_URL=redis://localhost:6379/1

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -23,7 +23,7 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     env:
-      CI_COMMIT_EMAIL: "ci-runner@cmip-ref.invalid"
+      CI_COMMIT_EMAIL: "ci-runner@climate-ref.invalid"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: dsaltares/fetch-gh-release-asset@master
         with:
-          repo: 'CMIP-REF/cmip-ref'
+          repo: 'CLIMATE-REF/climate-ref'
           version: tags/${{  github.ref_name }}
           regex: true
           file: ".*"

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ build: clean  ## build the packages to be deployed to PyPI
 	uv build --package cmip_ref --no-sources
 	uv build --package cmip_ref_core --no-sources
 	uv build --package cmip_ref_celery --no-sources
+	uv build --package cmip_ref_metrics_esmvaltool --no-sources
+	uv build --package cmip_ref_metrics_ilamb --no-sources
+	uv build --package cmip_ref_metrics_pmp --no-sources
+	uv build --package cmip_ref_metrics_example --no-sources
 
 .PHONY: ruff-fixes
 ruff-fixes:  ## fix the code using ruff

--- a/Makefile
+++ b/Makefile
@@ -169,4 +169,4 @@ fetch-test-data:  ## Download any data needed by the test suite
 
 .PHONY: update-sample-data-registry
 update-sample-data-registry:  ## Update the sample data registry
-	curl --output packages/ref/src/cmip_ref/datasets/sample_data.txt https://raw.githubusercontent.com/CMIP-REF/ref-sample-data/refs/heads/main/registry.txt
+	curl --output packages/ref/src/cmip_ref/datasets/sample_data.txt https://raw.githubusercontent.com/Climate-REF/ref-sample-data/refs/heads/main/registry.txt

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ It is designed to be used as a CI/CD pipeline to provide a quick validation of C
 CMIP REF is a community project, and we welcome contributions from anyone.
 
 
-[![CI](https://github.com/CMIP-REF/cmip-ref/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/CMIP-REF/cmip-ref/actions/workflows/ci.yaml)
-[![Coverage](https://codecov.io/gh/CMIP-REF/cmip-ref/branch/main/graph/badge.svg)](https://codecov.io/gh/CMIP-REF/cmip-ref)
-[![Docs](https://readthedocs.org/projects/cmip-ref/badge/?version=latest)](https://cmip-ref.readthedocs.io)
+[![CI](https://github.com/CLIMATE-REF/climate-ref/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/CLIMATE-REF/climate-ref/actions/workflows/ci.yaml)
+[![Coverage](https://codecov.io/gh/CLIMATE-REF/climate-ref/branch/main/graph/badge.svg)](https://codecov.io/gh/CLIMATE-REF/climate-ref)
+[![Docs](https://readthedocs.org/projects/climate-ref/badge/?version=latest)](https://cmip-ref.readthedocs.io)
 
 **PyPI :**
 [![PyPI](https://img.shields.io/pypi/v/cmip_ref.svg)](https://pypi.org/project/cmip-ref/)
 [![PyPI: Supported Python versions](https://img.shields.io/pypi/pyversions/cmip_ref.svg)](https://pypi.org/project/cmip-ref/)
 
 **Other info :**
-[![Licence](https://img.shields.io/github/license/CMIP-REF/cmip-ref.svg)](https://github.com/CMIP-REF/cmip-ref/blob/main/LICENCE)
-[![Last Commit](https://img.shields.io/github/last-commit/CMIP-REF/cmip-ref.svg)](https://github.com/CMIP-REF/cmip-ref/commits/main)
-[![Contributors](https://img.shields.io/github/contributors/CMIP-REF/cmip-ref.svg)](https://github.com/CMIP-REF/cmip-ref/graphs/contributors)
+[![Licence](https://img.shields.io/github/license/CLIMATE-REF/climate-ref.svg)](https://github.com/CLIMATE-REF/climate-ref/blob/main/LICENCE)
+[![Last Commit](https://img.shields.io/github/last-commit/CLIMATE-REF/climate-ref.svg)](https://github.com/CLIMATE-REF/climate-ref/commits/main)
+[![Contributors](https://img.shields.io/github/contributors/CLIMATE-REF/climate-ref.svg)](https://github.com/CLIMATE-REF/climate-ref/graphs/contributors)
 
 ## Getting started
 

--- a/changelog/119.docs.md
+++ b/changelog/119.docs.md
@@ -1,0 +1,1 @@
+Renamed CMIP-REF to Climate-REF

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 # Services to run the Rapid Evaluation Framework (REF) metric workers
 # These can be started by running `docker-compose up` in the root directory of the codebase.
 
-name: cmip-ref
+name: climate-ref
 services:
   redis:
     image: redis:7

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,23 +25,23 @@ from the examples given in that link.
 
 ### Breaking Changes
 
-- Refactor `cmip_ref.env` module to `cmip_ref_core.env` ([#60](https://github.com/CMIP-REF/cmip-ref/pulls/60))
+- Refactor `cmip_ref.env` module to `cmip_ref_core.env` ([#60](https://github.com/CLIMATE-REF/climate-ref/pulls/60))
 - Removed `cmip_ref.executor.ExecutorManager` in preference to loading an executor using a fully qualified package name.
 
   This allows the user to specify a custom executor as configuration
-  without needing any change to the REF codebase. ([#77](https://github.com/CMIP-REF/cmip-ref/pulls/77))
+  without needing any change to the REF codebase. ([#77](https://github.com/CLIMATE-REF/climate-ref/pulls/77))
 - Renamed the `$.paths.tmp` in the configuration to `$.paths.scratch` to better reflect its purpose.
-  This requires a change to the configuration file if you have a custom configuration. ([#89](https://github.com/CMIP-REF/cmip-ref/pulls/89))
+  This requires a change to the configuration file if you have a custom configuration. ([#89](https://github.com/CLIMATE-REF/climate-ref/pulls/89))
 - The REF now uses absolute paths throughout the application.
 
   This removes the need for a `config.paths.data` directory and the `config.paths.allow_out_of_tree_datasets` configuration option.
   This will enable more flexibility about where input datasets are ingested from.
-  Using absolute paths everywhere does add a requirement that datasets are available via the same paths for all nodes/container that may run the REF. ([#100](https://github.com/CMIP-REF/cmip-ref/pulls/100))
+  Using absolute paths everywhere does add a requirement that datasets are available via the same paths for all nodes/container that may run the REF. ([#100](https://github.com/CLIMATE-REF/climate-ref/pulls/100))
 - An [Executor][cmip_ref_core.executor.Executor] now supports only the asynchronous processing of tasks.
   A result is now not returned from the `run_metric` method,
   but instead optionally updated in the database.
 
-  The `run_metric` method also now requires a `provider` argument to be passed in. ([#104](https://github.com/CMIP-REF/cmip-ref/pulls/104))
+  The `run_metric` method also now requires a `provider` argument to be passed in. ([#104](https://github.com/CLIMATE-REF/climate-ref/pulls/104))
 
 ### Features
 
@@ -49,82 +49,82 @@ from the examples given in that link.
 
   Celery is a distributed task queue that allows you to run tasks asynchronously.
   This package will be used as a test bed for running the REF in a distributed environment,
-  as it can be deployed locally using docker containers. ([#60](https://github.com/CMIP-REF/cmip-ref/pulls/60))
-- Add `metric_providers` and `executor` sections to the configuration which loads the metric provider and executor using a fully qualified package name. ([#77](https://github.com/CMIP-REF/cmip-ref/pulls/77))
-- Implemented Pydantic data models to validate and serialize CMEC metric and output bundles. ([#84](https://github.com/CMIP-REF/cmip-ref/pulls/84))
+  as it can be deployed locally using docker containers. ([#60](https://github.com/CLIMATE-REF/climate-ref/pulls/60))
+- Add `metric_providers` and `executor` sections to the configuration which loads the metric provider and executor using a fully qualified package name. ([#77](https://github.com/CLIMATE-REF/climate-ref/pulls/77))
+- Implemented Pydantic data models to validate and serialize CMEC metric and output bundles. ([#84](https://github.com/CLIMATE-REF/climate-ref/pulls/84))
 - Add the `cmip_ref_celery` CLI commands to the `ref` CLI tool.
   These commands should be available when the `cmip_ref_celery` package is installed.
-  The commands should be available in the `ref` CLI tool as `ref celery ...`. ([#86](https://github.com/CMIP-REF/cmip-ref/pulls/86))
+  The commands should be available in the `ref` CLI tool as `ref celery ...`. ([#86](https://github.com/CLIMATE-REF/climate-ref/pulls/86))
 - Add `fetch-sample-data` to the CLI under the `datasets` command.
 
   ```bash
   ref datasets fetch-sample-data --version v0.3.0 --force-cleanup
-  ``` ([#96](https://github.com/CMIP-REF/cmip-ref/pulls/96))
+  ``` ([#96](https://github.com/CLIMATE-REF/climate-ref/pulls/96))
 - Add a [Celery](https://docs.celeryq.dev/en/stable/)-based executor
-  to enable asynchronous processing of tasks. ([#104](https://github.com/CMIP-REF/cmip-ref/pulls/104))
-- Add `ref executions list` and `ref executions inspect` CLI commands for interacting with metric executions. ([#108](https://github.com/CMIP-REF/cmip-ref/pulls/108))
+  to enable asynchronous processing of tasks. ([#104](https://github.com/CLIMATE-REF/climate-ref/pulls/104))
+- Add `ref executions list` and `ref executions inspect` CLI commands for interacting with metric executions. ([#108](https://github.com/CLIMATE-REF/climate-ref/pulls/108))
 
 ### Improvements
 
-- Move ILAMB/IOMB reference data initialization to a registry-dependent script. ([#83](https://github.com/CMIP-REF/cmip-ref/pulls/83))
-- ILAMB gpp metrics added with full html output and plots. ([#88](https://github.com/CMIP-REF/cmip-ref/pulls/88))
-- Saner error messages for configuration errors ([#89](https://github.com/CMIP-REF/cmip-ref/pulls/89))
+- Move ILAMB/IOMB reference data initialization to a registry-dependent script. ([#83](https://github.com/CLIMATE-REF/climate-ref/pulls/83))
+- ILAMB gpp metrics added with full html output and plots. ([#88](https://github.com/CLIMATE-REF/climate-ref/pulls/88))
+- Saner error messages for configuration errors ([#89](https://github.com/CLIMATE-REF/climate-ref/pulls/89))
 - Centralised the declaration of environment variable overrides of configuration values.
 
   Renamed the `REF_OUTPUT_ROOT` environment variable to `REF_RESULTS_ROOT` to better reflect its purpose.
-  It was previously unused. ([#92](https://github.com/CMIP-REF/cmip-ref/pulls/92))
+  It was previously unused. ([#92](https://github.com/CLIMATE-REF/climate-ref/pulls/92))
 - Sample data is now copied to the `test/test-data/sample-data` instead of symlinked.
 
   This makes it easier to use the sample data with remote executors as the data is now self-contained
-  without any links to other parts of the file system. ([#96](https://github.com/CMIP-REF/cmip-ref/pulls/96))
-- Integrated the pycmec validation models into ref core and metric packages ([#99](https://github.com/CMIP-REF/cmip-ref/pulls/99))
-- Added ILAMB relationship analysis to the current metrics and flexibility to define new metrics in ILAMB via a yaml file. ([#101](https://github.com/CMIP-REF/cmip-ref/pulls/101))
-- Sped up the test suite execution ([#103](https://github.com/CMIP-REF/cmip-ref/pulls/103))
+  without any links to other parts of the file system. ([#96](https://github.com/CLIMATE-REF/climate-ref/pulls/96))
+- Integrated the pycmec validation models into ref core and metric packages ([#99](https://github.com/CLIMATE-REF/climate-ref/pulls/99))
+- Added ILAMB relationship analysis to the current metrics and flexibility to define new metrics in ILAMB via a yaml file. ([#101](https://github.com/CLIMATE-REF/climate-ref/pulls/101))
+- Sped up the test suite execution ([#103](https://github.com/CLIMATE-REF/climate-ref/pulls/103))
 
 ### Improved Documentation
 
-- Added an excerpt from the architecture design document ([#87](https://github.com/CMIP-REF/cmip-ref/pulls/87))
-- Adds a roadmap to the documentation ([#98](https://github.com/CMIP-REF/cmip-ref/pulls/98))
+- Added an excerpt from the architecture design document ([#87](https://github.com/CLIMATE-REF/climate-ref/pulls/87))
+- Adds a roadmap to the documentation ([#98](https://github.com/CLIMATE-REF/climate-ref/pulls/98))
 
 ### Trivial/Internal Changes
 
-- [#97](https://github.com/CMIP-REF/cmip-ref/pulls/97), [#102](https://github.com/CMIP-REF/cmip-ref/pulls/102), [#116](https://github.com/CMIP-REF/cmip-ref/pulls/116), [#118](https://github.com/CMIP-REF/cmip-ref/pulls/118)
+- [#97](https://github.com/CLIMATE-REF/climate-ref/pulls/97), [#102](https://github.com/CLIMATE-REF/climate-ref/pulls/102), [#116](https://github.com/CLIMATE-REF/climate-ref/pulls/116), [#118](https://github.com/CLIMATE-REF/climate-ref/pulls/118)
 
 
 ## cmip_ref 0.1.6 (2025-02-03)
 
 ### Features
 
-- Added Equilibrium Climate Sensitivity (ECS) to the ESMValTool metrics package. ([#51](https://github.com/CMIP-REF/cmip-ref/pulls/51))
-- Added Transient Climate Response (TCS) to the ESMValTool metrics package. ([#62](https://github.com/CMIP-REF/cmip-ref/pulls/62))
-- Added the possibility to request datasets with complete and overlapping timeranges. ([#64](https://github.com/CMIP-REF/cmip-ref/pulls/64))
+- Added Equilibrium Climate Sensitivity (ECS) to the ESMValTool metrics package. ([#51](https://github.com/CLIMATE-REF/climate-ref/pulls/51))
+- Added Transient Climate Response (TCS) to the ESMValTool metrics package. ([#62](https://github.com/CLIMATE-REF/climate-ref/pulls/62))
+- Added the possibility to request datasets with complete and overlapping timeranges. ([#64](https://github.com/CLIMATE-REF/climate-ref/pulls/64))
 - Added a constraint for selecting supplementary variables, e.g. cell measures or
-  ancillary variables. ([#65](https://github.com/CMIP-REF/cmip-ref/pulls/65))
-- Added a sample metric to the ilamb metrics package. ([#66](https://github.com/CMIP-REF/cmip-ref/pulls/66))
-- Added a sample metric to the PMP metrics package. ([#72](https://github.com/CMIP-REF/cmip-ref/pulls/72))
-- - Added the standard ILAMB bias analysis as a metric. ([#74](https://github.com/CMIP-REF/cmip-ref/pulls/74))
+  ancillary variables. ([#65](https://github.com/CLIMATE-REF/climate-ref/pulls/65))
+- Added a sample metric to the ilamb metrics package. ([#66](https://github.com/CLIMATE-REF/climate-ref/pulls/66))
+- Added a sample metric to the PMP metrics package. ([#72](https://github.com/CLIMATE-REF/climate-ref/pulls/72))
+- - Added the standard ILAMB bias analysis as a metric. ([#74](https://github.com/CLIMATE-REF/climate-ref/pulls/74))
 
 ### Bug Fixes
 
-- - Added overlooked code to fully integrate ilamb into ref. ([#73](https://github.com/CMIP-REF/cmip-ref/pulls/73))
-- Correct the expected configuration name to `ref.toml` as per the documentation. ([#82](https://github.com/CMIP-REF/cmip-ref/pulls/82))
+- - Added overlooked code to fully integrate ilamb into ref. ([#73](https://github.com/CLIMATE-REF/climate-ref/pulls/73))
+- Correct the expected configuration name to `ref.toml` as per the documentation. ([#82](https://github.com/CLIMATE-REF/climate-ref/pulls/82))
 
 ### Improved Documentation
 
 - Update the package name in the changelog.
 
-  This will simplify the release process by fixing the extraction of changelog entries. ([#61](https://github.com/CMIP-REF/cmip-ref/pulls/61))
+  This will simplify the release process by fixing the extraction of changelog entries. ([#61](https://github.com/CLIMATE-REF/climate-ref/pulls/61))
 
 ### Trivial/Internal Changes
 
-- [#68](https://github.com/CMIP-REF/cmip-ref/pulls/68)
+- [#68](https://github.com/CLIMATE-REF/climate-ref/pulls/68)
 
 
 ## cmip_ref 0.1.5 (2025-01-13)
 
 ### Trivial/Internal Changes
 
-- [#56](https://github.com/CMIP-REF/cmip-ref/pulls/56)
+- [#56](https://github.com/CLIMATE-REF/climate-ref/pulls/56)
 
 
 ## cmip_ref 0.1.4 (2025-01-13)
@@ -134,28 +134,28 @@ from the examples given in that link.
 - Adds an `ingest` CLI command to ingest a new set of data into the database.
 
   This breaks a previous migration as alembic's `render_as_batch` attribute should have been set
-  to support targeting sqlite. ([#14](https://github.com/CMIP-REF/cmip-ref/pulls/14))
-- Renames `ref ingest` to `ref datasets ingest` ([#30](https://github.com/CMIP-REF/cmip-ref/pulls/30))
+  to support targeting sqlite. ([#14](https://github.com/CLIMATE-REF/climate-ref/pulls/14))
+- Renames `ref ingest` to `ref datasets ingest` ([#30](https://github.com/CLIMATE-REF/climate-ref/pulls/30))
 - Prepend package names with `cmip_` to avoid conflicting with an existing `PyPI` package.
 
   This is a breaking change because it changes the package name and all imports.
-  All package names will now begin with `cmip_ref`. ([#53](https://github.com/CMIP-REF/cmip-ref/pulls/53))
+  All package names will now begin with `cmip_ref`. ([#53](https://github.com/CLIMATE-REF/climate-ref/pulls/53))
 
 ### Features
 
 - Migrate to use UV workspaces to support multiple packages in the same repository.
   Adds a `ref-metrics-example` package that will be used to demonstrate the integration of a metric
-  package into the REF. ([#2](https://github.com/CMIP-REF/cmip-ref/pulls/2))
+  package into the REF. ([#2](https://github.com/CLIMATE-REF/climate-ref/pulls/2))
 - Adds the placeholder concept of `Executor`'s which are responsible for running metrics
-  in different environments. ([#4](https://github.com/CMIP-REF/cmip-ref/pulls/4))
+  in different environments. ([#4](https://github.com/CLIMATE-REF/climate-ref/pulls/4))
 - Adds the concept of MetricProvider's and Metrics to the core.
   These represent the functionality that metric providers must implement in order to be part of the REF.
-  The implementation is still a work in progress and will be expanding in follow-up PRs. ([#5](https://github.com/CMIP-REF/cmip-ref/pulls/5))
+  The implementation is still a work in progress and will be expanding in follow-up PRs. ([#5](https://github.com/CLIMATE-REF/climate-ref/pulls/5))
 - Add a collection of ESGF data that is required for test suite.
 
-  Package developers should run `make fetch-test-data` to download the required data for the test suite. ([#6](https://github.com/CMIP-REF/cmip-ref/pulls/6))
-- Adds the `ref` package with a basic CLI interface that will allow for users to interact with the database of jobs. ([#8](https://github.com/CMIP-REF/cmip-ref/pulls/8))
-- Add `SqlAlchemy` as an ORM for the database alongside `alembic` for managing database migrations. ([#11](https://github.com/CMIP-REF/cmip-ref/pulls/11))
+  Package developers should run `make fetch-test-data` to download the required data for the test suite. ([#6](https://github.com/CLIMATE-REF/climate-ref/pulls/6))
+- Adds the `ref` package with a basic CLI interface that will allow for users to interact with the database of jobs. ([#8](https://github.com/CLIMATE-REF/climate-ref/pulls/8))
+- Add `SqlAlchemy` as an ORM for the database alongside `alembic` for managing database migrations. ([#11](https://github.com/CLIMATE-REF/climate-ref/pulls/11))
 - Added a `DataRequirement` class to declare the requirements for a metric.
 
   This provides the ability to:
@@ -164,51 +164,51 @@ from the examples given in that link.
   * group datasets together to be used in a metric calculation
   * declare constraints on the data that is required for a metric calculation
 
-  ([#15](https://github.com/CMIP-REF/cmip-ref/pulls/15))
-- Add a placeholder iterative metric solving scheme ([#16](https://github.com/CMIP-REF/cmip-ref/pulls/16))
-- Extract a data catalog from the database to list the currently ingested datasets ([#24](https://github.com/CMIP-REF/cmip-ref/pulls/24))
+  ([#15](https://github.com/CLIMATE-REF/climate-ref/pulls/15))
+- Add a placeholder iterative metric solving scheme ([#16](https://github.com/CLIMATE-REF/climate-ref/pulls/16))
+- Extract a data catalog from the database to list the currently ingested datasets ([#24](https://github.com/CLIMATE-REF/climate-ref/pulls/24))
 - Translated selected groups of datasets into `MetricDataset`s.
   Each `MetricDataset` contains all of the dataset's needed for a given execution of a metric.
 
   Added a slug to the `MetricDataset` to uniquely identify the execution
-  and make it easier to identify the execution in the logs. ([#29](https://github.com/CMIP-REF/cmip-ref/pulls/29))
-- Adds `ref datasets list` command to list ingested datasets ([#30](https://github.com/CMIP-REF/cmip-ref/pulls/30))
+  and make it easier to identify the execution in the logs. ([#29](https://github.com/CLIMATE-REF/climate-ref/pulls/29))
+- Adds `ref datasets list` command to list ingested datasets ([#30](https://github.com/CLIMATE-REF/climate-ref/pulls/30))
 - Add database structures to represent a metric execution.
-  We record previous executions of a metric to minimise the number of times we need to run metrics. ([#31](https://github.com/CMIP-REF/cmip-ref/pulls/31))
+  We record previous executions of a metric to minimise the number of times we need to run metrics. ([#31](https://github.com/CLIMATE-REF/climate-ref/pulls/31))
 - Added option to skip any datasets that fail validation and to specify the number of cores to
   use when ingesting datasets.
-  This behaviour can be opted in using the `--skip-invalid` and `--n-jobs` options respectively. ([#36](https://github.com/CMIP-REF/cmip-ref/pulls/36))
-- Track datasets that were used for different metric executions ([#39](https://github.com/CMIP-REF/cmip-ref/pulls/39))
-- Added an example ESMValTool metric. ([#40](https://github.com/CMIP-REF/cmip-ref/pulls/40))
+  This behaviour can be opted in using the `--skip-invalid` and `--n-jobs` options respectively. ([#36](https://github.com/CLIMATE-REF/climate-ref/pulls/36))
+- Track datasets that were used for different metric executions ([#39](https://github.com/CLIMATE-REF/climate-ref/pulls/39))
+- Added an example ESMValTool metric. ([#40](https://github.com/CLIMATE-REF/climate-ref/pulls/40))
 - Support the option for different assumptions about the root paths between executors and the ref CLI.
 
   Where possible path fragments are stored in the database instead of complete paths.
-  This allows the ability to move the data folders without needing to update the database. ([#46](https://github.com/CMIP-REF/cmip-ref/pulls/46))
+  This allows the ability to move the data folders without needing to update the database. ([#46](https://github.com/CLIMATE-REF/climate-ref/pulls/46))
 
 ### Improvements
 
-- Add a bump, release and deploy flow for automating the release procedures ([#20](https://github.com/CMIP-REF/cmip-ref/pulls/20))
-- Migrate test data into standalone [CMIP-REF/ref-sample-data](https://github.com/CMIP-REF/ref-sample-data) repository.
+- Add a bump, release and deploy flow for automating the release procedures ([#20](https://github.com/CLIMATE-REF/climate-ref/pulls/20))
+- Migrate test data into standalone [CLIMATE-REF/ref-sample-data](https://github.com/CLIMATE-REF/ref-sample-data) repository.
 
   The sample data will be downloaded by the test suite automatically into `tests/test-data/sample-data`,
-  or manually by running `make fetch-test-data`. ([#49](https://github.com/CMIP-REF/cmip-ref/pulls/49))
+  or manually by running `make fetch-test-data`. ([#49](https://github.com/CLIMATE-REF/climate-ref/pulls/49))
 
 ### Bug Fixes
 
-- Adds `version` field to the `instance_id` field for CMIP6 datasets ([#35](https://github.com/CMIP-REF/cmip-ref/pulls/35))
+- Adds `version` field to the `instance_id` field for CMIP6 datasets ([#35](https://github.com/CLIMATE-REF/climate-ref/pulls/35))
 - Handle missing branch times.
-  Fixes [#38](https://github.com/CMIP-REF/cmip-ref/issues/38). ([#42](https://github.com/CMIP-REF/cmip-ref/pulls/42))
-- Move alembic configuration and migrations to `cmip_ref` package so that they can be included in the distribution. ([#54](https://github.com/CMIP-REF/cmip-ref/pulls/54))
+  Fixes [#38](https://github.com/CLIMATE-REF/climate-ref/issues/38). ([#42](https://github.com/CLIMATE-REF/climate-ref/pulls/42))
+- Move alembic configuration and migrations to `cmip_ref` package so that they can be included in the distribution. ([#54](https://github.com/CLIMATE-REF/climate-ref/pulls/54))
 
 ### Improved Documentation
 
-- Deployed documentation to https://cmip-ref.readthedocs.io/en/latest/ ([#16](https://github.com/CMIP-REF/cmip-ref/pulls/16))
+- Deployed documentation to https://cmip-ref.readthedocs.io/en/latest/ ([#16](https://github.com/CLIMATE-REF/climate-ref/pulls/16))
 - General documentation cleanup.
 
-  Added notebook describing the process of executing a notebook locally ([#19](https://github.com/CMIP-REF/cmip-ref/pulls/19))
-- Add Apache licence to the codebase ([#21](https://github.com/CMIP-REF/cmip-ref/pulls/21))
-- Improved developer documentation. ([#47](https://github.com/CMIP-REF/cmip-ref/pulls/47))
+  Added notebook describing the process of executing a notebook locally ([#19](https://github.com/CLIMATE-REF/climate-ref/pulls/19))
+- Add Apache licence to the codebase ([#21](https://github.com/CLIMATE-REF/climate-ref/pulls/21))
+- Improved developer documentation. ([#47](https://github.com/CLIMATE-REF/climate-ref/pulls/47))
 
 ### Trivial/Internal Changes
 
-- [#41](https://github.com/CMIP-REF/cmip-ref/pulls/41), [#44](https://github.com/CMIP-REF/cmip-ref/pulls/44), [#48](https://github.com/CMIP-REF/cmip-ref/pulls/48), [#52](https://github.com/CMIP-REF/cmip-ref/pulls/52), [#55](https://github.com/CMIP-REF/cmip-ref/pulls/55)
+- [#41](https://github.com/CLIMATE-REF/climate-ref/pulls/41), [#44](https://github.com/CLIMATE-REF/climate-ref/pulls/44), [#48](https://github.com/CLIMATE-REF/climate-ref/pulls/48), [#52](https://github.com/CLIMATE-REF/climate-ref/pulls/52), [#55](https://github.com/CLIMATE-REF/climate-ref/pulls/55)

--- a/docs/development.md
+++ b/docs/development.md
@@ -52,7 +52,7 @@ this can be modified by changing the `db.database_url` setting in the `ref.toml`
 
 If there are any issues, the messages from the `Makefile` should guide you
 through. If not, please raise an issue in the
-[issue tracker](https://github.com/CMIP-REF/cmip-ref/issues).
+[issue tracker](https://github.com/CLIMATE-REF/climate-ref/issues).
 
 ### Pip editable installation
 
@@ -86,7 +86,7 @@ make test
 
 ### Sample data
 
-We use sample data  from [ref-sample-data](https://github.com/CMIP-REF/ref-sample-data)
+We use sample data  from [ref-sample-data](https://github.com/CLIMATE-REF/ref-sample-data)
 to provide a consistent set of data for testing.
 These data are fetched automatically by the test suite.
 
@@ -162,7 +162,7 @@ allow us to identify where key changes were made.
 We use [towncrier](https://towncrier.readthedocs.io/en/stable/)
 to manage our changelog which involves writing a news fragment
 for each Merge Request that will be added to the [changelog](./changelog.md) on the next release.
-See the [changelog](https://github.com/CMIP-REF/cmip-ref/tree/main/changelog) directory
+See the [changelog](https://github.com/CLIMATE-REF/climate-ref/tree/main/changelog) directory
 for more information about the format of the changelog entries.
 
 ## Dependency management
@@ -220,15 +220,15 @@ but this is something that we will consider in the future.
 The steps required are the following:
 
 1. Bump the version: manually trigger the "bump" workflow from the main branch
-   (see here: [bump workflow](https://github.com/CMIP-REF/cmip-ref/actions/workflows/bump.yaml)).
+   (see here: [bump workflow](https://github.com/CLIMATE-REF/climate-ref/actions/workflows/bump.yaml)).
    A valid "bump_rule" will need to be specified.
    This will then trigger a draft release.
 
 1. Edit the draft release which has been created
-   (see here: [project releases](https://github.com/CMIP-REF/cmip-ref/releases)).
+   (see here: [project releases](https://github.com/CLIMATE-REF/climate-ref/releases)).
    Once you are happy with the release (removed placeholders, added key
    announcements etc.) then hit 'Publish release'.
-   This triggers the [deploy workflow](https://github.com/CMIP-REF/cmip-ref/actions/workflows/deploy.yaml).
+   This triggers the [deploy workflow](https://github.com/CLIMATE-REF/climate-ref/actions/workflows/deploy.yaml).
    This workflow deploys the built wheels and source distributions from the release to PyPI.
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,7 +35,7 @@ but not necesarily the additional packages required to run the metrics.
     type: warning
 
 The conda-forge packages are a work in progress and are not yet available.
-See [#80](https://github.com/CMIP-REF/cmip-ref/issues/80) for more information.
+See [#80](https://github.com/CLIMATE-REF/climate-ref/issues/80) for more information.
 ///
 
 You can install `cmip_ref` using `mamba` or `conda`:
@@ -54,8 +54,8 @@ Pixi uses the same packages as `conda` but is faster and can create reproducible
 You can run `cmip_ref` using Docker. First, build the Docker container from the source code:
 
 ```bash
-git clone https://github.com/CMIP-REF/cmip-ref.git
-cd cmip-ref
+git clone https://github.com/CLIMATE-REF/climate-ref.git
+cd climate-ref
 docker-compose build
 ```
 
@@ -70,8 +70,8 @@ docker-compose up
 To install `cmip_ref` from the source code, clone the repository and install it:
 
 ```bash
-git clone https://github.com/CMIP-REF/cmip-ref.git
-cd cmip-ref
+git clone https://github.com/CLIMATE-REF/climate-ref.git
+cd climate-ref
 make virtual-environment
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,7 +107,7 @@ gantt
 ## Metrics
 
 An overview of the current state of the selected metrics can be found in the
-[Metrics Github board](https://github.com/orgs/CMIP-REF/projects/2/views/2) document.
+[Metrics Github board](https://github.com/orgs/CLIMATE-REF/projects/2/views/2) document.
 This is being updated as the new metrics are integrated into the CMIP AR7 Fast Track REF.
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,8 @@ site_description: Rapid Evalutation Framework
 site_url: https://cmip-ref.readthedocs.io
 edit_uri: blob/master/docs/
 
-repo_name: CMIP-REF/cmip_ref
-repo_url: https://github.com/CMIP-REF/cmip-ref
+repo_name: Climate-REF/climate-ref
+repo_url: https://github.com/CLIMATE-REF/climate-ref
 
 nav:
   - CMIP REF: index.md

--- a/packages/ref/src/cmip_ref/testing.py
+++ b/packages/ref/src/cmip_ref/testing.py
@@ -22,7 +22,7 @@ def _determine_test_directory() -> Path | None:
 def _build_sample_data_registry(sample_data_version: str) -> pooch.Pooch:
     registry = pooch.create(
         path=pooch.os_cache("ref_sample_data"),
-        base_url="https://raw.githubusercontent.com/CMIP-REF/ref-sample-data/refs/tags/{version}/data/",
+        base_url="https://raw.githubusercontent.com/CLIMATE-REF/ref-sample-data/refs/tags/{version}/data/",
         version=sample_data_version,
         env="REF_SAMPLE_DATA_DIR",
     )

--- a/tests/test-data/README.md
+++ b/tests/test-data/README.md
@@ -15,7 +15,7 @@ These data are stored in a pooch cache outside of the repository.
 
 ## Sample Data
 
-A consistent set of [sample data](https://github.com/CMIP-REF/ref-sample-data)
+A consistent set of [sample data](https://github.com/CLIMATE-REF/ref-sample-data)
 is used by the REF test suite.
 This ensures that the tests are reproducible and that the test data are versioned.
 

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -5,7 +5,7 @@ filename = "docs/changelog.md"
 directory = "changelog/"
 title_format = "## cmip_ref {version} ({project_date})"
 underlines = ["", "", ""]
-issue_format = "[#{issue}](https://github.com/CMIP-REF/cmip-ref/pulls/{issue})"
+issue_format = "[#{issue}](https://github.com/CLIMATE-REF/climate-ref/pulls/{issue})"
 
   [[tool.towncrier.type]]
   directory = "breaking"


### PR DESCRIPTION
## Description

This doesn't change the package names, but fixes up the rest of the documentation.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
