### PR TITLE
Add support for NCI PBS Scheduler to the HPCExecutor

### DIFF
--- a/docs/how-to-guides/hpc_executor.md
+++ b/docs/how-to-guides/hpc_executor.md
@@ -9,6 +9,7 @@ You could use HPCExecutor if:
   - The login nodes allow users to run a program for a long time like several hours with little computational resources (less than 25% of one CPU core and negligible memory)
   - You want to run REF under the HPC workflow i.e., submitting batch jobs
   - The scheduler on your HPC is __slurm__. We may include other schedules in the future if needed. Please make an [issue](https://github.com/Climate-REF/climate-ref/issues) describing your requirements.
+  - You are using NCI Gadi. Gadi uses a custom version of PBSPro. You can select the "nci" or "gadi" scheduler in the configuration file.
 
 ## Pre-requirements
 
@@ -38,6 +39,22 @@ walltime = "00:30:00"
 username = "minxu"
 qos = "debug"
 scheduler_options = "#SBATCH -C cpu"
+cores_per_worker = 1
+max_workers_per_node = 64
+```
+If you are using NCI Gadi, you can use the following configuration:
+```toml
+[executor.config]
+scheduler = "nci" # or "gadi"
+account = "m1234"
+queue = "normal"
+walltime = "00:30:00"
+username = "minxu"
+ncpus = 1
+mem = "4GB"
+jobfs = "10GB"
+storage = "/scratch/XX" # Make sure you have access to the storage
+scheduler_options = ""
 cores_per_worker = 1
 max_workers_per_node = 64
 ```

--- a/packages/climate-ref/src/climate_ref/executor/nci_pbs.py
+++ b/packages/climate-ref/src/climate_ref/executor/nci_pbs.py
@@ -1,0 +1,61 @@
+from parsl.providers import PBSProProvider
+from parsl.launchers import SimpleLauncher
+
+
+template_string = '''#!/bin/bash
+
+#PBS -N ${jobname}
+#PBS -l ncpus=${ncpus}
+#PBS -l mem=${mem}
+#PBS -l jobfs=${jobfs}
+#PBS -l storage=${storage}
+#PBS -l walltime=$walltime
+#PBS -o ${job_stdout_path}
+#PBS -e ${job_stderr_path}
+${scheduler_options}
+
+${worker_init}
+
+export JOBNAME="${jobname}"
+
+${user_script}
+
+'''
+
+
+class NCIGadiPBSProProvider(PBSProProvider):
+    """PBSProProvider with a custom template string for NCI."""
+
+    def __init__(self, 
+                 account=None,
+                 queue=None,
+                 ncpus=1,
+                 mem='4GB',
+                 jobfs='10GB',
+                 storage='',
+                 scheduler_options='',
+                 worker_init='',
+                 launcher=SimpleLauncher(),
+                 walltime='00:20:00',
+                 cmd_timeout=120):
+        super().__init__(queue=queue,
+                         account=account,
+                         scheduler_options=scheduler_options,
+                         worker_init=worker_init,
+                         launcher=launcher,
+                         walltime=walltime,
+                         cmd_timeout=cmd_timeout)
+
+        self.ncpus = ncpus
+        self.mem = mem
+        self.jobfs = jobfs
+        self.storage = storage
+        self.template_string = template_string
+
+    def _write_submit_script(self, template, script_filename, job_name, configs):
+        """Write the submit script using the custom template."""
+        configs['ncpus'] = self.ncpus
+        configs['mem'] = self.mem
+        configs['jobfs'] = self.jobfs
+        configs['storage'] = self.storage
+        return super()._write_submit_script(template, script_filename, job_name, configs)


### PR DESCRIPTION
## Description

This pull request introduces support for the job scheduler used on the Gadi supercomputer at NCI.

Gadi runs a customised version of PBSPro that differs from standard PBSPro installations by **disabling the `select` directive**, and instead requiring explicit use of flags like `-l mem=`, `-l ncpus=`, and `-l storage=`.

Because the existing `PBSProProvider` class in Parsl assumes support for `select`, it is incompatible with Gadi. To address this, a new provider class, `NCIGadiPBSProProvider`, has been added. This class handles Gadi's unique scheduler requirements and generates valid job submission scripts accordingly.

Note: I do not currently have access to a standard PBSPro system, so this implementation is specific to NCI Gadi. If needed, I am happy to collaborate on a broader/generalised solution that supports both flavours.

## Checklist

Please confirm that this pull request includes the following:

- [ ] **Tests added**: Existing `HPCExecutor` tests cover basic integration, but there are no scheduler-specific tests for SLURM or Gadi yet.
- [x] **Documentation added**, where applicable.
- [ ] **Changelog item added** in the `changelog/` directory.
