### PR TITLE
Remove superfluous recipe keys in TCR diagnostic and rename diagnostic key

### DIFF
--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/tcr.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/tcr.py
@@ -58,7 +58,7 @@ class TransientClimateResponse(ESMValToolDiagnostic):
         """Update the recipe."""
         # Only run the diagnostic that computes TCR for a single model.
         recipe["diagnostics"] = {
-            "cmip6": {
+            "tcr": {
                 "description": "Calculate TCR.",
                 "variables": {
                     "tas": {
@@ -66,7 +66,7 @@ class TransientClimateResponse(ESMValToolDiagnostic):
                     },
                 },
                 "scripts": {
-                    "tcr": {
+                    "calculate": {
                         "script": "climate_metrics/tcr.py",
                         "calculate_mmm": False,
                     },
@@ -93,6 +93,15 @@ class TransientClimateResponse(ESMValToolDiagnostic):
         for dataset in datasets:
             dataset["timerange"] = timerange
 
+        # Remove keys from the recipe that are only used for YAML anchors
+        keys_to_remove = [
+            "TCR",
+            "SCATTERPLOT",
+            "VAR_SETTING",
+        ]
+        for key in keys_to_remove:
+            recipe.pop(key, None)
+
         recipe["datasets"] = datasets
 
     @staticmethod
@@ -103,7 +112,7 @@ class TransientClimateResponse(ESMValToolDiagnostic):
         output_args: OutputBundleArgs,
     ) -> tuple[CMECMetric, CMECOutput]:
         """Format the result."""
-        tcr_ds = xarray.open_dataset(result_dir / "work" / "cmip6" / "tcr" / "tcr.nc")
+        tcr_ds = xarray.open_dataset(result_dir / "work" / "tcr" / "calculate" / "tcr.nc")
         tcr = float(tcr_ds["tcr"].values[0])
 
         # Update the diagnostic bundle arguments with the computed diagnostics.

--- a/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_tcr.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_tcr.py
@@ -30,12 +30,19 @@ def test_update_recipe(metric_dataset):
     TransientClimateResponse().update_recipe(recipe, input_files)
     assert len(recipe["datasets"]) == 2
     assert len(recipe["diagnostics"]) == 1
-    assert set(recipe["diagnostics"]["cmip6"]["variables"]) == {"tas"}
+    assert set(recipe["diagnostics"]["tcr"]["variables"]) == {"tas"}
+    undesired_keys = [
+        "TCR",
+        "SCATTERPLOT",
+        "VAR_SETTING",
+    ]
+    for key in undesired_keys:
+        assert key not in recipe
 
 
 def test_format_output(tmp_path, metric_dataset):
     result_dir = tmp_path
-    subdir = result_dir / "work" / "cmip6" / "tcr"
+    subdir = result_dir / "work" / "tcr" / "calculate"
     subdir.mkdir(parents=True)
     tcr = xr.Dataset(
         data_vars={


### PR DESCRIPTION
## Description

The TCR recipe produced by the REF contains lots of unused keys (in the original recipe, they have been used to define YAML anchors). This PR removes these keys.

In addition, it renames the diagnostic name from `cmip6/tcr` to `tcr/calculate`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] ~Documentation added (where applicable)~
- [ ] Changelog item added to `changelog/`
