### PR TITLE
Enable retries hpcexecutor

### DIFF
--- a/packages/climate-ref-core/src/climate_ref_core/exceptions.py
+++ b/packages/climate-ref-core/src/climate_ref_core/exceptions.py
@@ -60,4 +60,10 @@ class DiagnosticError(RefException):
 
     def __init__(self, message: str, result: Any):
         super().__init__(message)
+        self.message = message
         self.result = result
+
+    # need for serialization of parsl
+    def __reduce__(self) -> tuple[type["DiagnosticError"], tuple[str, Any]]:
+        # Return a tuple: (callable, args_tuple_for_reconstruction)
+        return (self.__class__, (self.message, self.result))

--- a/packages/climate-ref/src/climate_ref/slurm.py
+++ b/packages/climate-ref/src/climate_ref/slurm.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 from typing import Any
 
 HAS_REAL_SLURM = importlib.util.find_spec("pyslurm") is not None
@@ -85,10 +86,13 @@ class SlurmChecker:
             return False
 
         sample_acc = account_info[0]
-        for acc in account_info:
-            if acc.user == "minxu":
-                sample_acc = acc
-                break
+        user_name = os.environ["USER"]
+
+        if user_name:
+            for acc in account_info:
+                if acc.user == user_name:
+                    sample_acc = acc
+                    break
 
         allowed_qoss = sample_acc.qos
         if allowed_qoss is None:

--- a/scripts/hpc-executor-prefetch.sh
+++ b/scripts/hpc-executor-prefetch.sh
@@ -50,7 +50,7 @@ if [ "$RUN_PREFETCH" = true ]; then
   ref datasets fetch-data --registry esmvaltool || exit 1
 
   # Cartopy data
-  python download-cartopy-data.py || exit 1
+  python ${REF_INSTALLATION_DIR}/scripts/download-cartopy-data.py || exit 1
 fi
 
 # 3. Ingest data (if enabled)
@@ -58,7 +58,8 @@ if [ "$RUN_INGEST" = true ]; then
   echo "=== Ingesting datasets ==="
   ref datasets ingest --source-type obs4mips "${REF_DATASET_CACHE_DIR}/datasets/obs4ref" || exit 1
   ref datasets ingest --source-type pmp-climatology "${REF_DATASET_CACHE_DIR}/datasets/pmp-climatology" || exit 1
-  ref datasets ingest --source-type cmip6 ~/.cache/climate_ref/v0.6.0/CMIP6 || exit 1
+  # need to run make fetch-test-data under REF directory and check the version under REF cache directory
+  ref datasets ingest --source-type cmip6 ${REF_DATASET_CACHE_DIR}/v0.6.3/CMIP6 || exit 1
 fi
 
 echo "=== Operation completed ==="


### PR DESCRIPTION
## Description

To use the retries in parsl, the exception has to be raised to trigger it to rerun the failed tasks.  The PR changed the exception logic of `_process_run` and `join` methods in HPCExecutor.  The retries number can be set by the executor.config.retries in the `ref.toml`. The default value is 2. 

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
