### PR TITLE
feat: Add basic support for a controlled vocabulary

### DIFF
--- a/changelog/183.feature.md
+++ b/changelog/183.feature.md
@@ -1,0 +1,4 @@
+Add the basic framework for enforcing a controlled vocabulary
+for the results in a CMEC metrics bundle.
+This is still in the prototype stage
+and is not yet integrated into post-metric execution processing.

--- a/packages/ref-core/src/cmip_ref_core/exceptions.py
+++ b/packages/ref-core/src/cmip_ref_core/exceptions.py
@@ -38,3 +38,7 @@ class ConstraintNotSatisfied(RefException):
     """Exception raised when a constraint is violated"""
 
     # TODO: implement when we have agreed on using constraints
+
+
+class ResultValidationError(RefException):
+    """Exception raised when the results from a metric execution are invalid"""

--- a/packages/ref-core/src/cmip_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/ref-core/src/cmip_ref_core/pycmec/controlled_vocabulary.py
@@ -1,0 +1,152 @@
+import pathlib
+
+from attrs import field, frozen
+from cattrs import Converter, transform_error
+from loguru import logger
+from ruamel.yaml import YAML
+
+from cmip_ref_core.exceptions import ResultValidationError
+from cmip_ref_core.pycmec.metric import CMECMetric
+
+yaml = YAML()
+
+
+@frozen
+class DimensionValue:
+    """
+    An allowed value for a dimension
+    """
+
+    name: str
+    long_name: str
+    description: str | None
+    units: str
+
+
+@frozen
+class Dimension:
+    """
+    Description of a dimension in a metric bundle
+
+    This information is also used by the frontend for presentation purposes.
+    """
+
+    name: str
+    """
+    A short idenfifier of the dimension.
+
+    This is used as a key in the metric bundle.
+    """
+    long_name: str
+    """
+    A longer name used for presentation
+    """
+    description: str
+    """
+    A short description of the dimension.
+
+    This is used for presentation
+    """
+    allow_extra_values: bool
+    """
+    If True, additional non-controlled values are allowed.
+    This is used for dimensions where not all the values are known at run time,'
+    for example, the model dimension.
+    """
+    required: bool
+    """
+    If True, this dimension is required to be specified in the results.
+    """
+    values: list[DimensionValue] = field(factory=list)
+    """
+    The list of controlled values for a given dimension.
+
+    If `allow_extra_values` is False,
+    then only these values are valid for the dimension.
+    """
+
+
+@frozen
+class CV:
+    """
+    A collection of controlled dimensions and values used to validate results.
+
+    A metric bundle does not have to specify all dimensions,
+    but any dimensions not in the CV are not permitted.
+    """
+
+    # TODO: There might be some additional fields in future if this CV is project-specific
+
+    dimensions: list[Dimension]
+
+    def get_dimension_by_name(self, name: str) -> Dimension:
+        """
+        Get a dimension by name
+
+        Parameters
+        ----------
+        name
+            The name of the dimension
+
+        Returns
+        -------
+        Dimension
+            The dimension with the given name
+
+        Raises
+        ------
+        KeyError
+            If the dimension is not found
+        """
+        for dim in self.dimensions:
+            if dim.name == name:
+                return dim
+        raise KeyError(f"Dimension {name} not found")
+
+    def validate_metrics(self, metric_bundle: CMECMetric) -> None:
+        """
+        Validate a metric bundle against a CV
+
+        The CV describes the accepted dimensions and values within a bundle
+
+        Parameters
+        ----------
+        metric_bundle
+
+        Raises
+        ------
+        ResultValidationError
+            If the validation of the dimensions or values fails
+        """
+        for result in metric_bundle.iter_results():
+            for k, v in result.dimensions.items():
+                try:
+                    dimension = self.get_dimension_by_name(k)
+                except KeyError:
+                    raise ResultValidationError(f"Unknown dimension: {k!r}")
+                if not dimension.allow_extra_values:
+                    if v not in [dv.name for dv in dimension.values]:
+                        raise ResultValidationError(f"Unknown value {v!r} for dimension {k!r}")
+            if result.value is None:
+                raise ResultValidationError("Unexpected missing value")
+
+    @staticmethod
+    def load_from_file(filename: pathlib.Path | str) -> "CV":
+        """
+        Load a CV from disk
+
+        Returns
+        -------
+            A new CV instance
+
+        """
+        convertor = Converter(forbid_extra_keys=True)
+        contents = yaml.load(pathlib.Path(filename))
+
+        try:
+            return convertor.structure(contents, CV)
+        except Exception as exc:
+            logger.error(f"Error loading CV from {filename}")
+            for error in transform_error(exc):
+                logger.error(error)
+            raise

--- a/packages/ref-core/src/cmip_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/ref-core/src/cmip_ref_core/pycmec/controlled_vocabulary.py
@@ -127,8 +127,9 @@ class CV:
                 if not dimension.allow_extra_values:
                     if v not in [dv.name for dv in dimension.values]:
                         raise ResultValidationError(f"Unknown value {v!r} for dimension {k!r}")
-            if result.value is None:
-                raise ResultValidationError("Unexpected missing value")
+            if not isinstance(result.value, float):  # pragma: no cover
+                # This may not be possible with the current CMECMetric implementation
+                raise ResultValidationError(f"Unexpected value: {result.value!r}")
 
     @staticmethod
     def load_from_file(filename: pathlib.Path | str) -> "CV":

--- a/packages/ref-core/tests/unit/pycmec/cmec_testdata/cv_sample.yaml
+++ b/packages/ref-core/tests/unit/pycmec/cmec_testdata/cv_sample.yaml
@@ -1,0 +1,34 @@
+dimensions:
+- name: model
+  long_name: model_id
+  description: ""
+  allow_extra_values: true
+  required: false
+- name: source_id
+  long_name: source_id
+  description: ""
+  allow_extra_values: true
+  required: false
+- name: metric
+  long_name: ""
+  description: ""
+  required: true
+  allow_extra_values: true
+- name: statistic
+  long_name: ""
+  description: ""
+  required: true
+  allow_extra_values: false
+  values:
+    - name: rmse
+      long_name: Root Mean Square Error
+      description: ""
+      units: dimensionless
+    - name: overall score
+      long_name: Overall Score
+      description: ""
+      units: dimensionless
+    - name: bias
+      long_name: Bias
+      description: ""
+      units: dimensionless

--- a/packages/ref-core/tests/unit/pycmec/conftest.py
+++ b/packages/ref-core/tests/unit/pycmec/conftest.py
@@ -1,9 +1,25 @@
+import json
 import pathlib
 
 import pytest
+
+from cmip_ref_core.pycmec.metric import CMECMetric
 
 
 # Update the original_datadir to specify where the expected values go
 @pytest.fixture(scope="session")
 def original_datadir():
     return pathlib.Path(__file__).parent / "cmec_testdata"
+
+
+@pytest.fixture
+def cmec_right_metric_dict(datadir):
+    with open(datadir / "cmec_metric_sample.json") as fh:
+        content = json.loads(fh.read())
+
+    return content
+
+
+@pytest.fixture
+def cmec_metric(cmec_right_metric_dict):
+    return CMECMetric(**cmec_right_metric_dict)

--- a/packages/ref-core/tests/unit/pycmec/test_cmec_metric.py
+++ b/packages/ref-core/tests/unit/pycmec/test_cmec_metric.py
@@ -10,14 +10,6 @@ from cmip_ref_core.pycmec.metric import (
 )
 
 
-@pytest.fixture
-def cmec_right_metric_dict(datadir):
-    with open(datadir / "cmec_metric_sample.json") as fh:
-        content = json.loads(fh.read())
-
-    return content
-
-
 @pytest.fixture(params=["dict", "CMECMetric"])
 def cmec_right_metric_data(request, cmec_right_metric_dict):
     if request.param == "dict":

--- a/packages/ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
+++ b/packages/ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
@@ -1,6 +1,8 @@
 import pytest
 
+from cmip_ref_core.exceptions import ResultValidationError
 from cmip_ref_core.pycmec.controlled_vocabulary import CV
+from cmip_ref_core.pycmec.metric import CMECMetric
 
 
 @pytest.fixture
@@ -18,6 +20,45 @@ def test_validate(cv, cmec_metric):
     cv.validate_metrics(cmec_metric)
 
 
-def test_validate_extra_dimension(cv, cmec_metric):
-    cmec_metric.merge()
-    cv.validate_metrics(cmec_metric)
+def test_invalid_dimension(cv, cmec_metric):
+    cmec_metric = CMECMetric(
+        DIMENSIONS={
+            "json_structure": ["model", "extra"],
+            "model": {
+                "E3SM": {"name": "E3SM"},
+            },
+            "extra": {
+                "Ecosystem and Carbon Cycle": {"name": "Ecosystem and Carbon Cycle"},
+                "Hydrology Cycle": {"name": "Hydrology Cycle"},
+            },
+        },
+        RESULTS={
+            "E3SM": {
+                "Ecosystem and Carbon Cycle": {"overall score": 0.11, "bias": 0.56},
+                "Hydrology Cycle": {"overall score": 0.26, "bias": 0.70},
+            },
+        },
+    )
+    with pytest.raises(ResultValidationError, match="Unknown dimension: 'extra'"):
+        cv.validate_metrics(cmec_metric)
+
+
+def test_missing_value(cv, cmec_metric):
+    cmec_metric = CMECMetric(
+        DIMENSIONS={
+            "json_structure": ["model", "metric"],
+            "model": {
+                "E3SM": {"name": "E3SM"},
+            },
+            "metric": {
+                "Hydrology Cycle": {"name": "Hydrology Cycle"},
+            },
+        },
+        RESULTS={
+            "E3SM": {
+                "Hydrology Cycle": {"unknown": 0.26, "bias": 0.70},
+            },
+        },
+    )
+    with pytest.raises(ResultValidationError, match="Unknown value 'unknown' for dimension 'statistic'"):
+        cv.validate_metrics(cmec_metric)

--- a/packages/ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
+++ b/packages/ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
@@ -1,0 +1,23 @@
+import pytest
+
+from cmip_ref_core.pycmec.controlled_vocabulary import CV
+
+
+@pytest.fixture
+def cv(datadir):
+    return CV.load_from_file(datadir / "cv_sample.yaml")
+
+
+def test_load_from_file(datadir):
+    cv = CV.load_from_file(str(datadir / "cv_sample.yaml"))
+
+    assert len(cv.dimensions)
+
+
+def test_validate(cv, cmec_metric):
+    cv.validate_metrics(cmec_metric)
+
+
+def test_validate_extra_dimension(cv, cmec_metric):
+    cmec_metric.merge()
+    cv.validate_metrics(cmec_metric)


### PR DESCRIPTION
## Description

Adds the basic framework for a controlled vocabulary for metric values and their dimensions. 

This is still a prototype, but it provides an example about how we could capture information about the dimensions we will use in the metric bundles.

The CMIP cvs are generally JSON files, one for each controlled dimension. They capture additional metadata about each of the controlled values. We need to support the definition of all permitted dimensions in addition to the controlled ones which has led to more structured schema as to also capture that information. Yaml was a more readable alternative imho 

If the cv grows to where it is difficult to follow we can split it out into different dimensions as well. The ref needs different information compared to the CMIP cvs so they couldn't be used directly, but may draw from them in a more complete version of the cv

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
