### PR TITLE
Allow arbitrary environment variables to be used in paths in the configuration file

### DIFF
--- a/changelog/349.improvement.md
+++ b/changelog/349.improvement.md
@@ -1,0 +1,1 @@
+Allow arbitrary environment variables to be used in paths in the configuration file.

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -15,6 +15,7 @@ which always take precedence over any other configuration values.
 # https://github.com/ESGF/esgf-download/blob/main/esgpull/config.py
 
 import importlib.resources
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -64,6 +65,7 @@ def ensure_absolute_path(path: str | Path) -> Path:
     """
     if isinstance(path, str):
         path = Path(path)
+    path = Path(*[os.path.expandvars(p) for p in path.parts])
     return path.resolve()
 
 

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -183,6 +183,14 @@ filename = "sqlite://climate_ref.db"
         assert config_new.paths.log == Path("/my/test/logs")
         assert config_new.paths.results == Path("/my/test/executions")
 
+    def test_custom_env_variable(self, monkeypatch, tmp_path, config):
+        monkeypatch.setenv("ABC", "/my")
+        config.paths.results = "${ABC}/test/executions"
+        # Environment variables are only expanded when loading from file.
+        config.save(tmp_path / "ref.toml")
+        config_new = Config.load(tmp_path / "ref.toml")
+        assert config_new.paths.results == Path("/my/test/executions")
+
     def test_executor_build(self, config, db):
         executor = config.executor.build(config, db)
         assert executor.name == "synchronous"


### PR DESCRIPTION
## Description

Allow arbitrary environment variables to be used in paths in the configuration file. This feature was requested at the feedback session today.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
