### PR TITLE
docs: update hackathon page to better fit for pre-alpha onboarding

### DIFF
--- a/changelog/182.trivial.md
+++ b/changelog/182.trivial.md
@@ -1,0 +1,1 @@
+Updated the hackathon documentation page to better fit for pre-alpha onboarding.

--- a/docs/hackathon.md
+++ b/docs/hackathon.md
@@ -1,6 +1,6 @@
-# Hackathon 2025
+# Hackathon and Pre-Alpha Onboarding
 
-**Met Office, Exeter, UK, 10 - 14 May 2025**
+**Hackathon at the Met Office, Exeter, UK, 10 - 14 May 2025**
 
 This hybrid hackathon is being run by the Model Benchmarking Task Team and the REF delivery team. We welcome attendance from technical and domain scientists from modelling centres involved in the CMIP AR7 Fast Track, observation dataset providers, as well as ESGF nodes and developers.
 
@@ -11,6 +11,10 @@ During the hackathon, there will also be dedicated drop-ins for wider community 
 * **13 March 08:00 – 09:00 UTC**: Modelling Centres
 * **13 March 11:00 – Midday UTC**: Observation dataset providers
 
+**Pre-Alpha Onboarding**
+
+If you couldn't make it to the hackathon but still want to get started in REF development, this information will be useful as well.
+
 ## Technical Requirements
 
 * A laptop with Python 3.10 or later installed
@@ -18,24 +22,9 @@ During the hackathon, there will also be dedicated drop-ins for wider community 
 * Docker installed (Optional)
 * [uv](https://docs.astral.sh/uv) installed
 
-## What can you do before the hackathon?
+## Set up your development environment
 
-Before attending the hackathon, it would be useful to clone the package and set up your local environment by following the [development installation](development.md#development-installation) instructions.
-
-Additionally, clone the [sample data repository](https://github.com/Climate-REF/ref-sample-data). Depending on your area of interest, you may wish to add additional sample data to the test suite.
-
-After installing the database, you can run the test suite using `make test` to ensure that everything is working as expected. This will fetch the sample data and run the tests.
-
-Some metric providers require additional test data that isn't in Obs4MIPs.
-We are working on adding these datasets to obs4MIPs before the  launch of the AR7 FT REF.
-To help save time during the hackathon, run the following commands beforehand to cache the ilamb and iomb reference datasets (~4GB).
-
-```bash
-uv run python scripts/fetch-ilamb-data.py ilamb.txt
-uv run python scripts/fetch-ilamb-data.py iomb.txt
-```
-
-If there are any issues with the installation, please raise an issue in the [issue tracker](https://github.com/Climate-REF/climate-ref/issues) so that we can help you get set up.
+Please clone the package and set up your local environment by following the [development installation](development.md#development-installation) instructions.
 
 ### Additional Data
 
@@ -54,7 +43,7 @@ The metrics that are currently available in the REF are relatively limited so no
 It is recommended to read through the [developer documentation](development.md) to get an understanding of the REF and how we collaborate.
 
 For those interested in learning more about the REF,
-we recommend reading the [Architecture design document (background/architecture.md).
+we recommend reading the [Architecture design document](background/architecture.md).
 This outlines the design of the REF and provides some background about the project.
 
 ## Brief technical overview of the REF


### PR DESCRIPTION
## Description

Small tweaks so that the hackathon page can also be used for pre-alpha post-hackathon onboarding

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
