### PR TITLE
Add option to install a development version of a metrics package

### DIFF
--- a/changelog/236.feature.md
+++ b/changelog/236.feature.md
@@ -1,0 +1,1 @@
+Added the option to install development versions of metrics packages.

--- a/packages/ref-core/src/cmip_ref_core/providers.py
+++ b/packages/ref-core/src/cmip_ref_core/providers.py
@@ -233,12 +233,13 @@ class CondaMetricsProvider(CommandLineMetricsProvider):
         name: str,
         version: str,
         slug: str | None = None,
-        url: str | None = None,
+        repo: str | None = None,
+        tag_or_commit: str | None = None,
     ) -> None:
         super().__init__(name, version, slug)
         self._conda_exe: Path | None = None
         self._prefix: Path | None = None
-        self.url = url
+        self.url = f"git+{repo}@{tag_or_commit}" if repo and tag_or_commit else None
 
     @property
     def prefix(self) -> Path:
@@ -323,24 +324,18 @@ class CondaMetricsProvider(CommandLineMetricsProvider):
         A unique path for storing the conda environment.
         """
         with self.get_environment_file() as file:
-            suffix = hashlib.sha1(file.read_bytes(), usedforsecurity=False).hexdigest()
-        return self.prefix / f"{self.slug}-{suffix}"
+            suffix = hashlib.sha1(file.read_bytes(), usedforsecurity=False)
+            if self.url is not None:
+                suffix.update(bytes(self.url, encoding="utf-8"))
+        return self.prefix / f"{self.slug}-{suffix.hexdigest()}"
 
-    def create_env(self, dev: bool = True) -> None:
+    def create_env(self) -> None:
         """
         Create a conda environment.
-
-        Parameters
-        ----------
-        dev:
-            If True, the archive path/URL from the provider will be used to
-            install the development version of the metrics package.
-
         """
         logger.debug(f"Attempting to create environment at {self.env_path}")
         if self.env_path.exists():
             logger.info(f"Environment at {self.env_path} already exists, not creating it.")
-            conda_exe = f"{self.get_conda_exe(update=False)}"
         else:
             conda_exe = f"{self.get_conda_exe(update=True)}"
             with self.get_environment_file() as file:
@@ -356,20 +351,20 @@ class CondaMetricsProvider(CommandLineMetricsProvider):
                 logger.debug(f"Running {' '.join(cmd)}")
                 subprocess.run(cmd, check=True)  # noqa: S603
 
-        if dev is True and self.url is not None:
-            # Run this even when the environment already exists because
-            # the url/path may not uniquely define the version.
-            logger.info(f"Installing development version of {self.slug} from {self.url}")
-            cmd = [
-                conda_exe,
-                "run",
-                "pip",
-                "install",
-                "--no-deps",
-                self.url,
-            ]
-            logger.debug(f"Running {' '.join(cmd)}")
-            subprocess.run(cmd, check=True)  # noqa: S603
+                if self.url is not None:
+                    logger.info(f"Installing development version of {self.slug} from {self.url}")
+                    cmd = [
+                        conda_exe,
+                        "run",
+                        "--prefix",
+                        f"{self.env_path}",
+                        "pip",
+                        "install",
+                        "--no-deps",
+                        self.url,
+                    ]
+                    logger.debug(f"Running {' '.join(cmd)}")
+                    subprocess.run(cmd, check=True)  # noqa: S603
 
     def run(self, cmd: Iterable[str]) -> None:
         """
@@ -381,7 +376,7 @@ class CondaMetricsProvider(CommandLineMetricsProvider):
             The command to run.
 
         """
-        self.create_env(dev=False)
+        self.create_env()
 
         cmd = [
             f"{self.get_conda_exe(update=False)}",

--- a/packages/ref-core/src/cmip_ref_core/providers.py
+++ b/packages/ref-core/src/cmip_ref_core/providers.py
@@ -326,16 +326,15 @@ class CondaMetricsProvider(CommandLineMetricsProvider):
             suffix = hashlib.sha1(file.read_bytes(), usedforsecurity=False).hexdigest()
         return self.prefix / f"{self.slug}-{suffix}"
 
-    def create_env(self, dev: str | bool = True) -> None:
+    def create_env(self, dev: bool = True) -> None:
         """
         Create a conda environment.
 
         Parameters
         ----------
         dev:
-            Path or URL to a development version of the package that can be
-            installed by pip. If True, the default path/URL from the provider
-            will be used. If False, no development version will be installed.
+            If True, the archive path/URL from the provider will be used to
+            install the development version of the metrics package.
 
         """
         logger.debug(f"Attempting to create environment at {self.env_path}")
@@ -357,24 +356,17 @@ class CondaMetricsProvider(CommandLineMetricsProvider):
                 logger.debug(f"Running {' '.join(cmd)}")
                 subprocess.run(cmd, check=True)  # noqa: S603
 
-        if dev is True:
-            url = self.url
-        elif dev is False:
-            url = None
-        else:
-            url = dev
-
-        if url is not None:
+        if dev is True and self.url is not None:
             # Run this even when the environment already exists because
             # the url/path may not uniquely define the version.
-            logger.info(f"Installing development version of {self.slug} from {url}")
+            logger.info(f"Installing development version of {self.slug} from {self.url}")
             cmd = [
                 conda_exe,
                 "run",
                 "pip",
                 "install",
                 "--no-deps",
-                url,
+                self.url,
             ]
             logger.debug(f"Running {' '.join(cmd)}")
             subprocess.run(cmd, check=True)  # noqa: S603

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/__init__.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/__init__.py
@@ -11,7 +11,8 @@ from cmip_ref_metrics_esmvaltool.recipe import _ESMVALTOOL_COMMIT
 provider = CondaMetricsProvider(
     "ESMValTool",
     __version__,
-    url=f"git+https://github.com/ESMValGroup/ESMValTool.git@{_ESMVALTOOL_COMMIT}",
+    repo="https://github.com/ESMValGroup/ESMValTool.git",
+    tag_or_commit=_ESMVALTOOL_COMMIT,
 )
 
 # Register the metrics.

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/__init__.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/__init__.py
@@ -5,9 +5,16 @@ Rapid evaluating CMIP data with ESMValTool.
 import cmip_ref_metrics_esmvaltool.metrics
 from cmip_ref_core.providers import CondaMetricsProvider
 from cmip_ref_metrics_esmvaltool._version import __version__
+from cmip_ref_metrics_esmvaltool.recipe import _ESMVALTOOL_COMMIT
 
-# Initialise the metrics manager and register the metrics
-provider = CondaMetricsProvider("ESMValTool", __version__)
+# Initialise the metrics manager.
+provider = CondaMetricsProvider(
+    "ESMValTool",
+    __version__,
+    url=f"git+https://github.com/ESMValGroup/ESMValTool.git@{_ESMVALTOOL_COMMIT}",
+)
+
+# Register the metrics.
 for _metric_cls_name in cmip_ref_metrics_esmvaltool.metrics.__all__:
     _metric_cls = getattr(cmip_ref_metrics_esmvaltool.metrics, _metric_cls_name)
     provider.register(_metric_cls())

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/recipe.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/recipe.py
@@ -113,8 +113,8 @@ def dataframe_to_recipe(files: pd.DataFrame) -> dict[str, Any]:
     return variables
 
 
-_ESMVALTOOL_VERSION = "2.13.0.dev10+g7883d411e"
-_ESMVALTOOL_COMMIT = _ESMVALTOOL_VERSION.split("+")[1][1:]
+_ESMVALTOOL_COMMIT = "864a0b9328e6d29d0591ffb593fdfcc88b22f1b8"
+_ESMVALTOOL_VERSION = f"2.13.0.dev10+{_ESMVALTOOL_COMMIT[:10]}"
 
 _RECIPES = pooch.create(
     path=pooch.os_cache("cmip_ref_metrics_esmvaltool"),

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/recipe.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/recipe.py
@@ -114,7 +114,7 @@ def dataframe_to_recipe(files: pd.DataFrame) -> dict[str, Any]:
 
 
 _ESMVALTOOL_COMMIT = "864a0b9328e6d29d0591ffb593fdfcc88b22f1b8"
-_ESMVALTOOL_VERSION = f"2.13.0.dev10+{_ESMVALTOOL_COMMIT[:10]}"
+_ESMVALTOOL_VERSION = f"2.13.0.dev21+{_ESMVALTOOL_COMMIT[:10]}"
 
 _RECIPES = pooch.create(
     path=pooch.os_cache("cmip_ref_metrics_esmvaltool"),

--- a/packages/ref/src/cmip_ref/cli/providers.py
+++ b/packages/ref/src/cmip_ref/cli/providers.py
@@ -76,7 +76,7 @@ def create_env(
         txt = f"virtual environment for provider {provider_.slug}"
         if isinstance(provider_, CondaMetricsProvider):
             logger.info(f"Creating {txt} in {provider_.env_path}")
-            provider_.create_env(dev=True)
+            provider_.create_env()
             logger.info(f"Finished creating {txt}")
         else:
             logger.info(f"Skipping creating {txt} because it does use virtual environments.")

--- a/packages/ref/src/cmip_ref/cli/providers.py
+++ b/packages/ref/src/cmip_ref/cli/providers.py
@@ -55,17 +55,6 @@ def create_env(
         str | None,
         typer.Option(help="Only install the environment for the named provider."),
     ] = None,
-    dev: Annotated[
-        str | None,
-        typer.Option(
-            help=(
-                "Install the development version of the metrics package using pip. "
-                "Any archive url/path accepted by pip can be provided. "
-                "If no url/path is provided, the default path for the metrics "
-                "provider will be used."
-            ),
-        ),
-    ] = None,
 ) -> None:
     """
     Create a virtual environment containing the provider software.
@@ -75,12 +64,7 @@ def create_env(
     with db.session.begin():
         providers = ProviderRegistry.build_from_config(config, db).providers
 
-    if provider is None:
-        if dev is not None:
-            msg = f'Please use the --provider argument to select the environment to install "{dev}" in.'
-            logger.error(msg)
-            raise typer.Exit(code=1)
-    else:
+    if provider is not None:
         available = ", ".join([f'"{p.slug}"' for p in providers])
         providers = [p for p in providers if p.slug == provider]
         if not providers:
@@ -92,7 +76,7 @@ def create_env(
         txt = f"virtual environment for provider {provider_.slug}"
         if isinstance(provider_, CondaMetricsProvider):
             logger.info(f"Creating {txt} in {provider_.env_path}")
-            provider_.create_env(True if dev is None else dev)
+            provider_.create_env(dev=True)
             logger.info(f"Finished creating {txt}")
         else:
             logger.info(f"Skipping creating {txt} because it does use virtual environments.")


### PR DESCRIPTION
## Description

Add an option to install a development version of a metrics package. To add a development version of the metrics package used by a provider, instantiate the provider with a `repo` and `tag_or_commit` arguments, e.g.:
https://github.com/bouweandela/climate-ref/blob/38547119fad35a2079a9fd2653d02527d7ed45e5/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/__init__.py#L11-L15

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
