### PR TITLE
fix: Allow empty metric bundles

### DIFF
--- a/changelog/284.fix.md
+++ b/changelog/284.fix.md
@@ -1,0 +1,1 @@
+Support the use of empty metric bundles

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/metric.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/metric.py
@@ -66,9 +66,7 @@ class MetricDimensions(RootModel[Any]):
 
     root: dict[str, Any] = Field(
         default={
-            MetricCV.JSON_STRUCTURE.value: ["model", "metric"],
-            "model": {},
-            "metric": {},
+            MetricCV.JSON_STRUCTURE.value: [],
         }
     )
 
@@ -217,7 +215,11 @@ class MetricResults(RootModel[Any]):
             # executions = rlt.root
             results = rlt
             metdims = info.context.root
-            cls._check_nested_dict_keys(results, metdims, level=0)
+            if len(metdims[MetricCV.JSON_STRUCTURE.value]) == 0:
+                if rlt != {}:
+                    raise ValueError("Expected an empty dictionary for the metric bundle")
+            else:
+                cls._check_nested_dict_keys(results, metdims, level=0)
 
         return rlt
 

--- a/packages/climate-ref-core/tests/unit/pycmec/cmec_testdata/test_metric_json_schema.yml
+++ b/packages/climate-ref-core/tests/unit/pycmec/cmec_testdata/test_metric_json_schema.yml
@@ -2,11 +2,7 @@ $defs:
   MetricDimensions:
     additionalProperties: true
     default:
-      json_structure:
-      - model
-      - metric
-      metric: {}
-      model: {}
+      json_structure: []
     description: 'CMEC diagnostic bundle DIMENSIONS object
 
 

--- a/packages/climate-ref-core/tests/unit/pycmec/test_cmec_metric.py
+++ b/packages/climate-ref-core/tests/unit/pycmec/test_cmec_metric.py
@@ -341,12 +341,15 @@ def test_metric_merge():
 
 def test_metric_create_template():
     assert CMECMetric.create_template() == {
-        "DIMENSIONS": {"json_structure": ["model", "metric"], "metric": {}, "model": {}},
+        "DIMENSIONS": {
+            "json_structure": [],
+        },
         "RESULTS": {},
         "DISCLAIMER": None,
         "NOTES": None,
         "PROVENANCE": None,
     }
+    CMECMetric.model_validate(CMECMetric.create_template())
 
 
 def test_metric_load_from_jsons(datadir):

--- a/packages/climate-ref-core/tests/unit/pycmec/test_cmec_metric.py
+++ b/packages/climate-ref-core/tests/unit/pycmec/test_cmec_metric.py
@@ -198,6 +198,14 @@ def test_validate_result_wo_dim(cmec_right_metric_dict):
         MetricResults(cmec_right_metric_dict["RESULTS"])
 
 
+def test_validate_semi_empty(cmec_right_metric_dict):
+    with pytest.raises(ValidationError):
+        CMECMetric(DIMENSIONS={"json_structure": []}, RESULTS={"model": {}})
+
+    with pytest.raises(ValidationError):
+        CMECMetric(DIMENSIONS={}, RESULTS={})
+
+
 def test_metric_deepest_dictionary_value(cmec_right_metric_dict):
     cmec_right_metric_dict["RESULTS"]["CESM2"]["Ecosystem and Carbon Cycle"]["overall score"] = {
         "value": 0.11,

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_at_global_warming_levels.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_at_global_warming_levels.py
@@ -62,7 +62,7 @@ class ClimateAtGlobalWarmingLevels(ESMValToolDiagnostic):
             ),
         ),
     )
-    facets = ("model", "metric")
+    facets = ()
 
     @staticmethod
     def update_recipe(recipe: Recipe, input_files: pandas.DataFrame) -> None:

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
@@ -22,10 +22,7 @@ class CloudRadiativeEffects(ESMValToolDiagnostic):
     slug = "cloud-radiative-effects"
     base_recipe = "ref/recipe_ref_cre.yml"
 
-    # TODO: These facets are needed to pass metric bundle validation,
-    # in the integration test, but this diagnostic does not produce a metric.
-    # Should they be removed?
-    facets = ("model", "metric")
+    facets = ()
 
     variables = (
         "rlut",

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/example.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/example.py
@@ -28,7 +28,7 @@ class GlobalMeanTimeseries(ESMValToolDiagnostic):
             ),
         ),
     )
-    facets = ("model", "metric")
+    facets = ()
 
     @staticmethod
     def update_recipe(recipe: Recipe, input_files: pandas.DataFrame) -> None:

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_area_seasonal_cycle.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_area_seasonal_cycle.py
@@ -39,7 +39,7 @@ class SeaIceAreaSeasonalCycle(ESMValToolDiagnostic):
         ),
         # TODO: Use OSI-450-nh and OSI-450-sh from obs4MIPs once available.
     )
-    facets = ("model", "metric")
+    facets = ()
 
     @staticmethod
     def update_recipe(recipe: Recipe, input_files: pandas.DataFrame) -> None:

--- a/tests/test-data/regression/esmvaltool/climate-at-global-warming-levels/cmip6_ssp126/diagnostic.json
+++ b/tests/test-data/regression/esmvaltool/climate-at-global-warming-levels/cmip6_ssp126/diagnostic.json
@@ -1,11 +1,6 @@
 {
   "DIMENSIONS": {
-    "json_structure": [
-      "model",
-      "metric"
-    ],
-    "model": {},
-    "metric": {}
+    "json_structure": []
   },
   "RESULTS": {},
   "PROVENANCE": null,

--- a/tests/test-data/regression/esmvaltool/cloud-radiative-effects/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5/diagnostic.json
+++ b/tests/test-data/regression/esmvaltool/cloud-radiative-effects/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5/diagnostic.json
@@ -1,11 +1,6 @@
 {
   "DIMENSIONS": {
-    "json_structure": [
-      "model",
-      "metric"
-    ],
-    "model": {},
-    "metric": {}
+    "json_structure": []
   },
   "RESULTS": {},
   "PROVENANCE": null,

--- a/tests/test-data/regression/esmvaltool/global-mean-timeseries/cmip6_CMIP6.C4MIP CDRMIP.CSIRO.ACCESS-ESM1-5.esm-1pct-brch-1000PgC.r1i1p1f1.Amon.tas.gn.v20191206/diagnostic.json
+++ b/tests/test-data/regression/esmvaltool/global-mean-timeseries/cmip6_CMIP6.C4MIP CDRMIP.CSIRO.ACCESS-ESM1-5.esm-1pct-brch-1000PgC.r1i1p1f1.Amon.tas.gn.v20191206/diagnostic.json
@@ -1,11 +1,6 @@
 {
   "DIMENSIONS": {
-    "json_structure": [
-      "model",
-      "metric"
-    ],
-    "model": {},
-    "metric": {}
+    "json_structure": []
   },
   "RESULTS": {},
   "PROVENANCE": null,

--- a/tests/test-data/regression/esmvaltool/sea-ice-area-seasonal-cycle/cmip6_CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.SImon.siconc.gn.v20200817/diagnostic.json
+++ b/tests/test-data/regression/esmvaltool/sea-ice-area-seasonal-cycle/cmip6_CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.SImon.siconc.gn.v20200817/diagnostic.json
@@ -1,11 +1,6 @@
 {
   "DIMENSIONS": {
-    "json_structure": [
-      "model",
-      "metric"
-    ],
-    "model": {},
-    "metric": {}
+    "json_structure": []
   },
   "RESULTS": {},
   "PROVENANCE": null,


### PR DESCRIPTION
## Description
Update the default metric bundle to be empty.
Fixed the validation of empty bundles

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
