### PR TITLE
Avoid selecting the areacella variable when filling the recipe for cloud scatterplots

### DIFF
--- a/changelog/427.fix.md
+++ b/changelog/427.fix.md
@@ -1,0 +1,1 @@
+Avoid selecting the areacella variable when filling the recipe for cloud scatterplots.

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
@@ -56,6 +56,7 @@ def update_recipe(
     diagnostic = diagnostics.pop(diagnostic_name)
     diagnostics.clear()
     diagnostics[diagnostic_name] = diagnostic
+    recipe_variables = {k: v for k, v in recipe_variables.items() if k != "areacella"}
     datasets = next(iter(recipe_variables.values()))["additional_datasets"]
     for dataset in datasets:
         dataset["timerange"] = "1996/2014"


### PR DESCRIPTION
## Description

Fixes #426


## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
