### PR TITLE
Use constraints that filter the group instead of discard the full group

### DIFF
--- a/changelog/416.breaking.md
+++ b/changelog/416.breaking.md
@@ -1,0 +1,3 @@
+Changed all constraints so they return a filtered dataframe instead of a boolean.
+
+This allows using the constraints in multi-model diagnostics.

--- a/packages/climate-ref-core/src/climate_ref_core/constraints.py
+++ b/packages/climate-ref-core/src/climate_ref_core/constraints.py
@@ -17,45 +17,21 @@ else:
 
 import numpy as np
 import pandas as pd
-from attrs import frozen
+from attrs import field, frozen
 from loguru import logger
 
 from climate_ref_core.datasets import SourceDatasetType
-from climate_ref_core.exceptions import ConstraintNotSatisfied
 
 
 @runtime_checkable
-class GroupValidator(Protocol):
-    """
-    A constraint that must be satisfied when executing a given diagnostic run.
-
-    All constraints must be satisfied for a given group to be run.
-    """
-
-    def validate(self, group: pd.DataFrame) -> bool:
-        """
-        Validate if the constraint is satisfied by the dataset.
-
-        This is executed after the apply method to determine if the constraint is satisfied.
-        If the constraint is not satisfied, the group will not be executed.
-
-        Parameters
-        ----------
-        group
-            A group of datasets that is being validated.
-
-        Returns
-        -------
-        :
-            Whether the constraint is satisfied
-        """
-        ...
-
-
-@runtime_checkable
-class GroupOperation(Protocol):
+class GroupConstraint(Protocol):
     """
     An operation to perform on a group of datasets resulting in a new group of datasets.
+
+    This is applied to a group of datasets representing the inputs to a potential diagnostic execution.
+
+    If the operation results in an empty group, the constraint is considered not satisfied.
+    The group must satisfy all constraints to be processed.
 
     !! warning
 
@@ -92,18 +68,6 @@ class GroupOperation(Protocol):
         ...
 
 
-GroupConstraint = GroupOperation | GroupValidator
-"""
-A constraint that must be satisfied for a group of datasets to be executed.
-
-This is applied to a group of datasets representing the inputs to a potential diagnostic execution.
-The group must satisfy all constraints to be processed.
-
-This can include operations that are applied to a group of datasets which may modify the group,
-but may also include validators that check if the group satisfies a certain condition.
-"""
-
-
 def apply_constraint(
     dataframe: pd.DataFrame,
     constraint: GroupConstraint,
@@ -126,52 +90,58 @@ def apply_constraint(
     :
         The updated group of datasets or None if the constraint was not satisfied
     """
-    try:
-        updated_group = (
-            constraint.apply(dataframe, data_catalog) if isinstance(constraint, GroupOperation) else dataframe
-        )
-
-        valid = constraint.validate(updated_group) if isinstance(constraint, GroupValidator) else True
-        if not valid:
-            logger.debug(f"Constraint {constraint} not satisfied for {dataframe}")
-            raise ConstraintNotSatisfied(f"Constraint {constraint} not satisfied for {dataframe}")
-    except ConstraintNotSatisfied:
+    updated_group = constraint.apply(dataframe, data_catalog)
+    if updated_group.empty:
         logger.debug(f"Constraint {constraint} not satisfied for {dataframe}")
         return None
 
     return updated_group
 
 
+def _to_tuple(value: None | str | tuple[str, ...]) -> tuple[str, ...]:
+    """
+    Clean the value of group_by to a tuple of strings
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    return tuple(value)
+
+
 @frozen
 class RequireFacets:
     """
-    A constraint that requires a dataset to have certain facets.
+    A constraint that requires datasets to have certain facet values.
     """
 
     dimension: str
-    required_facets: tuple[str, ...]
+    """The name of the facet to filter on."""
+
+    required_facets: tuple[str, ...] = field(converter=_to_tuple)
+    "The required facet values."
+
     operator: Literal["all", "any"] = "all"
+    """Whether all or any of the required facets must be present."""
 
-    group_by: tuple[str, ...] | None = None
+    group_by: tuple[str, ...] | None = field(converter=_to_tuple, default=None)
     """
-    The fields to group the datasets by. Each group must contain all or any of the
-    required facets to fulfill the constraint.
+    The facets to group the datasets by.
 
-    The default is to treat the datasets as a single group.
+    Each group created by `group_by` must contain at least one dataset where the
+    value of the given dimension is in the list of required facet values.
 
     For example, if there are multiple models and variables in the selection,
     `group_by` can be used to make sure that only those models are selected that
     provide all required variables.
     """
 
-    def validate(self, group: pd.DataFrame) -> bool:
+    def apply(self, group: pd.DataFrame, data_catalog: pd.DataFrame) -> pd.DataFrame:
         """
-        Check that the required facets are present in the group
+        Filter out groups of datasets that do not provide the required facets
         """
-        if self.dimension not in group:
-            logger.warning(f"Dimension {self.dimension} not present in group {group}")
-            return False
         op = all if self.operator == "all" else any
+        select = pd.Series(True, index=group.index)
         groups = [group] if not self.group_by else (g[1] for g in group.groupby(list(self.group_by)))
         for subgroup in groups:
             if not op(value in subgroup[self.dimension].values for value in self.required_facets):
@@ -179,8 +149,8 @@ class RequireFacets:
                     f"Constraint {self} not satisfied because required facet values "
                     f"not found for group {', '.join(subgroup['path'])}"
                 )
-                return False
-        return True
+                select.loc[subgroup.index] = False
+        return group[select]
 
 
 @frozen
@@ -367,8 +337,8 @@ class RequireTimerange:
 
     group_by: tuple[str, ...]
     """
-    The fields to group the datasets by. Each group must cover the timerange
-    to fulfill the constraint.
+    The fields to group the datasets by. Groups that do not cover the timerange
+    will be removed.
     """
 
     start: PartialDateTime | None = None
@@ -381,35 +351,35 @@ class RequireTimerange:
     The end time of the required timerange. If None, no end time is required.
     """
 
-    def validate(self, group: pd.DataFrame) -> bool:
+    def apply(self, group: pd.DataFrame, data_catalog: pd.DataFrame) -> pd.DataFrame:
         """
         Check that all subgroups of the group have a contiguous timerange.
         """
-        group = group.dropna(subset=["start_time", "end_time"])
-        for _, subgroup in group.groupby(list(self.group_by)):
+        select = pd.Series(True, index=group.index)
+        for _, subgroup in group.dropna(subset=["start_time", "end_time"]).groupby(list(self.group_by)):
             start = subgroup["start_time"].min()
             end = subgroup["end_time"].max()
             result = True
             if self.start is not None and start > self.start:
                 logger.debug(
-                    f"Constraint {self.__class__.__name__} not satisfied "
-                    f"because start time {start} is after required start time "
-                    f"{self.start} for {', '.join(subgroup['path'])}"
+                    f"Constraint {self} not satisfied because start time {start} "
+                    f"is after required start time for {', '.join(subgroup['path'])}"
                 )
                 result = False
             if self.end is not None and end < self.end:
                 logger.debug(
-                    f"Constraint {self.__class__.__name__} not satisfied "
-                    f"because end time {end} is before required end time "
-                    f"{self.end} for {', '.join(subgroup['path'])}"
+                    f"Constraint {self} not satisfied because end time {end} "
+                    f"is before required end time for {', '.join(subgroup['path'])}"
                 )
                 result = False
             if result:
-                result = RequireContiguousTimerange(group_by=self.group_by).validate(subgroup)
+                contiguous_subgroup = RequireContiguousTimerange(group_by=self.group_by).apply(
+                    subgroup, data_catalog
+                )
+                result = len(contiguous_subgroup) == len(subgroup)
             if not result:
-                return False
-
-        return True
+                select.loc[subgroup.index] = False
+        return group[select]
 
 
 @frozen
@@ -420,11 +390,11 @@ class RequireContiguousTimerange:
 
     group_by: tuple[str, ...]
     """
-    The fields to group the datasets by. Each group must be contiguous in time
-    to fulfill the constraint.
+    The fields to group the datasets by. Groups that are not be contiguous in time
+    are removed.
     """
 
-    def validate(self, group: pd.DataFrame) -> bool:
+    def apply(self, group: pd.DataFrame, data_catalog: pd.DataFrame) -> pd.DataFrame:
         """
         Check that all subgroups of the group have a contiguous timerange.
         """
@@ -434,11 +404,10 @@ class RequireContiguousTimerange:
             days=31,  # Maximum number of days in a month.
             hours=1,  # Allow for potential rounding errors.
         )
-        group = group.dropna(subset=["start_time", "end_time"])
-        if len(group) < 2:  # noqa: PLR2004
-            return True
 
-        for _, subgroup in group.groupby(list(self.group_by)):
+        select = pd.Series(True, index=group.index)
+
+        for _, subgroup in group.dropna(subset=["start_time", "end_time"]).groupby(list(self.group_by)):
             if len(subgroup) < 2:  # noqa: PLR2004
                 continue
             sorted_group = subgroup.sort_values("start_time", kind="stable")
@@ -466,12 +435,13 @@ class RequireContiguousTimerange:
                 paths = sorted_group["path"]
                 for gap_idx in np.flatnonzero(gap_indices):
                     logger.debug(
-                        f"Constraint {self.__class__.__name__} not satisfied "
-                        f"because gap larger than {max_timedelta} found between "
+                        f"Constraint {self} not satisfied because gap larger "
+                        f"than {max_timedelta} found between "
                         f"{paths.iloc[gap_idx]} and {paths.iloc[gap_idx + 1]}"
                     )
-                return False
-        return True
+                select.loc[subgroup.index] = False
+
+        return group[select]
 
 
 @frozen
@@ -486,17 +456,24 @@ class RequireOverlappingTimerange:
     the groups to fulfill the constraint.
     """
 
-    def validate(self, group: pd.DataFrame) -> bool:
+    def apply(self, group: pd.DataFrame, data_catalog: pd.DataFrame) -> pd.DataFrame:
         """
         Check that all subgroups of the group have an overlapping timerange.
         """
-        group = group.dropna(subset=["start_time", "end_time"])
-        if len(group) < 2:  # noqa: PLR2004
-            return True
+        group_with_time = group.dropna(subset=["start_time", "end_time"])
+        if len(group_with_time) < 2:  # noqa: PLR2004
+            return group
 
-        starts = group.groupby(list(self.group_by))["start_time"].min()
-        ends = group.groupby(list(self.group_by))["end_time"].max()
-        return starts.max() < ends.min()  # type: ignore[no-any-return]
+        starts = group_with_time.groupby(list(self.group_by))["start_time"].min()
+        ends = group_with_time.groupby(list(self.group_by))["end_time"].max()
+        result = starts.max() < ends.min()
+        if not result:
+            logger.debug(
+                f"Constraint {self} not satisfied because no overlapping timerange "
+                f"found for groups in {', '.join(group['path'])}"
+            )
+            return group.loc[[]]
+        return group
 
 
 @frozen

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_at_global_warming_levels.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_at_global_warming_levels.py
@@ -59,6 +59,11 @@ class ClimateAtGlobalWarmingLevels(ESMValToolDiagnostic):
                     matching_facets=matching_facets,
                     optional_matching_facets=tuple(),
                 ),
+                RequireTimerange(
+                    group_by=matching_facets,
+                    start=PartialDateTime(year=1850, month=1),
+                    end=PartialDateTime(year=2100, month=12),
+                ),
                 RequireFacets(
                     "experiment_id",
                     required_facets=("historical",),
@@ -68,11 +73,6 @@ class ClimateAtGlobalWarmingLevels(ESMValToolDiagnostic):
                     "variable_id",
                     required_facets=variables,
                     group_by=("experiment_id", "source_id", "member_id", "grid_label", "table_id"),
-                ),
-                RequireTimerange(
-                    group_by=matching_facets,
-                    start=PartialDateTime(year=1850, month=1),
-                    end=PartialDateTime(year=2100, month=12),
                 ),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_drivers_for_fire.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_drivers_for_fire.py
@@ -50,6 +50,12 @@ class ClimateDriversForFire(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
+                RequireTimerange(
+                    group_by=("instance_id",),
+                    start=PartialDateTime(2013, 1),
+                    end=PartialDateTime(2014, 12),
+                ),
+                AddSupplementaryDataset.from_defaults("sftlf", SourceDatasetType.CMIP6),
                 RequireFacets(
                     "variable_id",
                     (
@@ -58,16 +64,10 @@ class ClimateDriversForFire(ESMValToolDiagnostic):
                         "pr",
                         "tas",
                         "tasmax",
+                        "sftlf",
                         "treeFrac",
                         "vegFrac",
                     ),
-                ),
-                AddSupplementaryDataset.from_defaults("sftlf", SourceDatasetType.CMIP6),
-                RequireFacets("variable_id", ("sftlf",)),
-                RequireTimerange(
-                    group_by=("instance_id",),
-                    start=PartialDateTime(2013, 1),
-                    end=PartialDateTime(2014, 12),
                 ),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
@@ -44,13 +44,13 @@ class CloudRadiativeEffects(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
-                RequireFacets("variable_id", variables),
                 RequireTimerange(
                     group_by=("instance_id",),
                     start=PartialDateTime(1996, 1),
                     end=PartialDateTime(2014, 12),
                 ),
                 RequireOverlappingTimerange(group_by=("instance_id",)),
+                RequireFacets("variable_id", variables),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
@@ -31,12 +31,12 @@ def get_cmip6_data_requirements(variables: tuple[str, ...]) -> tuple[DataRequire
             ),
             group_by=("source_id", "experiment_id", "member_id", "frequency", "grid_label"),
             constraints=(
-                RequireFacets("variable_id", variables),
                 RequireTimerange(
                     group_by=("instance_id",),
                     start=PartialDateTime(1996, 1),
                     end=PartialDateTime(2014, 12),
                 ),
+                RequireFacets("variable_id", variables),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/ecs.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/ecs.py
@@ -52,6 +52,8 @@ class EquilibriumClimateSensitivity(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
+                RequireContiguousTimerange(group_by=("instance_id",)),
+                RequireOverlappingTimerange(group_by=("instance_id",)),
                 RequireFacets(
                     "variable_id",
                     required_facets=variables,
@@ -62,8 +64,6 @@ class EquilibriumClimateSensitivity(ESMValToolDiagnostic):
                     required_facets=experiments,
                     group_by=("source_id", "member_id", "grid_label", "variable_id"),
                 ),
-                RequireContiguousTimerange(group_by=("instance_id",)),
-                RequireOverlappingTimerange(group_by=("instance_id",)),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/enso.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/enso.py
@@ -49,16 +49,16 @@ class ENSOBasicClimatology(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
+                RequireContiguousTimerange(group_by=("instance_id",)),
+                RequireOverlappingTimerange(group_by=("instance_id",)),
                 RequireFacets(
                     "variable_id",
                     (
                         "pr",
-                        "tos",
                         "tauu",
+                        "tos",
                     ),
                 ),
-                RequireContiguousTimerange(group_by=("instance_id",)),
-                RequireOverlappingTimerange(group_by=("instance_id",)),
             ),
         ),
     )

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/regional_historical_changes.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/regional_historical_changes.py
@@ -118,12 +118,12 @@ class RegionalHistoricalAnnualCycle(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
-                RequireFacets("variable_id", variables),
                 RequireTimerange(
                     group_by=("instance_id",),
                     start=PartialDateTime(1980, 1),
                     end=PartialDateTime(2009, 12),
                 ),
+                RequireFacets("variable_id", variables),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),
@@ -148,6 +148,7 @@ class RegionalHistoricalAnnualCycle(ESMValToolDiagnostic):
                     start=PartialDateTime(1980, 1),
                     end=PartialDateTime(2009, 12),
                 ),
+                RequireFacets("variable_id", ("psl", "ua")),
             ),
             # TODO: Add obs4MIPs datasets once available and working:
             #
@@ -246,12 +247,12 @@ class RegionalHistoricalTimeSeries(RegionalHistoricalAnnualCycle):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
-                RequireFacets("variable_id", variables),
                 RequireTimerange(
                     group_by=("instance_id",),
                     start=PartialDateTime(1980, 1),
                     end=PartialDateTime(2014, 12),
                 ),
+                RequireFacets("variable_id", variables),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_sensitivity.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_sensitivity.py
@@ -48,6 +48,11 @@ class SeaIceSensitivity(ESMValToolDiagnostic):
             ),
             group_by=("experiment_id",),  # this does nothing, but group_by cannot be empty
             constraints=(
+                RequireTimerange(
+                    group_by=("instance_id",),
+                    start=PartialDateTime(1979, 1),
+                    end=PartialDateTime(2014, 12),
+                ),
                 RequireFacets(
                     "variable_id",
                     required_facets=("siconc", "tas"),
@@ -59,11 +64,6 @@ class SeaIceSensitivity(ESMValToolDiagnostic):
                     "variable_id",
                     required_facets=("areacello",),
                     group_by=("source_id", "grid_label"),
-                ),
-                RequireTimerange(
-                    group_by=("instance_id",),
-                    start=PartialDateTime(1979, 1),
-                    end=PartialDateTime(2014, 12),
                 ),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/tcr.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/tcr.py
@@ -46,9 +46,9 @@ class TransientClimateResponse(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
-                RequireFacets("experiment_id", experiments),
                 RequireContiguousTimerange(group_by=("instance_id",)),
                 RequireOverlappingTimerange(group_by=("instance_id",)),
+                RequireFacets("experiment_id", experiments),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/tcre.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/tcre.py
@@ -27,10 +27,6 @@ class TransientClimateResponseEmissions(ESMValToolDiagnostic):
     slug = "transient-climate-response-emissions"
     base_recipe = "recipe_tcre.yml"
 
-    experiments = (
-        "esm-1pctCO2",
-        "esm-piControl",
-    )
     variables = (
         "tas",
         "fco2antt",
@@ -41,7 +37,7 @@ class TransientClimateResponseEmissions(ESMValToolDiagnostic):
             filters=(
                 FacetFilter(
                     facets={
-                        "variable_id": ("tas", "fco2antt"),
+                        "variable_id": variables,
                         "experiment_id": "esm-1pctCO2",
                         "table_id": "Amon",
                     },
@@ -56,10 +52,10 @@ class TransientClimateResponseEmissions(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
-                RequireFacets("experiment_id", ("esm-1pctCO2", "esm-piControl")),
-                RequireFacets("variable_id", ("tas", "fco2antt")),
                 RequireContiguousTimerange(group_by=("instance_id",)),
                 RequireOverlappingTimerange(group_by=("instance_id",)),
+                RequireFacets("experiment_id", ("esm-1pctCO2", "esm-piControl")),
+                RequireFacets("variable_id", variables),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/zec.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/zec.py
@@ -46,9 +46,9 @@ class ZeroEmissionCommitment(ESMValToolDiagnostic):
             ),
             group_by=("source_id", "member_id", "grid_label"),
             constraints=(
-                RequireFacets("experiment_id", experiments),
                 RequireContiguousTimerange(group_by=("instance_id",)),
                 RequireOverlappingTimerange(group_by=("instance_id",)),
+                RequireFacets("experiment_id", experiments),
                 AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
             ),
         ),


### PR DESCRIPTION
## Description

Replace all constraints that had a boolean decision to keep or discard the entire group with a more fine-grained decision that filters out just those subgroups that do not match the constraint.

Closes #415 

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
