### PR TITLE
Set the FI_PROVIDER environment variable

### DIFF
--- a/changelog/281.fix.md
+++ b/changelog/281.fix.md
@@ -1,0 +1,3 @@
+Sets the environment variable `FI_PROVIDER=tcp` to use the TCP provider for libfabric (part of MPICH).
+The defaults were causing MPICH errors on some systems (namely macOS).
+This also removes the PMP provider's direct dependency on the source of `pcmdi_metric`.

--- a/packages/climate-ref-pmp/pyproject.toml
+++ b/packages/climate-ref-pmp/pyproject.toml
@@ -21,11 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "climate-ref-core",
-    "pcmdi_metrics",
 ]
-
-[tool.uv.sources]
-pcmdi_metrics = { git = "https://github.com/PCMDI/pcmdi_metrics", rev="v3.9.1" }
 
 [project.license]
 text = "Apache-2.0"

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/annual_cycle.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/annual_cycle.py
@@ -153,14 +153,18 @@ class AnnualCycle(CommandLineDiagnostic):
         data_name = f"{source_id}_{experiment_id}_{member_id}"
         data_path = model_files
         params = {
-            "driver_file": "mean_climate/pcmdi_compute_climatologies.py",
-            "parameter_file": self.parameter_file_1,
             "vars": variable_id,
             "infile": data_path,
             "outfile": f"{output_directory_path}/{variable_id}_{data_name}_clims.nc",
         }
 
-        cmds.append(build_pmp_command(**params))
+        cmds.append(
+            build_pmp_command(
+                driver_file="pcmdi_compute_climatologies.py",
+                parameter_file=self.parameter_file_1,
+                **params,
+            )
+        )
 
         # ----------------------------------------------
         # PART 2: Build the command to calculate diagnostics
@@ -183,8 +187,6 @@ class AnnualCycle(CommandLineDiagnostic):
         date = datetime.datetime.now().strftime("%Y%m%d")
 
         params = {
-            "driver_file": "mean_climate/mean_climate_driver.py",
-            "parameter_file": self.parameter_file_2,
             "vars": variable_id,
             "custom_observations": f"{output_directory_path}/obs_dict.json",
             "test_data_path": output_directory_path,
@@ -195,7 +197,13 @@ class AnnualCycle(CommandLineDiagnostic):
             "cmec": "",
         }
 
-        cmds.append(build_pmp_command(**params))
+        cmds.append(
+            build_pmp_command(
+                driver_file="mean_climate_driver.py",
+                parameter_file=self.parameter_file_2,
+                **params,
+            )
+        )
 
         return cmds
 

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
@@ -148,7 +148,7 @@ class ExtratropicalModesOfVariability(CommandLineDiagnostic):
 
         # Pass the parameters using **kwargs
         return build_pmp_command(
-            driver_file="variability_mode/variability_modes_driver.py",
+            driver_file="variability_modes_driver.py",
             parameter_file=self.parameter_file,
             **params,
         )

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/pmp_driver.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/pmp_driver.py
@@ -162,7 +162,8 @@ def build_pmp_command(
     # This is a workaround for a fatal error in internal_Finalize of MPICH
     # when running in a conda environment on MacOS.
     # It is not clear if this is a bug in MPICH or a problem with the conda environment.
-    if "FI_PROVIDER" in os.environ:
+    if "FI_PROVIDER" not in os.environ:  # pragma: no branch
+        logger.debug("Setting env variable 'FI_PROVIDER=tcp'")
         os.environ["FI_PROVIDER"] = "tcp"
 
     # Run the driver script inside the PMP conda environment

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/pmp_driver.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/pmp_driver.py
@@ -144,6 +144,9 @@ def build_pmp_command(
     The output consists of a JSON file that contains the executions of the PMP diagnostics,
     and a set of PNG and data files that are produced by the diagnostics.
 
+    The PMP driver scripts are installed in the PMP conda environment,
+    but absolute paths should be used for non-PMP scripts.
+
     Parameters
     ----------
     driver_file
@@ -154,7 +157,6 @@ def build_pmp_command(
         Additional arguments to pass to the driver script
     """
     # Note this uses the driver script from the REF env *not* the PMP conda env
-    _driver_script = _get_resource("pcmdi_metrics", driver_file, use_resources=False)
     _parameter_file = _get_resource("climate_ref_pmp.params", parameter_file, use_resources=True)
 
     # This is a workaround for a fatal error in internal_Finalize of MPICH
@@ -165,8 +167,7 @@ def build_pmp_command(
 
     # Run the driver script inside the PMP conda environment
     cmd = [
-        "python",
-        _driver_script,
+        driver_file,
         "-p",
         _parameter_file,
     ]

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/pmp_driver.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/pmp_driver.py
@@ -157,6 +157,12 @@ def build_pmp_command(
     _driver_script = _get_resource("pcmdi_metrics", driver_file, use_resources=False)
     _parameter_file = _get_resource("climate_ref_pmp.params", parameter_file, use_resources=True)
 
+    # This is a workaround for a fatal error in internal_Finalize of MPICH
+    # when running in a conda environment on MacOS.
+    # It is not clear if this is a bug in MPICH or a problem with the conda environment.
+    if "FI_PROVIDER" in os.environ:
+        os.environ["FI_PROVIDER"] = "tcp"
+
     # Run the driver script inside the PMP conda environment
     cmd = [
         "python",

--- a/packages/climate-ref-pmp/tests/unit/test_annual_cycle.py
+++ b/packages/climate-ref-pmp/tests/unit/test_annual_cycle.py
@@ -133,9 +133,6 @@ def test_annual_cycle_diagnostic(
     )
     # The output directory must exist
     output_dir = definition.output_directory
-    driver_script = _get_resource(
-        "pcmdi_metrics", "mean_climate/pcmdi_compute_climatologies.py", use_resources=False
-    )
     parameter_file = _get_resource(
         "climate_ref_pmp.params", "pmp_param_annualcycle_1-clims.py", use_resources=True
     )
@@ -150,8 +147,7 @@ def test_annual_cycle_diagnostic(
     # Check the first command
     cmd = result[0]
     assert cmd == [
-        "python",
-        driver_script,
+        "pcmdi_compute_climatologies.py",
         "-p",
         parameter_file,
         "--vars",
@@ -163,14 +159,12 @@ def test_annual_cycle_diagnostic(
     ]
 
     # Check the second command
-    driver_script = _get_resource("pcmdi_metrics", "mean_climate/mean_climate_driver.py", use_resources=False)
     parameter_file = _get_resource(
         "climate_ref_pmp.params", "pmp_param_annualcycle_2-metrics.py", use_resources=True
     )
     cmd = result[1]
     assert cmd == [
-        "python",
-        driver_script,
+        "mean_climate_driver.py",
         "-p",
         parameter_file,
         "--vars",

--- a/packages/climate-ref-pmp/tests/unit/test_pmp_driver.py
+++ b/packages/climate-ref-pmp/tests/unit/test_pmp_driver.py
@@ -29,24 +29,6 @@ def test_process_json_result(pdo_example_dir):
     ]
 
 
-def test_execute_missing_driver():
-    with pytest.raises(
-        FileNotFoundError,
-        match="Resource variability_mode/missing.py not found in pcmdi_metrics package.",
-    ):
-        build_pmp_command(
-            driver_file="variability_mode/missing.py",
-            parameter_file="pmp_param_MoV-ts.py",
-            model_files=["model1.nc"],
-            reference_name="HadISST-1-1",
-            reference_paths=["reference.nc"],
-            source_id="source_id",
-            member_id="member_id",
-            output_directory_path="output",
-            experiment_id="historical",
-        )
-
-
 def test_execute_missing_parameter():
     with pytest.raises(
         FileNotFoundError,

--- a/packages/climate-ref-pmp/tests/unit/test_variability_modes.py
+++ b/packages/climate-ref-pmp/tests/unit/test_variability_modes.py
@@ -51,8 +51,7 @@ def test_pdo_metric(data_catalog, config, mocker, definition_factory, pdo_exampl
 
     mock_run.assert_called_with(
         [
-            "python",
-            _get_resource("pcmdi_metrics", "variability_mode/variability_modes_driver.py", False),
+            "variability_modes_driver.py",
             "-p",
             _get_resource("climate_ref_pmp.params", "pmp_param_MoV-ts.py", True),
             "--variability_mode",

--- a/uv.lock
+++ b/uv.lock
@@ -750,14 +750,10 @@ version = "0.5.0"
 source = { editable = "packages/climate-ref-pmp" }
 dependencies = [
     { name = "climate-ref-core" },
-    { name = "pcmdi-metrics" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "climate-ref-core", editable = "packages/climate-ref-core" },
-    { name = "pcmdi-metrics", git = "https://github.com/PCMDI/pcmdi_metrics?rev=v3.9.1" },
-]
+requires-dist = [{ name = "climate-ref-core", editable = "packages/climate-ref-core" }]
 
 [package.metadata.requires-dev]
 dev = []
@@ -2884,11 +2880,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/d1/81/74f6a65b848ffd16c
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/2b/b50d3d08ea0fc419c183a84210571eba005328efa62b6b98bc28e9ead32a/patsy-1.0.1-py2.py3-none-any.whl", hash = "sha256:751fb38f9e97e62312e921a1954b81e1bb2bcda4f5eeabaf94db251ee791509c", size = 232923 },
 ]
-
-[[package]]
-name = "pcmdi-metrics"
-version = "3.9.1"
-source = { git = "https://github.com/PCMDI/pcmdi_metrics?rev=v3.9.1#15907575b99dea4fae53c242b8d6dcd7365da902" }
 
 [[package]]
 name = "pexpect"


### PR DESCRIPTION
## Description

This is a workaround for MPICH failures on macOS.

This also removes a direct dependency on the pcmdi_metric source on GitHub (since pcmdi_metrics doesn't have a release on PyPi). Instead the driver scripts in the conda installation are used.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
