### PR TITLE
Ensure that the paths are always absolute

### DIFF
--- a/changelog/230.improvement.md
+++ b/changelog/230.improvement.md
@@ -1,0 +1,1 @@
+The configuration paths are now all resolved to absolute paths

--- a/packages/ref-core/src/cmip_ref_core/metrics.py
+++ b/packages/ref-core/src/cmip_ref_core/metrics.py
@@ -40,8 +40,11 @@ def ensure_relative_path(path: pathlib.Path | str, root_directory: pathlib.Path)
         The path relative to the root directory
     """
     path = pathlib.Path(path)
-    if path.is_absolute():
+    try:
         return path.relative_to(root_directory)
+    except ValueError:
+        if path.is_absolute():
+            raise
     return path
 
 

--- a/packages/ref-core/tests/unit/test_metrics.py
+++ b/packages/ref-core/tests/unit/test_metrics.py
@@ -404,6 +404,20 @@ def test_ensure_relative_path(input_path, expected):
     assert ensure_relative_path(input_path, root_directory=Path("/example")) == expected
 
 
+@pytest.mark.parametrize(
+    "input_path, expected",
+    (
+        (Path("example/test"), Path("test")),
+        ("example/test", Path("test")),
+        ("example/test/other", Path("test/other")),
+        ("test/other", Path("test/other")),
+        (Path("test/other"), Path("test/other")),
+    ),
+)
+def test_ensure_relative_path_non_absolute(input_path, expected):
+    assert ensure_relative_path(input_path, root_directory=Path("example")) == expected
+
+
 def test_ensure_relative_path_failed():
     with pytest.raises(ValueError):
         ensure_relative_path("/other", root_directory=Path("/example"))

--- a/packages/ref/src/cmip_ref/config.py
+++ b/packages/ref/src/cmip_ref/config.py
@@ -48,6 +48,24 @@ Prefix for the environment variables used by the REF
 """
 
 
+def ensure_absolute_path(path: str | Path) -> Path:
+    """
+    Ensure that the path is absolute
+
+    Parameters
+    ----------
+    path
+        Path to check
+
+    Returns
+    -------
+        Absolute path
+    """
+    if isinstance(path, str):
+        path = Path(path)
+    return path.resolve()
+
+
 @config(prefix=env_prefix)
 class PathConfig:
     """
@@ -60,14 +78,14 @@ class PathConfig:
     ///
     """
 
-    log: Path = env_field(name="LOG_ROOT", converter=Path)
+    log: Path = env_field(name="LOG_ROOT", converter=ensure_absolute_path)
     """
     Directory to store log files from the compute engine
 
     This is not currently used by the REF, but is included for future use.
     """
 
-    scratch: Path = env_field(name="SCRATCH_ROOT", converter=Path)
+    scratch: Path = env_field(name="SCRATCH_ROOT", converter=ensure_absolute_path)
     """
     Shared scratch space for the REF.
 
@@ -78,7 +96,7 @@ class PathConfig:
     but does not need to be mounted in the same location on all the metric services.
     """
 
-    software: Path = env_field(name="SOFTWARE_ROOT", converter=Path)
+    software: Path = env_field(name="SOFTWARE_ROOT", converter=ensure_absolute_path)
     """
     Shared software space for the REF.
 
@@ -89,7 +107,7 @@ class PathConfig:
     """
 
     # TODO: This could be another data source option
-    results: Path = env_field(name="RESULTS_ROOT", converter=Path)
+    results: Path = env_field(name="RESULTS_ROOT", converter=ensure_absolute_path)
     """
     Path to store the results of the metrics
     """

--- a/packages/ref/src/cmip_ref/config.py
+++ b/packages/ref/src/cmip_ref/config.py
@@ -76,6 +76,9 @@ class PathConfig:
 
     These paths must be common across all systems that the REF is being run
     ///
+
+    If any of these paths are specified as relative paths,
+    they will be resolved to absolute paths.
     """
 
     log: Path = env_field(name="LOG_ROOT", converter=ensure_absolute_path)

--- a/packages/ref/src/cmip_ref/config.py
+++ b/packages/ref/src/cmip_ref/config.py
@@ -114,19 +114,19 @@ class PathConfig:
 
     @log.default
     def _log_factory(self) -> Path:
-        return env.path("REF_CONFIGURATION") / "log"
+        return env.path("REF_CONFIGURATION").resolve() / "log"
 
     @scratch.default
     def _scratch_factory(self) -> Path:
-        return env.path("REF_CONFIGURATION") / "scratch"
+        return env.path("REF_CONFIGURATION").resolve() / "scratch"
 
     @software.default
     def _software_factory(self) -> Path:
-        return env.path("REF_CONFIGURATION") / "software"
+        return env.path("REF_CONFIGURATION").resolve() / "software"
 
     @results.default
     def _results_factory(self) -> Path:
-        return env.path("REF_CONFIGURATION") / "results"
+        return env.path("REF_CONFIGURATION").resolve() / "results"
 
 
 @config(prefix=env_prefix)

--- a/packages/ref/tests/unit/cli/test_root.py
+++ b/packages/ref/tests/unit/cli/test_root.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 import pytest
 
@@ -37,6 +38,9 @@ def test_config_directory_custom(config, invoke_cli):
     config.paths.scratch = "test-value"
     config.save()
 
+    # The loaded value is converted into an absolute path
+    expected_value = Path("test-value").resolve()
+
     result = invoke_cli(
         [
             "--configuration-directory",
@@ -45,7 +49,7 @@ def test_config_directory_custom(config, invoke_cli):
             "list",
         ],
     )
-    assert 'scratch = "test-value"\n' in result.output
+    assert f'scratch = "{expected_value}"\n' in result.output
 
 
 def test_config_directory_append(config, invoke_cli):

--- a/packages/ref/tests/unit/test_config.py
+++ b/packages/ref/tests/unit/test_config.py
@@ -38,7 +38,7 @@ class TestConfig:
 
         # The default location is overridden in the config fixture
         loaded = Config.default()
-        assert loaded.paths.scratch == Path("data")
+        assert loaded.paths.scratch == Path("data").resolve()
 
     def test_load(self, config, tmp_path):
         res = config.dump(defaults=True)

--- a/packages/ref/tests/unit/test_config.py
+++ b/packages/ref/tests/unit/test_config.py
@@ -120,6 +120,7 @@ filename = "sqlite://cmip_ref.db"
         monkeypatch.setenv("REF_CONFIGURATION", "test")
 
         cfg = Config.load(Path("test.toml"))
+        default_path = Path("test").resolve()
 
         with_defaults = cfg.dump(defaults=True)
 
@@ -149,10 +150,10 @@ filename = "sqlite://cmip_ref.db"
             ],
             "executor": {"executor": "cmip_ref.executor.local.LocalExecutor", "config": {}},
             "paths": {
-                "log": "test/log",
-                "results": "test/results",
-                "scratch": "test/scratch",
-                "software": "test/software",
+                "log": f"{default_path}/log",
+                "results": f"{default_path}/results",
+                "scratch": f"{default_path}/scratch",
+                "software": f"{default_path}/software",
             },
             "db": {"database_url": "sqlite:///test/db/cmip_ref.db", "run_migrations": True},
         }


### PR DESCRIPTION
## Description

Ensures that the paths in the config object are always absolute.
This makes it easier to check if we have a path relative to an output directory or a fully resolved path.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
