### PR TITLE
Add activity and institute to recipe

### DIFF
--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/recipe.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/recipe.py
@@ -16,8 +16,10 @@ yaml = YAML()
 
 FACETS = {
     "CMIP6": {
+        "activity": "activity_id",
         "dataset": "source_id",
         "ensemble": "member_id",
+        "institute": "institution_id",
         "exp": "experiment_id",
         "grid": "grid_label",
         "mip": "table_id",


### PR DESCRIPTION
## Description

Add activity and institute to ESMValTool recipes to allow running with datasets that are not in the controlled vocabulary.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
