### PR TITLE
test: Add an integration test for the AR7 FT metric providers

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -61,6 +61,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: integration-output
+          name: integration-output-${{ matrix.python-version }}
           path: ${{ env.REF_TEST_OUTPUT }}
           retention-days: 7

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -35,6 +35,8 @@ jobs:
           make fetch-test-data
           make test
   tests-slow:
+    env:
+      REF_TEST_OUTPUT: ".test-outputs"
     strategy:
       fail-fast: false
       matrix:
@@ -54,3 +56,11 @@ jobs:
         run: |
           make fetch-test-data
           make test-integration-slow
+      # Upload the scratch and results directories as artifacts
+      - name: Upload scratch artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-output
+          path: ${{ env.REF_TEST_OUTPUT }}
+          retention-days: 7

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -1,0 +1,56 @@
+name: Integration tests
+
+on:
+  # Allow manual triggering of this workflow
+  workflow_dispatch:
+  # Run on each push to main and tagged version
+  push:
+    branches: [main]
+    tags: ['v*']
+  # Runs every day at 2:15am (UTC) (~ midday in AEST)
+  schedule:
+    - cron: '2 15 * * *'
+
+jobs:
+  tests:
+    # These tests are also run on each push to main and tagged version via the `ci` workflow
+    if: github.event_name != 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+    runs-on: "${{ matrix.os }}"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run tests
+        run: |
+          make fetch-test-data
+          make test
+  tests-slow:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest" ]
+        python-version: [ "3.10" ]
+    runs-on: "${{ matrix.os }}"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run tests
+        run: |
+          make fetch-test-data
+          make test-integration-slow

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -36,7 +36,7 @@ jobs:
           make test
   tests-slow:
     env:
-      REF_TEST_OUTPUT: ".test-outputs"
+      REF_TEST_OUTPUT: "test-outputs"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,3 +107,24 @@ jobs:
         run: |
           echo "No changelog present."
           exit 1
+  # TODO: Remove once this test passes
+  tests-slow:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest" ]
+        python-version: [ "3.10" ]
+    runs-on: "${{ matrix.os }}"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run tests
+        run: |
+          make fetch-test-data
+          make test-integration-slow

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,35 +116,3 @@ jobs:
         run: |
           echo "No changelog present."
           exit 1
-  # TODO: Remove once this test passes
-  tests-slow:
-    env:
-      REF_TEST_OUTPUT: "test-outputs"
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ "ubuntu-latest" ]
-        python-version: [ "3.10" ]
-    runs-on: "${{ matrix.os }}"
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Run tests
-        run: |
-          make fetch-test-data
-          uv run python scripts/fetch-ilamb-data.py ilamb.txt
-          make test-integration-slow
-      # Upload the scratch and results directories as artifacts
-      - name: Upload scratch artifacts
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: integration-output-${{ matrix.python-version }}
-          path: ${{ env.REF_TEST_OUTPUT }}
-          retention-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,7 @@ jobs:
       - name: Run tests
         run: |
           make fetch-test-data
+          uv run python scripts/fetch-ilamb-data.py ilamb.txt
           make test-integration-slow
       # Upload the scratch and results directories as artifacts
       - name: Upload scratch artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-output
+          name: test-output-${{ matrix.python-version }}
           path: ${{ env.REF_TEST_OUTPUT }}
           retention-days: 7
 
@@ -145,6 +145,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: integration-output
+          name: integration-output-${{ matrix.python-version }}
           path: ${{ env.REF_TEST_OUTPUT }}
           retention-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
   tests:
     env:
-      REF_TEST_OUTPUT: ".test-outputs"
+      REF_TEST_OUTPUT: "test-outputs"
     strategy:
       fail-fast: false
       matrix:
@@ -119,7 +119,7 @@ jobs:
   # TODO: Remove once this test passes
   tests-slow:
     env:
-      REF_TEST_OUTPUT: ".test-outputs"
+      REF_TEST_OUTPUT: "test-outputs"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
         run: make pre-commit
 
   tests:
+    env:
+      REF_TEST_OUTPUT: ".test-outputs"
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +47,13 @@ jobs:
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload scratch artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-output
+          path: ${{ env.REF_TEST_OUTPUT }}
+          retention-days: 7
 
   imports-without-extras:
     strategy:
@@ -109,6 +118,8 @@ jobs:
           exit 1
   # TODO: Remove once this test passes
   tests-slow:
+    env:
+      REF_TEST_OUTPUT: ".test-outputs"
     strategy:
       fail-fast: false
       matrix:
@@ -128,3 +139,11 @@ jobs:
         run: |
           make fetch-test-data
           make test-integration-slow
+      # Upload the scratch and results directories as artifacts
+      - name: Upload scratch artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-output
+          path: ${{ env.REF_TEST_OUTPUT }}
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ clean-sample-data:  ## clean up the sample data
 build: clean  ## build the packages to be deployed to PyPI
 	cp LICENCE NOTICE packages/ref
 	cp LICENCE NOTICE packages/ref-core
+	cp LICENCE NOTICE packages/ref-celery
+	cp LICENCE NOTICE packages/ref-metrics-example
+	cp LICENCE NOTICE packages/ref-metrics-esmvaltool
+	cp LICENCE NOTICE packages/ref-metrics-ilamb
+	cp LICENCE NOTICE packages/ref-metrics-pmp
 	uv build --package cmip_ref --no-sources
 	uv build --package cmip_ref_core --no-sources
 	uv build --package cmip_ref_celery --no-sources
@@ -102,6 +107,12 @@ test-metrics-pmp:  ## run the tests
 
 .PHONY: test-integration
 test-integration:  ## run the integration tests
+	uv run \
+		pytest tests -m "not slow" \
+		-r a -v
+
+.PHONY: test-integration-slow
+test-integration-slow:  ## run the integration tests, including the slow tests which may take a while
 	uv run \
 		pytest tests \
 		-r a -v

--- a/changelog/187.improvement.md
+++ b/changelog/187.improvement.md
@@ -1,0 +1,2 @@
+Add an integration test for the AR7 Fast-track metric providers.
+This will be run nightly as part of the Climate-REF CI pipeline.

--- a/conftest.py
+++ b/conftest.py
@@ -63,7 +63,7 @@ def config(tmp_path, monkeypatch, request) -> Config:
     # Each test gets its own directory (based on the test filename and the test name)
     # Sanitize the directory name to remove invalid characters
     dir_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
-    ref_config_dir = root_output_dir / request.path.stem / dir_name
+    ref_config_dir = root_output_dir / request.module.__name__ / dir_name
 
     monkeypatch.setenv("REF_CONFIGURATION", str(ref_config_dir))
 

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ See https://docs.pytest.org/en/7.1.x/reference/fixtures.html#conftest-py-sharing
 """
 
 import os
+import re
 import tempfile
 from pathlib import Path
 
@@ -60,7 +61,9 @@ def config(tmp_path, monkeypatch, request) -> Config:
     # This is useful in the CI to capture any results for later analysis
     root_output_dir = Path(os.environ.get("REF_TEST_OUTPUT", tmp_path / "cmip_ref"))
     # Each test gets its own directory (based on the test filename and the test name)
-    ref_config_dir = root_output_dir / request.path.stem / request.node.name
+    # Sanitize the directory name to remove invalid characters
+    dir_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
+    ref_config_dir = root_output_dir / request.path.stem / dir_name
 
     monkeypatch.setenv("REF_CONFIGURATION", str(ref_config_dir))
 

--- a/packages/ref-celery/pyproject.toml
+++ b/packages/ref-celery/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "cmip-ref-celery"
+name = "cmip_ref_celery"
 version = "0.2.0"
 description = "Celery app for mananging tasks and workers"
 readme = "README.md"

--- a/packages/ref-metrics-ilamb/src/cmip_ref_metrics_ilamb/standard.py
+++ b/packages/ref-metrics-ilamb/src/cmip_ref_metrics_ilamb/standard.py
@@ -111,10 +111,7 @@ def _load_csv_and_merge(output_directory: Path) -> pd.DataFrame:
     Load individual csv scalar data and merge into a dataframe.
     """
     df = pd.concat(
-        [
-            pd.read_csv(output_directory / f, keep_default_na=False, na_values=["NaN"])
-            for f in output_directory.glob("*.csv")
-        ]
+        [pd.read_csv(f, keep_default_na=False, na_values=["NaN"]) for f in output_directory.glob("*.csv")]
     ).drop_duplicates(subset=["source", "region", "analysis", "name"])
     df["name"] = df["name"] + " [" + df["units"] + "]"
     return df

--- a/packages/ref-metrics-pmp/tests/unit/test_variability_modes.py
+++ b/packages/ref-metrics-pmp/tests/unit/test_variability_modes.py
@@ -32,7 +32,7 @@ def provider(tmp_path):
     return provider
 
 
-def test_pdo_metric(  # noqa: PLR0913
+def test_pdo_metric(
     cmip6_data_catalog, obs4mips_data_catalog, mocker, definition_factory, pdo_example_dir, provider
 ):
     metric = ExtratropicalModesOfVariability("PDO")

--- a/packages/ref/tests/unit/cli/test_datasets.py
+++ b/packages/ref/tests/unit/cli/test_datasets.py
@@ -31,7 +31,7 @@ class TestDatasetsList:
 
 
 class TestDatasetsListColumns:
-    def test_list(self, db_seeded, invoke_cli):
+    def test_list_columns(self, db_seeded, invoke_cli):
         result = invoke_cli(["datasets", "list-columns"])
         assert result.stdout.strip() == "\n".join(
             sorted(CMIP6DatasetAdapter().load_catalog(db_seeded, include_files=False).columns.to_list())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ filterwarnings = [
     'ignore:The `validate_arguments` method is deprecated:pydantic.warnings.PydanticDeprecatedSince20',
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
 ]
+markers = [
+    "slow",
+]
 
 # We currently check for GPL licensed code, but this restriction may be removed
 [tool.liccheck]

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,7 +29,8 @@ ignore = [
 "test*.py" = [
     "D",  # Documentation not needed in tests
     "S101",  # S101 Use of `assert` detected
-    "PLR2004" # Magic value used in comparison
+    "PLR2004", # Magic value used in comparison
+    "PLR0913" # Too many arguments in function definition
 ]
 "conftest.py" = [
     "D",  # Documentation not needed in tests

--- a/tests/integration/test_ar7_ft.py
+++ b/tests/integration/test_ar7_ft.py
@@ -72,7 +72,8 @@ def test_solve_ar7_ft(
     print(df)
 
     # Check that all 3 metric providers have been used
-    assert len(df["provider"].unique()) == 3
+    # TODO: Update once the PMP metrics are solving
+    assert set(df["provider"].unique()) == {"esmvaltool", "ilamb"}
 
     # Check that all metrics have been successful
     assert df["successful"].all(), df[["metric", "successful"]]

--- a/tests/integration/test_ar7_ft.py
+++ b/tests/integration/test_ar7_ft.py
@@ -1,0 +1,82 @@
+import platform
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from cmip_ref.config import default_metric_providers
+from cmip_ref.database import Database
+from cmip_ref.models import MetricExecution
+
+
+def create_execution_dataframe(executions):
+    data = []
+
+    for execution in executions:
+        assert len(execution.results) == 1
+        result = execution.results[0]
+
+        data.append(
+            {
+                "metric": execution.metric.slug,
+                "provider": execution.metric.provider.slug,
+                "execution_id": execution.id,
+                "result_id": result.id,
+                "execution_key": execution.key,
+                "successful": result.successful,
+            }
+        )
+
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def config(config, monkeypatch):
+    """
+    Overwrite the default test config to use the metric providers for AR7 FT
+    """
+    # Force the default metric providers
+    config.metric_providers = default_metric_providers()
+
+    # Put the conda environments in a shared location
+    # ROOT / .ref / software
+    config.paths.software = Path(__file__).parents[3] / ".ref" / "software"
+
+    # Write the config to disk so it is used by the CLI
+    config.save()
+
+    return config
+
+
+@pytest.mark.slow
+def test_solve_ar7_ft(
+    sample_data_dir,
+    config,
+    invoke_cli,
+    monkeypatch,
+):
+    # Arm-based MacOS users will need to set the environment variable `MAMBA_PLATFORM=osx-64`
+    if platform.system() == "Darwin" and platform.machine() == "arm64":
+        monkeypatch.setenv("MAMBA_PLATFORM", "osx-64")
+
+    assert len(config.metric_providers) == 3
+
+    db = Database.from_config(config)
+
+    # Ingest the sample data
+    invoke_cli(["datasets", "ingest", "--source-type", "cmip6", str(sample_data_dir / "CMIP6")])
+    invoke_cli(["datasets", "ingest", "--source-type", "obs4mips", str(sample_data_dir / "obs4MIPs")])
+
+    # Solve
+    # This will also create conda environments for the metric providers
+    invoke_cli(["--verbose", "solve", "--timeout", f"{60 * 60}"])
+
+    executions = db.session.query(MetricExecution).all()
+    df = create_execution_dataframe(executions)
+    print(df)
+
+    # Check that all 3 metric providers have been used
+    assert len(df["provider"].unique()) == 3
+
+    # Check that all metrics have been successful
+    assert df["successful"].all(), df[["metric", "successful"]]

--- a/tests/integration/test_ar7_ft.py
+++ b/tests/integration/test_ar7_ft.py
@@ -1,5 +1,4 @@
 import platform
-from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -31,18 +30,15 @@ def create_execution_dataframe(executions):
 
 
 @pytest.fixture
-def config(config, monkeypatch):
+def config_ar7_ft(config):
     """
     Overwrite the default test config to use the metric providers for AR7 FT
     """
     # Force the default metric providers
     config.metric_providers = default_metric_providers()
 
-    # Put the conda environments in a shared location
-    # ROOT / .ref / software
-    config.paths.software = Path(__file__).parents[3] / ".ref" / "software"
-
     # Write the config to disk so it is used by the CLI
+    # This overwrites the default config
     config.save()
 
     return config
@@ -51,7 +47,7 @@ def config(config, monkeypatch):
 @pytest.mark.slow
 def test_solve_ar7_ft(
     sample_data_dir,
-    config,
+    config_ar7_ft,
     invoke_cli,
     monkeypatch,
 ):
@@ -59,9 +55,9 @@ def test_solve_ar7_ft(
     if platform.system() == "Darwin" and platform.machine() == "arm64":
         monkeypatch.setenv("MAMBA_PLATFORM", "osx-64")
 
-    assert len(config.metric_providers) == 3
+    assert len(config_ar7_ft.metric_providers) == 3
 
-    db = Database.from_config(config)
+    db = Database.from_config(config_ar7_ft)
 
     # Ingest the sample data
     invoke_cli(["datasets", "ingest", "--source-type", "cmip6", str(sample_data_dir / "CMIP6")])


### PR DESCRIPTION
## Description

Add an integration test for the AR7 FT setup. This adds a workflow which is run nightly.

The results from the test suite are now archived to enable debugging if the suite fails

PMP is currently failing due to missing data so is ignored.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
