### PR TITLE
feat: Add backups for the database

### DIFF
--- a/changelog/299.improvement.md
+++ b/changelog/299.improvement.md
@@ -1,1 +1,0 @@
-Added automatic backup of SQLite database files before running migrations. Backups are stored in a `backups` directory adjacent to the database file and are named with timestamps. The number of backups to retain can be configured via the `max_backups` setting in the database configuration, with a default of 5 backups.

--- a/changelog/299.improvement.md
+++ b/changelog/299.improvement.md
@@ -1,0 +1,1 @@
+Added automatic backup of SQLite database files before running migrations. Backups are stored in a `backups` directory adjacent to the database file and are named with timestamps. The number of backups to retain can be configured via the `max_backups` setting in the database configuration, with a default of 5 backups.

--- a/changelog/301.improvement.md
+++ b/changelog/301.improvement.md
@@ -1,0 +1,4 @@
+Added automatic backup of SQLite database files before running migrations.
+Backups are stored in a `backups` directory adjacent to the database file and are named with timestamps.
+The number of backups to retain can be configured via the `db.max_backups` setting in the database configuration,
+with a default of 5 backups.

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -276,6 +276,16 @@ class DbConfig:
     """
     run_migrations: bool = field(default=True)
 
+    max_backups: int = env_field(name="MAX_BACKUPS", default=5)
+    """
+    Maximum number of database backups to keep.
+
+
+    When running migrations for on-disk SQLite databases, a backup of the database is created.
+    This setting controls how many of these backups are retained.
+    The oldest backups are automatically removed when this limit is exceeded.
+    """
+
     @database_url.default
     def _connection_url_factory(self) -> str:
         filename = env.path("REF_CONFIGURATION") / "db" / "climate_ref.db"

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -159,7 +159,11 @@ filename = "sqlite://climate_ref.db"
                 "software": f"{default_path}/software",
                 "dimensions_cv": str(Path("pycmec") / "cv_cmip7_aft.yaml"),
             },
-            "db": {"database_url": "sqlite:///test/db/climate_ref.db", "run_migrations": True},
+            "db": {
+                "database_url": "sqlite:///test/db/climate_ref.db",
+                "max_backups": 5,
+                "run_migrations": True,
+            },
         }
 
     def test_from_env_variables(self, monkeypatch, config):


### PR DESCRIPTION
## Description

Added automatic backup of SQLite database files before running migrations.
Backups are stored in a `backups` directory adjacent to the database file and are named with timestamps.
The number of backups to retain can be configured via the `db.max_backups` setting in the database configuration,
with a default of 5 backups.


## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
