### PR TITLE
Add `ref executions flag-dirty EXECUTION_GRP_ID`

### DIFF
--- a/packages/climate-ref/src/climate_ref/cli/executions.py
+++ b/packages/climate-ref/src/climate_ref/cli/executions.py
@@ -209,3 +209,25 @@ def inspect(ctx: typer.Context, execution_id: int) -> None:
     console.print(_datasets_panel(result))
     console.print(_results_directory_panel(result_directory))
     console.print(_log_panel(result_directory))
+
+
+@app.command()
+def flag_dirty(ctx: typer.Context, execution_id: int) -> None:
+    """
+    Flag an execution group for recomputation
+    """
+    session = ctx.obj.database.session
+    with session.begin():
+        execution_group = session.get(ExecutionGroup, execution_id)
+
+        if not execution_group:
+            logger.error(f"Execution not found: {execution_id}")
+            raise typer.Exit(code=1)
+
+        if not execution_group.executions:
+            logger.error(f"No results found for execution: {execution_id}")
+            return
+
+        execution_group.dirty = True
+
+        console.print(_execution_panel(execution_group))


### PR DESCRIPTION
## Description

Sometimes while debugging, an execution will be successful but not yet correct. This command will allow you to manually declare an execution as dirty which will make debugging easier.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
