### PR TITLE
PMP annual cycle: `CaldendarMonth`

### DIFF
--- a/changelog/263.breaking.md
+++ b/changelog/263.breaking.md
@@ -1,0 +1,2 @@
+Removed unnecessary prefixes in the metric slugs.
+This will cause duplicate results to be generated so we recommend starting with a clean REF installation.

--- a/changelog/266.feature.md
+++ b/changelog/266.feature.md
@@ -1,0 +1,1 @@
+Support multiple sets of data requirements

--- a/changelog/268.fix.md
+++ b/changelog/268.fix.md
@@ -1,0 +1,1 @@
+PMP annual cycle output JSON tranformed to be more comply with CMEC

--- a/docs/how-to-guides/metric-dataset-selection.py
+++ b/docs/how-to-guides/metric-dataset-selection.py
@@ -105,6 +105,9 @@ for unique_id, dataset_files in data_catalog.groupby(adapter.slug_column):
 # of datasets within the data catalog that match the requirements.
 # Below are some examples showing different data requests
 # and the corresponding groups of datasets that would be executed.
+#
+# Multiple sets of these data requirements are also supported if a list of lists of data requirements
+# are specified.
 
 # %%
 from cmip_ref.solver import extract_covered_datasets

--- a/packages/ref-core/src/cmip_ref_core/datasets.py
+++ b/packages/ref-core/src/cmip_ref_core/datasets.py
@@ -3,9 +3,10 @@ Dataset management and filtering
 """
 
 import enum
+import functools
 import hashlib
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Self
 
 import pandas as pd
 from attrs import field, frozen
@@ -20,6 +21,21 @@ class SourceDatasetType(enum.Enum):
     CMIP7 = "cmip7"
     obs4MIPs = "obs4mips"
     PMPClimatology = "pmp-climatology"
+
+    @classmethod
+    @functools.lru_cache(maxsize=1)
+    def ordered(
+        cls,
+    ) -> list[Self]:
+        """
+        Order in alphabetical order according to their value
+
+        Returns
+        -------
+        :
+            Ordered list of dataset types
+        """
+        return sorted(cls, key=lambda x: x.value)
 
 
 def _clean_facets(raw_values: dict[str, str | tuple[str, ...] | list[str]]) -> dict[str, tuple[str, ...]]:
@@ -99,6 +115,11 @@ class MetricDataset:
 
     def __init__(self, collection: dict[SourceDatasetType | str, DatasetCollection]):
         self._collection = {SourceDatasetType(k): v for k, v in collection.items()}
+
+    def __contains__(self, key: SourceDatasetType | str) -> bool:
+        if isinstance(key, str):
+            key = SourceDatasetType(key)
+        return key in self._collection
 
     def __getitem__(self, key: SourceDatasetType | str) -> DatasetCollection:
         if isinstance(key, str):

--- a/packages/ref-core/src/cmip_ref_core/metrics.py
+++ b/packages/ref-core/src/cmip_ref_core/metrics.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import pathlib
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import pandas as pd
@@ -390,12 +390,17 @@ class AbstractMetric(Protocol):
     Defaults to the name of the metric in lowercase with spaces replaced by hyphens.
     """
 
-    data_requirements: tuple[DataRequirement, ...]
+    data_requirements: Sequence[DataRequirement] | Sequence[Sequence[DataRequirement]]
     """
     Description of the required datasets for the current metric
 
-    This information is used to filter the a data catalog of both CMIP and/or observation datasets
+    This information is used to filter the a data catalog of both model and/or observation datasets
     that are required by the metric.
+
+    A metric may specify either a single set of requirements (i.e. a list of `DataRequirement`'s),
+    or multiple sets of requirements (i.e. a list of lists of `DataRequirement`'s).
+    Each of these sets of requirements will be processed separately which is effectively an OR operation
+    across the sets of requirements.
 
     Any modifications to the input data will new metric calculation.
     """

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/climate_at_global_warming_levels.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/climate_at_global_warming_levels.py
@@ -18,7 +18,7 @@ class ClimateAtGlobalWarmingLevels(ESMValToolMetric):
     """
 
     name = "Climate variables at global warming levels"
-    slug = "esmvaltool-climate-at-global-warming-levels"
+    slug = "climate-at-global-warming-levels"
     base_recipe = "recipe_calculate_gwl_exceedance_stats.yml"
 
     variables = (

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/ecs.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/ecs.py
@@ -23,7 +23,7 @@ class EquilibriumClimateSensitivity(ESMValToolMetric):
     """
 
     name = "Equilibrium Climate Sensitivity"
-    slug = "esmvaltool-equilibrium-climate-sensitivity"
+    slug = "equilibrium-climate-sensitivity"
     base_recipe = "recipe_ecs.yml"
 
     variables = (

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/example.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/example.py
@@ -14,7 +14,7 @@ class GlobalMeanTimeseries(ESMValToolMetric):
     """
 
     name = "Global Mean Timeseries"
-    slug = "esmvaltool-global-mean-timeseries"
+    slug = "global-mean-timeseries"
     base_recipe = "examples/recipe_python.yml"
 
     data_requirements = (

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/sea_ice_area_seasonal_cycle.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/sea_ice_area_seasonal_cycle.py
@@ -17,7 +17,7 @@ class SeaIceAreaSeasonalCycle(ESMValToolMetric):
     """
 
     name = "Sea ice area seasonal cycle"
-    slug = "esmvaltool-sea-ice-area-seasonal-cycle"
+    slug = "sea-ice-area-seasonal-cycle"
     base_recipe = "ref/recipe_ref_sea_ice_area_basic.yml"
 
     data_requirements = (

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/tcr.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/tcr.py
@@ -23,7 +23,7 @@ class TransientClimateResponse(ESMValToolMetric):
     """
 
     name = "Transient Climate Response"
-    slug = "esmvaltool-transient-climate-response"
+    slug = "transient-climate-response"
     base_recipe = "recipe_tcr.yml"
 
     experiments = (

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/tcre.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/tcre.py
@@ -23,7 +23,7 @@ class TransientClimateResponseEmissions(ESMValToolMetric):
     """
 
     name = "Transient Climate Response to Cumulative CO2 Emissions"
-    slug = "esmvaltool-transient-climate-response-emissions"
+    slug = "transient-climate-response-emissions"
     base_recipe = "recipe_tcre.yml"
 
     experiments = (

--- a/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/zec.py
+++ b/packages/ref-metrics-esmvaltool/src/cmip_ref_metrics_esmvaltool/metrics/zec.py
@@ -23,7 +23,7 @@ class ZeroEmissionCommitment(ESMValToolMetric):
     """
 
     name = "Zero Emission Commitment"
-    slug = "esmvaltool-zero-emission-commitment"
+    slug = "zero-emission-commitment"
     base_recipe = "recipe_zec.yml"
 
     experiments = (

--- a/packages/ref-metrics-esmvaltool/tests/unit/test_metrics.py
+++ b/packages/ref-metrics-esmvaltool/tests/unit/test_metrics.py
@@ -22,9 +22,7 @@ def metric_dataset(cmip6_data_catalog) -> MetricDataset:
 def test_example_metric(mocker, tmp_path, metric_dataset, cmip6_data_catalog, definition_factory):
     provider = cmip_ref_metrics_esmvaltool.provider
 
-    metric = next(
-        metric for metric in provider.metrics() if metric.slug == "esmvaltool-global-mean-timeseries"
-    )
+    metric = next(metric for metric in provider.metrics() if metric.slug == "global-mean-timeseries")
     ds = cmip6_data_catalog.groupby("instance_id", as_index=False).first()
 
     definition = definition_factory(cmip6=DatasetCollection(ds, "instance_id"))

--- a/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
+++ b/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
@@ -319,7 +319,7 @@ def _transform_results(data: dict[str, Any]) -> dict[str, Any]:
                                     stat
                                 ].pop("CalendarMonths")
                                 for i, value in enumerate(calendar_months):
-                                    key_name = f"CalendarMonths-{i+1:02d}"
+                                    key_name = f"CalendarMonth-{i+1:02d}"
                                     data["RESULTS"][model]["default"][realization][region][stat][key_name] = (
                                         value
                                     )
@@ -332,7 +332,7 @@ def _transform_results(data: dict[str, Any]) -> dict[str, Any]:
     ):
         calendar_months = data["DIMENSIONS"]["season"].pop("CalendarMonths")
         for i in range(1, 13):
-            key_name = f"CalendarMonths-{i:02d}"
+            key_name = f"CalendarMonth-{i:02d}"
             data["DIMENSIONS"]["season"][key_name] = {}
 
     return data

--- a/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
+++ b/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
@@ -23,29 +23,49 @@ class AnnualCycle(CommandLineMetric):
         self.name = "PMP Annual Cycle"
         self.slug = "pmp-annual-cycle"
         self.data_requirements = (
-            DataRequirement(
-                source_type=SourceDatasetType.PMPClimatology,
-                # TODO: Add or operators and enable more varaiables
-                filters=(
-                    FacetFilter(
-                        facets={"source_id": ("GPCP-Monthly-3-2", "ERA-5"), "variable_id": ("pr", "ts")}
-                    ),
+            # Surface temperature
+            (
+                DataRequirement(
+                    source_type=SourceDatasetType.PMPClimatology,
+                    filters=(FacetFilter(facets={"source_id": ("ERA-5",), "variable_id": ("ts",)}),),
+                    group_by=("variable_id", "source_id"),
                 ),
-                group_by=("variable_id", "source_id"),
+                DataRequirement(
+                    source_type=SourceDatasetType.CMIP6,
+                    filters=(
+                        FacetFilter(
+                            facets={
+                                "frequency": "mon",
+                                "experiment_id": ("amip", "historical", "hist-GHG", "piControl"),
+                                "variable_id": ("ts",),
+                            }
+                        ),
+                    ),
+                    group_by=("variable_id", "source_id", "experiment_id", "member_id"),
+                ),
             ),
-            DataRequirement(
-                source_type=SourceDatasetType.CMIP6,
-                # TODO: Add or operators and enable more varaiables
-                filters=(
-                    FacetFilter(
-                        facets={
-                            "frequency": "mon",
-                            "experiment_id": ("amip", "historical", "hist-GHG", "piControl"),
-                            "variable_id": ("pr", "ts"),
-                        }
+            # Precipitation
+            (
+                DataRequirement(
+                    source_type=SourceDatasetType.PMPClimatology,
+                    filters=(
+                        FacetFilter(facets={"source_id": ("GPCP-Monthly-3-2",), "variable_id": ("pr",)}),
                     ),
+                    group_by=("variable_id", "source_id"),
                 ),
-                group_by=("variable_id", "source_id", "experiment_id", "variant_label", "member_id"),
+                DataRequirement(
+                    source_type=SourceDatasetType.CMIP6,
+                    filters=(
+                        FacetFilter(
+                            facets={
+                                "frequency": "mon",
+                                "experiment_id": ("amip", "historical", "hist-GHG", "piControl"),
+                                "variable_id": ("pr",),
+                            }
+                        ),
+                    ),
+                    group_by=("variable_id", "source_id", "experiment_id", "member_id"),
+                ),
             ),
         )
 

--- a/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
+++ b/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
@@ -323,4 +323,16 @@ def _transform_results(data: dict[str, Any]) -> dict[str, Any]:
                                     data["RESULTS"][model]["default"][realization][region][stat][key_name] = (
                                         value
                                     )
+
+    # Remove the "CalendarMonths" key from the nested structure in "DIMENSIONS"
+    if (
+        "DIMENSIONS" in data
+        and "season" in data["DIMENSIONS"]
+        and "CalendarMonths" in data["DIMENSIONS"]["season"]
+    ):
+        calendar_months = data["DIMENSIONS"]["season"].pop("CalendarMonths")
+        for i in range(1, 13):
+            key_name = f"CalendarMonths-{i:02d}"
+            data["DIMENSIONS"]["season"][key_name] = {}
+
     return data

--- a/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
+++ b/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/annual_cycle.py
@@ -20,8 +20,8 @@ class AnnualCycle(CommandLineMetric):
     """
 
     def __init__(self) -> None:
-        self.name = "PMP Annual Cycle"
-        self.slug = "pmp-annual-cycle"
+        self.name = "Annual Cycle"
+        self.slug = "annual-cycle"
         self.data_requirements = (
             # Surface temperature
             (

--- a/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/variability_modes.py
+++ b/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/variability_modes.py
@@ -14,7 +14,7 @@ from cmip_ref_metrics_pmp.pmp_driver import build_pmp_command, process_json_resu
 
 class ExtratropicalModesOfVariability(CommandLineMetric):
     """
-    Calculate the annual cycle for a dataset
+    Calculate the extratropical modes of variability for a given area
     """
 
     ts_modes = ("PDO", "NPGO", "AMO")
@@ -22,8 +22,8 @@ class ExtratropicalModesOfVariability(CommandLineMetric):
 
     def __init__(self, mode_id: str):
         self.mode_id = mode_id.upper()
-        self.name = f"PMP Extratropical modes of variability {mode_id}"
-        self.slug = f"pmp-extratropical-modes-of-variability-{mode_id.lower()}"
+        self.name = f"Extratropical modes of variability: {mode_id}"
+        self.slug = f"extratropical-modes-of-variability-{mode_id.lower()}"
 
         def get_data_requirements(
             obs_source: str,

--- a/packages/ref/tests/unit/test_solver.py
+++ b/packages/ref/tests/unit/test_solver.py
@@ -18,7 +18,6 @@ from cmip_ref.solver import (
 from cmip_ref_core.constraints import AddSupplementaryDataset, RequireFacets, SelectParentExperiment
 from cmip_ref_core.datasets import SourceDatasetType
 from cmip_ref_core.metrics import DataRequirement, FacetFilter
-from cmip_ref_core.providers import MetricsProvider
 
 
 @pytest.fixture
@@ -351,8 +350,50 @@ def test_solve_metrics_dry_run(mocker, db_seeded, config, solver):
     # TODO: Check that no new metrics were added to the db
 
 
+def test_solve_metric_executions_missing(mock_metric, provider):
+    mock_metric.data_requirements = ()
+    with pytest.raises(ValueError, match=f"Metric {mock_metric.slug} has no data requirements"):
+        next(solve_metric_executions({}, mock_metric, provider))
+
+
+def test_solve_metric_executions_mixed_data_requirements(mock_metric, provider):
+    mock_metric.data_requirements = (
+        DataRequirement(
+            source_type=SourceDatasetType.CMIP6,
+            filters=(),
+            group_by=("variable_id", "source_id"),
+        ),
+        (
+            DataRequirement(
+                source_type=SourceDatasetType.CMIP6,
+                filters=(),
+                group_by=("variable_id", "experiment_id"),
+            ),
+        ),
+    )
+    data_catalog = {SourceDatasetType.CMIP6: pd.DataFrame()}
+
+    with pytest.raises(TypeError, match="Expected a DataRequirement, got <class 'tuple'>"):
+        next(solve_metric_executions(data_catalog, mock_metric, provider))
+
+    mock_metric.data_requirements = mock_metric.data_requirements[::-1]
+    with pytest.raises(
+        TypeError,
+        match="Expected a sequence of DataRequirement, got <class 'cmip_ref_core.metrics.DataRequirement'>",
+    ):
+        next(solve_metric_executions(data_catalog, mock_metric, provider))
+
+    mock_metric.data_requirements = ("test",)
+    with pytest.raises(TypeError, match="Expected a DataRequirement, got <class 'str'>"):
+        next(solve_metric_executions(data_catalog, mock_metric, provider))
+
+    mock_metric.data_requirements = (None,)
+    with pytest.raises(TypeError, match="Expected a DataRequirement, got <class 'NoneType'>"):
+        next(solve_metric_executions(data_catalog, mock_metric, provider))
+
+
 @pytest.mark.parametrize("variable,expected", [("tas", 4), ("pr", 1), ("not_a_variable", 0)])
-def test_solve_metric_executions(solver, mock_metric, variable, expected):
+def test_solve_metric_executions(solver, mock_metric, provider, variable, expected):
     metric = mock_metric
     metric.data_requirements = (
         DataRequirement(
@@ -366,8 +407,6 @@ def test_solve_metric_executions(solver, mock_metric, variable, expected):
             group_by=("variable_id", "experiment_id"),
         ),
     )
-    provider = MetricsProvider("mock_provider", "v0.1.0")
-    provider.register(mock_metric)
 
     data_catalog = {
         SourceDatasetType.obs4MIPs: pd.DataFrame(
@@ -387,6 +426,45 @@ def test_solve_metric_executions(solver, mock_metric, variable, expected):
     }
     executions = solve_metric_executions(data_catalog, metric, provider)
     assert len(list(executions)) == expected
+
+
+def test_solve_metric_executions_multiple_sets(solver, mock_metric, provider):
+    metric = mock_metric
+    metric.data_requirements = (
+        (
+            DataRequirement(
+                source_type=SourceDatasetType.CMIP6,
+                filters=(FacetFilter(facets={"variable_id": "tas"}),),
+                group_by=("variable_id",),
+            ),
+        ),
+        (
+            DataRequirement(
+                source_type=SourceDatasetType.CMIP6,
+                filters=(FacetFilter(facets={"variable_id": "pr"}),),
+                group_by=("variable_id", "experiment_id"),
+            ),
+        ),
+    )
+
+    data_catalog = {
+        SourceDatasetType.CMIP6: pd.DataFrame(
+            {
+                "variable_id": ["tas", "tas", "pr"],
+                "experiment_id": ["ssp119", "ssp126", "ssp119"],
+                "variant_label": ["r1i1p1f1", "r1i1p1f1", "r1i1p1f1"],
+            }
+        ),
+    }
+    executions = list(solve_metric_executions(data_catalog, metric, provider))
+    assert len(executions) == 2
+
+    assert executions[0].metric_dataset[SourceDatasetType.CMIP6].selector == (("variable_id", "tas"),)
+
+    assert executions[1].metric_dataset[SourceDatasetType.CMIP6].selector == (
+        ("variable_id", "pr"),
+        ("experiment_id", "ssp119"),
+    )
 
 
 def _prep_data_catalog(data_catalog: dict[str, Any]) -> pd.DataFrame:


### PR DESCRIPTION
## Description

PMP annual cycle output JSON file includes `CaldendarMonth` key and its value is a list. To comply with CMEC, renamed the `CaldendarMonth` to `CaldendarMonth-01` ~ `CaldendarMonth-12` and assigned their value individually, so list is not used as value in the JSON.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
