### PR TITLE
Support multiple sets of data requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest" ]
-        python-version: [ "3.11", "3.12", "3.13" ]
+        python-version: [ "3.13" ]
     runs-on: "${{ matrix.os }}"
     defaults:
       run:

--- a/changelog/266.feature.md
+++ b/changelog/266.feature.md
@@ -1,0 +1,1 @@
+Support multiple sets of data requirements

--- a/changelog/267.fix.md
+++ b/changelog/267.fix.md
@@ -1,0 +1,1 @@
+Retry downloads if they fail

--- a/docs/how-to-guides/metric-dataset-selection.py
+++ b/docs/how-to-guides/metric-dataset-selection.py
@@ -105,6 +105,9 @@ for unique_id, dataset_files in data_catalog.groupby(adapter.slug_column):
 # of datasets within the data catalog that match the requirements.
 # Below are some examples showing different data requests
 # and the corresponding groups of datasets that would be executed.
+#
+# Multiple sets of these data requirements are also supported if a list of lists of data requirements
+# are specified.
 
 # %%
 from cmip_ref.solver import extract_covered_datasets

--- a/packages/ref-core/src/cmip_ref_core/dataset_registry.py
+++ b/packages/ref-core/src/cmip_ref_core/dataset_registry.py
@@ -148,6 +148,7 @@ class DatasetRegistryManager:
             path=pooch.os_cache(cache_name),
             base_url=base_url,
             version=version,
+            retry_if_failed=5,
             env="REF_METRICS_DATA_DIR",
         )
         registry.load_registry(str(importlib.resources.files(package) / resource))

--- a/packages/ref-core/src/cmip_ref_core/datasets.py
+++ b/packages/ref-core/src/cmip_ref_core/datasets.py
@@ -3,9 +3,10 @@ Dataset management and filtering
 """
 
 import enum
+import functools
 import hashlib
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Self
 
 import pandas as pd
 from attrs import field, frozen
@@ -20,6 +21,21 @@ class SourceDatasetType(enum.Enum):
     CMIP7 = "cmip7"
     obs4MIPs = "obs4mips"
     PMPClimatology = "pmp-climatology"
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def ordered(
+        cls,
+    ) -> list[Self]:
+        """
+        Order in alphabetical order according to their value
+
+        Returns
+        -------
+        :
+            Ordered list of dataset types
+        """
+        return sorted(cls, key=lambda x: x.value)
 
 
 def _clean_facets(raw_values: dict[str, str | tuple[str, ...] | list[str]]) -> dict[str, tuple[str, ...]]:

--- a/packages/ref-core/src/cmip_ref_core/datasets.py
+++ b/packages/ref-core/src/cmip_ref_core/datasets.py
@@ -100,6 +100,11 @@ class MetricDataset:
     def __init__(self, collection: dict[SourceDatasetType | str, DatasetCollection]):
         self._collection = {SourceDatasetType(k): v for k, v in collection.items()}
 
+    def __contains__(self, key: SourceDatasetType | str) -> bool:
+        if isinstance(key, str):
+            key = SourceDatasetType(key)
+        return key in self._collection
+
     def __getitem__(self, key: SourceDatasetType | str) -> DatasetCollection:
         if isinstance(key, str):
             key = SourceDatasetType(key)

--- a/packages/ref-core/src/cmip_ref_core/metrics.py
+++ b/packages/ref-core/src/cmip_ref_core/metrics.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import pathlib
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import pandas as pd
@@ -390,12 +390,17 @@ class AbstractMetric(Protocol):
     Defaults to the name of the metric in lowercase with spaces replaced by hyphens.
     """
 
-    data_requirements: tuple[DataRequirement, ...]
+    data_requirements: Sequence[DataRequirement] | Sequence[Sequence[DataRequirement]]
     """
     Description of the required datasets for the current metric
 
-    This information is used to filter the a data catalog of both CMIP and/or observation datasets
+    This information is used to filter the a data catalog of both model and/or observation datasets
     that are required by the metric.
+
+    A metric may specify either a single set of requirements (i.e. a list of `DataRequirement`'s),
+    or multiple sets of requirements (i.e. a list of lists of `DataRequirement`'s).
+    Each of these sets of requirements will be processed separately which is effectively an OR operation
+    across the sets of requirements.
 
     Any modifications to the input data will new metric calculation.
     """

--- a/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
+++ b/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
@@ -23,29 +23,49 @@ class AnnualCycle(CommandLineMetric):
         self.name = "PMP Annual Cycle"
         self.slug = "pmp-annual-cycle"
         self.data_requirements = (
-            DataRequirement(
-                source_type=SourceDatasetType.PMPClimatology,
-                # TODO: Add or operators and enable more varaiables
-                filters=(
-                    FacetFilter(
-                        facets={"source_id": ("GPCP-Monthly-3-2", "ERA-5"), "variable_id": ("pr", "ts")}
-                    ),
+            # Surface temperature
+            (
+                DataRequirement(
+                    source_type=SourceDatasetType.PMPClimatology,
+                    filters=(FacetFilter(facets={"source_id": ("ERA-5",), "variable_id": ("ts",)}),),
+                    group_by=("variable_id", "source_id"),
                 ),
-                group_by=("variable_id", "source_id"),
+                DataRequirement(
+                    source_type=SourceDatasetType.CMIP6,
+                    filters=(
+                        FacetFilter(
+                            facets={
+                                "frequency": "mon",
+                                "experiment_id": ("amip", "historical", "hist-GHG", "piControl"),
+                                "variable_id": ("ts",),
+                            }
+                        ),
+                    ),
+                    group_by=("variable_id", "source_id", "experiment_id", "member_id"),
+                ),
             ),
-            DataRequirement(
-                source_type=SourceDatasetType.CMIP6,
-                # TODO: Add or operators and enable more varaiables
-                filters=(
-                    FacetFilter(
-                        facets={
-                            "frequency": "mon",
-                            "experiment_id": ("amip", "historical", "hist-GHG", "piControl"),
-                            "variable_id": ("pr", "ts"),
-                        }
+            # Precipitation
+            (
+                DataRequirement(
+                    source_type=SourceDatasetType.PMPClimatology,
+                    filters=(
+                        FacetFilter(facets={"source_id": ("GPCP-Monthly-3-2",), "variable_id": ("pr",)}),
                     ),
+                    group_by=("variable_id", "source_id"),
                 ),
-                group_by=("variable_id", "source_id", "experiment_id", "variant_label", "member_id"),
+                DataRequirement(
+                    source_type=SourceDatasetType.CMIP6,
+                    filters=(
+                        FacetFilter(
+                            facets={
+                                "frequency": "mon",
+                                "experiment_id": ("amip", "historical", "hist-GHG", "piControl"),
+                                "variable_id": ("pr",),
+                            }
+                        ),
+                    ),
+                    group_by=("variable_id", "source_id", "experiment_id", "member_id"),
+                ),
             ),
         )
 

--- a/packages/ref/src/cmip_ref/solver.py
+++ b/packages/ref/src/cmip_ref/solver.py
@@ -199,12 +199,10 @@ def solve_metric_executions(
         # We have a sequence of collections of data requirements
         for requirement_collection in metric.data_requirements:
             if not isinstance(requirement_collection, Sequence):
-                raise ValueError(
-                    f"Expected a sequence of data requirements, got {type(requirement_collection)}"
-                )
+                raise TypeError(f"Expected a sequence of DataRequirement, got {type(requirement_collection)}")
             yield from _solve_from_data_requirements(data_catalog, metric, requirement_collection, provider)
     else:
-        raise ValueError(f"Expected a sequence of data requirements, got {type(first_item)}")
+        raise TypeError(f"Expected a DataRequirement, got {type(first_item)}")
 
 
 def _solve_from_data_requirements(
@@ -217,6 +215,8 @@ def _solve_from_data_requirements(
     dataset_groups = {}
 
     for requirement in data_requirements:
+        if not isinstance(requirement, DataRequirement):
+            raise TypeError(f"Expected a DataRequirement, got {type(requirement)}")
         if requirement.source_type not in data_catalog:
             raise InvalidMetricException(metric, f"No data catalog for source type {requirement.source_type}")
 


### PR DESCRIPTION
## Description
Support multiple data requirements, either a list of data requirements or a list of lists of data requirements where each inner list is processed independently.

These different sets of data requirements can have different group bys and different filters.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
