### PR TITLE
Update the default log level of the CLI to info

### DIFF
--- a/changelog/292.improvement.md
+++ b/changelog/292.improvement.md
@@ -1,0 +1,2 @@
+Update the default log level to INFO from WARNING.
+Added the `-q` option to decrease the log level to WARNING.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,32 +10,30 @@ $ uv run ref
 
  Usage: ref [OPTIONS] COMMAND [ARGS]...
 
- ref: A CLI for the CMIP Rapid Evaluation Framework
+ climate_ref: A CLI for the Assessment Fast Track Rapid Evaluation Framework
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --configuration-direc…          PATH                  Configuration          │
-│                                                       directory              │
-│                                                       [default: None]        │
-│ --verbose               -v                                                   │
-│ --log-level                     [WARNING|DEBUG|INFO]  [default: WARNING]     │
-│ --version                                                                    │
-│ --install-completion                                  Install completion for │
-│                                                       the current shell.     │
-│ --show-completion                                     Show completion for    │
-│                                                       the current shell, to  │
-│                                                       copy it or customize   │
-│                                                       the installation.      │
-│ --help                                                Show this message and  │
-│                                                       exit.                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ solve        Solve for diagnostics that require recalculation                    │
-│ config       View and update the REF configuration                           │
-│ datasets     View and ingest input datasets                                  │
-│ executions   View diagnostic executions                                          │
-│ providers    Manage the REF providers.                                       │
-│ celery       Managing remote execution workers                               │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ This CLI provides a number of commands for managing and executing diagnostics.
+
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --configuration-directory          PATH                        Configuration directory [default: None]               │
+│ --verbose                  -v                                  Set the log level to DEBUG                            │
+│ --quiet                    -q                                  Set the log level to WARNING                          │
+│ --log-level                        [ERROR|WARNING|DEBUG|INFO]  Set the level of logging information to display       │
+│                                                                [default: INFO]                                       │
+│ --version                                                      Print the version and exit                            │
+│ --install-completion                                           Install completion for the current shell.             │
+│ --show-completion                                              Show completion for the current shell, to copy it or  │
+│                                                                customize the installation.                           │
+│ --help                                                         Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ solve        Solve for executions that require recalculation                                                         │
+│ config       View and update the REF configuration                                                                   │
+│ datasets     View and ingest input datasets                                                                          │
+│ executions   View diagnostic executions                                                                              │
+│ providers    Manage the REF providers.                                                                               │
+│ celery       Managing remote execution workers                                                                       │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 This provides the ability to:

--- a/packages/climate-ref-core/src/climate_ref_core/executor.py
+++ b/packages/climate-ref-core/src/climate_ref_core/executor.py
@@ -33,7 +33,7 @@ def execute_locally(
     log_level
         The log level to use for the execution
     """
-    logger.exception(f"Executing {definition.execution_slug()!r}")
+    logger.info(f"Executing {definition.execution_slug()!r}")
 
     try:
         if definition.output_directory.exists():

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/metric.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/metric.py
@@ -522,6 +522,10 @@ class CMECMetric(BaseModel):
         """
         dimensions = cast(list[str], self.DIMENSIONS[MetricCV.JSON_STRUCTURE.value])
 
+        if len(dimensions) == 0:
+            # There is no data to iterate over
+            return
+
         yield from _walk_results(dimensions, self.RESULTS, {})
 
 

--- a/packages/climate-ref/src/climate_ref/cli/__init__.py
+++ b/packages/climate-ref/src/climate_ref/cli/__init__.py
@@ -23,7 +23,8 @@ class LogLevel(str, Enum):
     Log levels for the CLI
     """
 
-    Normal = "WARNING"
+    Error = "ERROR"
+    Warning = "WARNING"
     Debug = "DEBUG"
     Info = "INFO"
 
@@ -109,19 +110,28 @@ app = build_app()
 
 
 @app.callback()
-def main(
+def main(  # noqa: PLR0913
     ctx: typer.Context,
     configuration_directory: Annotated[Path | None, typer.Option(help="Configuration directory")] = None,
-    verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
-    log_level: Annotated[LogLevel, typer.Option(case_sensitive=False)] = LogLevel.Normal,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Set the log level to DEBUG")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Set the log level to WARNING")] = False,
+    log_level: Annotated[
+        LogLevel, typer.Option(case_sensitive=False, help="Set the level of logging information to display")
+    ] = LogLevel.Info,
     version: Annotated[
         Optional[bool],
-        typer.Option("--version", callback=_version_callback, is_eager=True),
+        typer.Option(
+            "--version", callback=_version_callback, is_eager=True, help="Print the version and exit"
+        ),
     ] = None,
 ) -> None:
     """
-    climate_ref: A CLI for the CMIP Rapid Evaluation Framework
+    climate_ref: A CLI for the Assessment Fast Track Rapid Evaluation Framework
+
+    This CLI provides a number of commands for managing and executing diagnostics.
     """
+    if quiet:
+        log_level = LogLevel.Warning
     if verbose:
         log_level = LogLevel.Debug
 

--- a/packages/climate-ref/src/climate_ref/executor/local.py
+++ b/packages/climate-ref/src/climate_ref/executor/local.py
@@ -13,6 +13,7 @@ from climate_ref.models import Execution
 from climate_ref_core.diagnostics import ExecutionDefinition, ExecutionResult
 from climate_ref_core.exceptions import ExecutionError
 from climate_ref_core.executor import execute_locally
+from climate_ref_core.logging import add_log_handler
 
 from .result_handling import handle_execution_result
 
@@ -62,6 +63,12 @@ class ExecutionFuture:
     execution: Execution | None = None
 
 
+def _process_initialiser() -> None:
+    # Setup the logging for the process
+    # This replaces the loguru default handler
+    add_log_handler()
+
+
 class LocalExecutor:
     """
     Run a diagnostic locally using a process pool.
@@ -95,7 +102,7 @@ class LocalExecutor:
         if pool is not None:
             self.pool = pool
         else:
-            self.pool = ProcessPoolExecutor(max_workers=n)
+            self.pool = ProcessPoolExecutor(max_workers=n, initializer=_process_initialiser)
         self._results: list[ExecutionFuture] = []
 
     def run(

--- a/packages/climate-ref/tests/unit/cli/test_root.py
+++ b/packages/climate-ref/tests/unit/cli/test_root.py
@@ -12,7 +12,7 @@ def test_without_subcommand(invoke_cli):
     result = invoke_cli([])
     assert "Usage:" in result.stdout
     assert "climate_ref [OPTIONS] COMMAND [ARGS]" in result.stdout
-    assert "climate_ref: A CLI for the CMIP Rapid Evaluation Framework" in result.stdout
+    assert "climate_ref: A CLI for the Assessment Fast Track Rapid Evaluation Framework" in result.stdout
 
 
 def test_version(invoke_cli):
@@ -32,6 +32,30 @@ def test_verbose(invoke_cli):
     )
     # Only info and higher messages logged
     assert not re.search(exp_log, result.stderr)
+
+
+@pytest.mark.parametrize(
+    "cmds, expected_log_level",
+    [
+        [["--log-level", "DEBUG"], "DEBUG"],
+        [["--log-level", "INFO"], "INFO"],
+        [["--log-level", "WARNING"], "WARNING"],
+        [["--log-level", "ERROR"], "ERROR"],
+        [["-v"], "DEBUG"],
+        [["-q"], "WARNING"],
+        # Verbose wins
+        [["-v", "-q"], "DEBUG"],
+        [["-q", "-v"], "DEBUG"],
+        # -q/-v wins over --log-level
+        [["-v", "--log-level", "ERROR"], "DEBUG"],
+        [["-q", "--log-level", "INFO"], "WARNING"],
+    ],
+)
+def test_log_level(invoke_cli, cmds, expected_log_level):
+    result = invoke_cli(
+        [*cmds, "config", "list"],
+    )
+    assert f'log_level = "{expected_log_level}"' in result.stdout
 
 
 def test_config_directory_custom(config, invoke_cli):


### PR DESCRIPTION
## Description
Changes the default log level of the CLI to INFO along with fixing a few minor logging issues

`--quiet` and `--verbose` can be used to easily change the log level


## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
