### PR TITLE
Match all facet values when using `FacetFilter` with `keep=False`

### DIFF
--- a/changelog/209.fix.md
+++ b/changelog/209.fix.md
@@ -1,0 +1,2 @@
+Fixed the behaviour of FacetFilter with `keep=False` so all facets need to match
+before excluding a file.

--- a/packages/ref-core/src/cmip_ref_core/metrics.py
+++ b/packages/ref-core/src/cmip_ref_core/metrics.py
@@ -328,6 +328,7 @@ class DataRequirement:
             Filtered data catalog
         """
         for facet_filter in self.filters:
+            mask = None
             for facet, value in facet_filter.facets.items():
                 clean_value = value if isinstance(value, tuple) else (value,)
 
@@ -336,7 +337,13 @@ class DataRequirement:
                         f"Facet {facet!r} not in data catalog columns: {data_catalog.columns.to_list()}"
                     )
 
-                mask = data_catalog[facet].isin(clean_value)
+                facet_mask = data_catalog[facet].isin(clean_value)
+                if mask is None:
+                    mask = facet_mask
+                else:
+                    mask &= facet_mask
+
+            if mask is not None:
                 if not facet_filter.keep:
                     mask = ~mask
 

--- a/packages/ref-core/src/cmip_ref_core/metrics.py
+++ b/packages/ref-core/src/cmip_ref_core/metrics.py
@@ -328,7 +328,7 @@ class DataRequirement:
             Filtered data catalog
         """
         for facet_filter in self.filters:
-            mask = None
+            values = {}
             for facet, value in facet_filter.facets.items():
                 clean_value = value if isinstance(value, tuple) else (value,)
 
@@ -336,18 +336,12 @@ class DataRequirement:
                     raise KeyError(
                         f"Facet {facet!r} not in data catalog columns: {data_catalog.columns.to_list()}"
                     )
+                values[facet] = clean_value
 
-                facet_mask = data_catalog[facet].isin(clean_value)
-                if mask is None:
-                    mask = facet_mask
-                else:
-                    mask &= facet_mask
-
-            if mask is not None:
-                if not facet_filter.keep:
-                    mask = ~mask
-
-                data_catalog = data_catalog[mask]
+            mask = data_catalog[list(values)].isin(values).all(axis="columns")
+            if not facet_filter.keep:
+                mask = ~mask
+            data_catalog = data_catalog[mask]
         return data_catalog
 
 

--- a/packages/ref-core/tests/unit/test_metrics.py
+++ b/packages/ref-core/tests/unit/test_metrics.py
@@ -336,6 +336,40 @@ def test_apply_filters_dont_keep(apply_data_catalog):
     )
 
 
+def test_apply_filters_dont_keep_multifacet(apply_data_catalog):
+    """Test that all facet values must match to exclude a file from the catalog."""
+    requirement = DataRequirement(
+        source_type=SourceDatasetType.CMIP6,
+        filters=(
+            FacetFilter(
+                {
+                    "variable": "tas",
+                    "source_id": "CAS",
+                },
+                keep=False,
+            ),
+        ),
+        group_by=None,
+    )
+
+    filtered = requirement.apply_filters(apply_data_catalog)
+    pd.testing.assert_frame_equal(
+        filtered,
+        pd.DataFrame(
+            {
+                "variable": ["tas", "pr", "rsut", "tas"],
+                "source_id": [
+                    "CESM2",
+                    "CESM2",
+                    "CESM2",
+                    "ACCESS",
+                ],
+            },
+            index=[0, 1, 2, 3],
+        ),
+    )
+
+
 def test_apply_filters_missing(apply_data_catalog):
     requirement = DataRequirement(
         source_type=SourceDatasetType.CMIP6,


### PR DESCRIPTION
## Description

For the TCRE metric #208, I need variables `"tas"` and `"fco2antt"` from the `"esm-1pctCO2"` experiment and variable `"tas"` from the `"esm-piControl"` experiment. Therefore I wrote the following filters:
```
FacetFilter(
    facets={
        "variable_id": ("tas", "fco2antt"),
        "frequency": "mon",
        "experiment_id": ("esm-1pctCO2", "esm-piControl"),
    },
),
FacetFilter(
    facets={
        "variable_id": "fco2antt",
        "experiment_id": "esm-piControl",
    },
    keep=False,
),
```
The first filter selects all files with `"variable_id"` `"tas"` and `"fco2antt"` from both experiments and the second filter then excludes files with `"variable_id"` `"fco2antt"` from the `"esm-piControl"` experiment.

The implementation here makes the above filters work as expected.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
