### PR TITLE
feat: add makefile command to download ilamb ref data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ fetch-test-data:  ## Download any data needed by the test suite
 .PHONY: fetch-ref-data
 fetch-ref-data:  ## Download reference data needed by providers and (temporarily) not in obs4mips
 	uv run python ./scripts/fetch-ilamb-data.py ilamb.txt
+	uv run python ./scripts/fetch-ilamb-data.py iomb.txt
 
 .PHONY: update-sample-data-registry
 update-sample-data-registry:  ## Update the sample data registry

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,10 @@ fetch-test-data:  ## Download any data needed by the test suite
 	uv run ref datasets fetch-sample-data
 	uv run python ./scripts/fetch-ilamb-data.py test.txt
 
+.PHONY: fetch-ref-data
+fetch-ref-data:  ## Download reference data needed by providers and (temporarily) not in obs4mips
+	uv run python ./scripts/fetch-ilamb-data.py ilamb.txt
+
 .PHONY: update-sample-data-registry
 update-sample-data-registry:  ## Update the sample data registry
 	curl --output packages/ref/src/cmip_ref/datasets/sample_data.txt https://raw.githubusercontent.com/Climate-REF/ref-sample-data/refs/heads/main/registry.txt

--- a/changelog/155.improvement.md
+++ b/changelog/155.improvement.md
@@ -1,0 +1,1 @@
+Added the `fetch-ref-data` make command to download reference data while it's not in obs4mips, yet.

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,6 +55,27 @@ If there are any issues, the messages from the `Makefile` should guide you
 through. If not, please raise an issue in the
 [issue tracker](https://github.com/Climate-REF/climate-ref/issues).
 
+### Running your first `solve`
+
+If you want to run the sample data through the whole pipeline, you need to download
+reference data, but note that the reference data is severable Gigabytes in size.
+
+```shell
+# Download reference data which is not (yet) included in obs4mips
+make fetch-ref-data
+```
+
+After that, you can let the REF calculate all included metrics for the sample data.
+Note that this will take a while to run.
+
+```shell
+uv run ref solve
+```
+
+Afterwards, you can check the output of `uv run ref executions list` to see if metrics
+were evaluated successfully, and if they were, you find the results in the
+`.ref/results` folder.
+
 ### Pip editable installation
 
 If you would like to install the REF into an existing (conda) environment

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,8 @@ uv run ref solve
 
 Afterwards, you can check the output of `uv run ref executions list` to see if metrics
 were evaluated successfully, and if they were, you find the results in the
-`.ref/results` folder.
+`.ref/results` folder. Don't worry too much if some executions are failing for you,
+things are still in active development at the moment.
 
 ### Pip editable installation
 


### PR DESCRIPTION
## Description

Temporarily, you still need reference data not in obs4mips to run ilamb for development. Add a makefile command for that and a corresponding section in the docs.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
