### PR TITLE
Fix bug in writing ESMValTool recipes that loses order of preprocessing steps

### DIFF
--- a/changelog/384.fix.md
+++ b/changelog/384.fix.md
@@ -1,0 +1,3 @@
+Fix bug in writing ESMValTool recipes that loses order of preprocessing steps.
+This bug was introduced in [#378](https://github.com/Climate-REF/climate-ref/pull/378)
+and included in the v0.6.5 release.

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
@@ -87,7 +87,7 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
 
         recipe_path = definition.to_output_path("recipe.yml")
         with recipe_path.open("w", encoding="utf-8") as file:
-            yaml.dump(recipe, file)
+            yaml.safe_dump(recipe, file, sort_keys=False)
 
         climate_data = definition.to_output_path("climate_data")
 


### PR DESCRIPTION
## Description

When switching from ruamel.yaml to pyyaml in #378, I introduced a bug that caused the order of preprocessing steps to be discarded. This has broken diagnostics enso-basic-climatology, enso-characteristics, and transient-climate-response-emissions.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
