### PR TITLE
Nicer error message when specifying wrong columns in `ref datasets list`

### DIFF
--- a/changelog/203.improvement.md
+++ b/changelog/203.improvement.md
@@ -1,0 +1,3 @@
+Improved the error message when running `ref datasets list` with the `--column` argument.
+If a column is specified that is not available, the error message now only mentions
+the invalid column name(s) and shows a list of available columns.

--- a/packages/ref-core/tests/unit/test_metrics.py
+++ b/packages/ref-core/tests/unit/test_metrics.py
@@ -351,7 +351,7 @@ def test_apply_filters_missing(apply_data_catalog):
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "input_path, expected",
     (
         (Path("/example/test"), Path("test")),
         ("/example/test", Path("test")),
@@ -360,8 +360,8 @@ def test_apply_filters_missing(apply_data_catalog):
         (Path("test/other"), Path("test/other")),
     ),
 )
-def test_ensure_relative_path(input, expected):
-    assert ensure_relative_path(input, root_directory=Path("/example")) == expected
+def test_ensure_relative_path(input_path, expected):
+    assert ensure_relative_path(input_path, root_directory=Path("/example")) == expected
 
 
 def test_ensure_relative_path_failed():

--- a/packages/ref/src/cmip_ref/_config_helpers.py
+++ b/packages/ref/src/cmip_ref/_config_helpers.py
@@ -33,7 +33,7 @@ def _format_key_exception(exc: BaseException, _: type | None) -> str | None:
         return None
 
 
-def _format_exception(exc: BaseException, type: type | None) -> str:
+def _format_exception(exc: BaseException, type: type | None) -> str:  # noqa: A002
     """Format an exception into a string description of the error.
 
     Parameters

--- a/packages/ref/src/cmip_ref/cli/datasets.py
+++ b/packages/ref/src/cmip_ref/cli/datasets.py
@@ -4,6 +4,7 @@ View and ingest input datasets
 
 import errno
 import os
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Annotated
 
@@ -43,8 +44,17 @@ def list_(
     data_catalog = adapter.load_catalog(database, include_files=include_files, limit=limit)
 
     if column:
-        if not all(col in data_catalog.columns for col in column):
-            logger.error(f"Column not found in data catalog: {column}")
+        missing = set(column) - set(data_catalog.columns)
+        if missing:
+
+            def format(columns: Iterable[str]) -> str:
+                return ", ".join(f"'{c}'" for c in sorted(columns))
+
+            logger.error(
+                f"Column{'s' if len(missing) > 1 else ''} "
+                f"{format(missing)} not found in data catalog. "
+                f"Choose from: {format(data_catalog.columns)}"
+            )
             raise typer.Exit(code=1)
         data_catalog = data_catalog[column]
 

--- a/packages/ref/src/cmip_ref/cli/datasets.py
+++ b/packages/ref/src/cmip_ref/cli/datasets.py
@@ -47,13 +47,13 @@ def list_(
         missing = set(column) - set(data_catalog.columns)
         if missing:
 
-            def format(columns: Iterable[str]) -> str:
+            def format_(columns: Iterable[str]) -> str:
                 return ", ".join(f"'{c}'" for c in sorted(columns))
 
             logger.error(
                 f"Column{'s' if len(missing) > 1 else ''} "
-                f"{format(missing)} not found in data catalog. "
-                f"Choose from: {format(data_catalog.columns)}"
+                f"{format_(missing)} not found in data catalog. "
+                f"Choose from: {format_(data_catalog.columns)}"
             )
             raise typer.Exit(code=1)
         data_catalog = data_catalog[column]

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,6 +13,7 @@ select = [
     "RUF",
     "UP",
     "S",
+    "A",
 ]
 unfixable = [
     "PD002",


### PR DESCRIPTION
## Description

Adds a nicer error message when running `ref datasets list` with the `--column` argument. If a column is specified that is not available in the dataframe, a list of available columns will be shown.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
