### PR TITLE
feat(db): add read-only mode and migration_status helper

### DIFF
--- a/changelog/624.feature.md
+++ b/changelog/624.feature.md
@@ -1,0 +1,7 @@
+Added first-class read-only support and a migration-status helper to the
+`Database` API. `Database.from_config(..., read_only=True)` rewrites
+file-based SQLite URLs to read-only URI form and skips migrations, and
+`Database.migration_status(config)` reports the current/head revisions and
+state without requiring consumers to re-derive the Alembic plumbing. The
+`ref db status`, `ref db migrate`, and `ref db history` commands now use
+the new helper.

--- a/changelog/624.feature.md
+++ b/changelog/624.feature.md
@@ -1,7 +1,4 @@
-Added first-class read-only support and a migration-status helper to the
-`Database` API. `Database.from_config(..., read_only=True)` rewrites
-file-based SQLite URLs to read-only URI form and skips migrations, and
-`Database.migration_status(config)` reports the current/head revisions and
-state without requiring consumers to re-derive the Alembic plumbing. The
-`ref db status`, `ref db migrate`, and `ref db history` commands now use
-the new helper.
+Added first-class read-only support and a migration-status helper to the `Database` API.
+
+`Database.from_config(..., read_only=True)` rewrites file-based SQLite URLs to read-only URI form and skips migrations,
+and `Database.migration_status(config)` reports the current/head revisions and state.

--- a/docs/how-to-guides/using-pre-computed-results.py
+++ b/docs/how-to-guides/using-pre-computed-results.py
@@ -28,9 +28,14 @@
 #
 # We start by generating and installing a Python package for interacting with the API
 # from the OpenAPI-compatible [schema](https://api.climate-ref.org/api/v1/openapi.json).
+#
+# We pin the generated package name via an `openapi-python-client` config override so
+# that the Python import names below stay stable even if the API's `info.title` is
+# renamed upstream.
 
 # %%
-# !uvx --quiet --from openapi-python-client openapi-python-client generate --url https://api.climate-ref.org/api/v1/openapi.json --meta setup --output-path climate_ref_client --overwrite
+# !printf 'package_name_override: climate_ref_client\nproject_name_override: climate-ref-client\n' > /tmp/openapi-client-config.yaml
+# !uvx --quiet --from openapi-python-client openapi-python-client generate --url https://api.climate-ref.org/api/v1/openapi.json --config /tmp/openapi-client-config.yaml --meta setup --output-path climate_ref_client --overwrite
 
 # %%
 # !pip install --quiet ./climate_ref_client
@@ -51,13 +56,13 @@ import pandas as pd
 import requests
 import seaborn as sns
 import xarray as xr
-from climate_rapid_evaluation_framework_client import Client
-from climate_rapid_evaluation_framework_client.api.diagnostics import (
+from climate_ref_client import Client
+from climate_ref_client.api.diagnostics import (
     diagnostics_list,
     diagnostics_list_metric_values,
 )
-from climate_rapid_evaluation_framework_client.api.executions import executions_get
-from climate_rapid_evaluation_framework_client.models.metric_value_type import (
+from climate_ref_client.api.executions import executions_get
+from climate_ref_client.models.metric_value_type import (
     MetricValueType,
 )
 from IPython.display import Markdown

--- a/docs/how-to-guides/using-pre-computed-results.py
+++ b/docs/how-to-guides/using-pre-computed-results.py
@@ -5,9 +5,9 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.18.1
+#       jupytext_version: 1.19.1
 #   kernelspec:
-#     display_name: Python 3 (ipykernel)
+#     display_name: climate-ref-root (3.11.14)
 #     language: python
 #     name: python3
 # ---
@@ -38,7 +38,7 @@
 # !uvx --quiet --from openapi-python-client openapi-python-client generate --url https://api.climate-ref.org/api/v1/openapi.json --config /tmp/openapi-client-config.yaml --meta setup --output-path climate_ref_client --overwrite
 
 # %%
-# !pip install --quiet ./climate_ref_client
+# %pip install --quiet ./climate_ref_client
 
 # %% [markdown]
 # ## Set up the notebook
@@ -94,7 +94,7 @@ diagnostics[0]
 # %%
 txt = ""
 for diagnostic in sorted(diagnostics, key=lambda diagnostic: diagnostic.name):
-    title = f"### {diagnostic.name}"
+    title = f"### {diagnostic.name} - {diagnostic.slug}"
     description = diagnostic.description.strip()
     if not description.endswith("."):
         description += "."
@@ -102,8 +102,6 @@ for diagnostic in sorted(diagnostics, key=lambda diagnostic: diagnostic.name):
         description += f" {diagnostic.aft_link.short_description.strip()}"
         if not description.endswith("."):
             description += "."
-        if (aft_description := diagnostic.aft_link.description.strip()) != "nan":
-            description += f" {aft_description}"
         if not description.endswith("."):
             description += "."
     txt += f"{title}\n{description}\n\n"
@@ -182,12 +180,12 @@ _ = sns.heatmap(
 
 # %%
 # Select the "Sea Ice Area Basic Metrics" diagnostic as an example
-diagnostic_name = "Sea Ice Area Basic Metrics"
-diagnostic = next(d for d in diagnostics if d.name == diagnostic_name)
+diagnostic_slug = "sea-ice-area-basic"
+diagnostic = next(d for d in diagnostics if d.slug == diagnostic_slug)
 # Inspect an example series value:
 diagnostics_list_metric_values.sync(
     diagnostic.provider.slug,
-    diagnostic.slug,
+    diagnostic_slug=diagnostic_slug,
     value_type=MetricValueType.SERIES,
     client=client,
 ).data[0]
@@ -288,3 +286,5 @@ plot = ds.tas.plot.contourf(
     },
 )
 _ = plot.axes.coastlines()
+
+# %%

--- a/packages/climate-ref-core/tests/unit/test_packaging.py
+++ b/packages/climate-ref-core/tests/unit/test_packaging.py
@@ -1,0 +1,29 @@
+"""
+Tests that guard the shape of the installed ``climate_ref_core`` package.
+"""
+
+import importlib.resources
+
+import pytest
+import yaml
+
+
+def test_pycmec_package_data_is_importable():
+    """``climate_ref_core.pycmec`` must be importable as a resource package."""
+    files = importlib.resources.files("climate_ref_core.pycmec")
+    assert files.is_dir()
+
+
+@pytest.mark.parametrize("filename", ["cv_cmip7_aft.yaml"])
+def test_bundled_data_files_resolve(filename):
+    """Bundled package-data files must resolve and be readable from the wheel."""
+    resource = importlib.resources.files("climate_ref_core.pycmec") / filename
+
+    assert resource.is_file(), f"{filename} is missing from the installed climate_ref_core package"
+
+    contents = resource.read_text(encoding="utf-8")
+    assert contents, f"{filename} resolved but is empty"
+
+    # The CV YAML must parse — a truncated or corrupt file would break startup.
+    parsed = yaml.safe_load(contents)
+    assert isinstance(parsed, dict)

--- a/packages/climate-ref/src/climate_ref/cli/db.py
+++ b/packages/climate-ref/src/climate_ref/cli/db.py
@@ -10,7 +10,12 @@ from alembic.script import ScriptDirectory
 from rich.table import Table
 
 from climate_ref.config import Config
-from climate_ref.database import Database, _create_backup, _get_database_revision, _get_sqlite_path
+from climate_ref.database import (
+    Database,
+    MigrationState,
+    _create_backup,
+    _get_sqlite_path,
+)
 
 app = typer.Typer(help=__doc__)
 
@@ -33,13 +38,12 @@ def migrate(ctx: typer.Context) -> None:
     config = ctx.obj.config
     console = ctx.obj.console
 
-    script = _get_script_directory(db, config)
-    head_rev = script.get_current_head()
+    status_info = db.migration_status(config)
+    current_rev = status_info["current"]
+    head_rev = status_info["head"]
+    state = status_info["state"]
 
-    with db._engine.connect() as connection:
-        current_rev = _get_database_revision(connection)
-
-    if current_rev == head_rev:
+    if state is MigrationState.UP_TO_DATE:
         console.print(f"Database is already up to date at revision [bold]{current_rev}[/bold].")
         return
 
@@ -63,20 +67,24 @@ def status(ctx: typer.Context) -> None:
     config = ctx.obj.config
     console = ctx.obj.console
 
-    script = _get_script_directory(db, config)
-    head_rev = script.get_current_head()
-
-    with db._engine.connect() as connection:
-        current_rev = _get_database_revision(connection)
+    status_info = db.migration_status(config)
+    current_rev = status_info["current"]
+    head_rev = status_info["head"]
+    state = status_info["state"]
 
     console.print(f"Database URL:     [bold]{db.url}[/bold]")
     console.print(f"Current revision: [bold]{current_rev or '(empty)'}[/bold]")
     console.print(f"Head revision:    [bold]{head_rev}[/bold]")
 
-    if current_rev == head_rev:
+    if state is MigrationState.UP_TO_DATE:
         console.print("[green]Database is up to date.[/green]")
-    elif current_rev is None:
+    elif state is MigrationState.UNMANAGED:
         console.print("[yellow]Database has no revision stamp (new or unmanaged).[/yellow]")
+    elif state is MigrationState.REMOVED:
+        console.print(
+            f"[red]Database revision {current_rev!r} has been removed. "
+            "Please delete your database and start again.[/red]"
+        )
     else:
         console.print(
             "[yellow]Database is behind. Run 'ref db migrate' to apply pending migrations.[/yellow]"
@@ -116,9 +124,7 @@ def history(
     console = ctx.obj.console
 
     script = _get_script_directory(db, config)
-
-    with db._engine.connect() as connection:
-        current_rev = _get_database_revision(connection)
+    current_rev = db.migration_status(config)["current"]
 
     revisions = list(script.walk_revisions())
     if last is not None:

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -22,6 +22,7 @@ import pandas as pd
 import sqlalchemy
 from alembic.config import Config as AlembicConfig
 from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from loguru import logger
 from sqlalchemy.orm import Session
 
@@ -57,7 +58,8 @@ def _get_sqlite_path(database_url: str) -> Path | None:
     """
     Extract the file path from a SQLite database URL.
 
-    Returns ``None`` for in-memory databases or non-SQLite URLs.
+    Returns ``None`` for in-memory databases, URI-form URLs (``sqlite:///file:...``),
+    or non-SQLite URLs.
     """
     split_url = urlparse.urlsplit(database_url)
     if split_url.scheme != "sqlite":
@@ -65,7 +67,35 @@ def _get_sqlite_path(database_url: str) -> Path | None:
     path = urlparse.unquote(split_url.path[1:])
     if not path or path == ":memory:":
         return None
+    if path.startswith("file:"):
+        # URI-form SQLite URL — the path is opaque (may contain query params
+        # of its own for mode=ro etc.) and we shouldn't try to interpret it.
+        return None
     return Path(path)
+
+
+def _make_readonly_sqlite_url(database_url: str) -> tuple[str, dict[str, Any]]:
+    """
+    Rewrite a file-based SQLite URL to read-only URI form.
+
+    Returns the rewritten URL and connect_args to pass to SQLAlchemy.
+    For non-SQLite URLs, or URLs that can't be rewritten, the URL is returned unchanged
+    with empty connect_args.
+    """
+    split_url = urlparse.urlsplit(database_url)
+    if split_url.scheme != "sqlite":
+        logger.warning("Read-only mode is only supported for SQLite databases; ignoring read-only flag")
+        return database_url, {}
+
+    path = urlparse.unquote(split_url.path[1:])
+    if not path or path == ":memory:":
+        return database_url, {}
+
+    if path.startswith("file:"):
+        # Already URI form — caller is responsible for any ro/immutable flags.
+        return database_url, {"uri": True}
+
+    return f"sqlite:///file:{path}?mode=ro&immutable=1&uri=true", {"uri": True}
 
 
 def _get_database_revision(connection: sqlalchemy.engine.Connection) -> str | None:
@@ -191,6 +221,17 @@ class ModelState(enum.Enum):
     DELETED = "deleted"
 
 
+class MigrationState(enum.Enum):
+    """
+    State of the database schema relative to the expected Alembic head.
+    """
+
+    UP_TO_DATE = "up_to_date"
+    BEHIND = "behind"
+    UNMANAGED = "unmanaged"
+    REMOVED = "removed"
+
+
 class Database:
     """
     Manage the database connection and migrations
@@ -198,10 +239,13 @@ class Database:
     The database migrations are optionally run after the connection to the database is established.
     """
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, *, connect_args: dict[str, Any] | None = None) -> None:
         logger.info(f"Connecting to database at {url}")
         self.url = url
-        self._engine = sqlalchemy.create_engine(self.url)
+        engine_kwargs: dict[str, Any] = {}
+        if connect_args:
+            engine_kwargs["connect_args"] = connect_args
+        self._engine = sqlalchemy.create_engine(self.url, **engine_kwargs)
         # TODO: Set autobegin=False
         self.session = Session(self._engine)
 
@@ -248,6 +292,46 @@ class Database:
 
         return alembic_config
 
+    def migration_status(self, config: "Config") -> dict[str, Any]:
+        """
+        Report the current migration state of the database.
+
+        Returns a dict with ``current`` (the current revision or ``None``),
+        ``head`` (the latest available revision), and ``state`` (a
+        :class:`MigrationState`).
+
+        This is the canonical way for consumers of the library to check whether
+        the database schema matches what the installed ``climate_ref`` expects.
+        Prefer it over re-deriving Alembic plumbing in downstream code.
+
+        Parameters
+        ----------
+        config
+            REF Configuration, used to build the Alembic config.
+
+        Returns
+        -------
+        :
+            A dict with keys ``current``, ``head``, and ``state``.
+        """
+        alembic_cfg = self.alembic_config(config)
+        script = ScriptDirectory.from_config(alembic_cfg)
+        head_rev = script.get_current_head()
+
+        with self._engine.connect() as connection:
+            current_rev = _get_database_revision(connection)
+
+        if current_rev in _REMOVED_REVISIONS:
+            state = MigrationState.REMOVED
+        elif current_rev is None:
+            state = MigrationState.UNMANAGED
+        elif current_rev == head_rev:
+            state = MigrationState.UP_TO_DATE
+        else:
+            state = MigrationState.BEHIND
+
+        return {"current": current_rev, "head": head_rev, "state": state}
+
     def migrate(self, config: "Config", skip_backup: bool = False) -> None:
         """
         Migrate the database to the latest revision
@@ -282,7 +366,13 @@ class Database:
         alembic.command.upgrade(self.alembic_config(config), "heads")
 
     @staticmethod
-    def from_config(config: "Config", run_migrations: bool = True, skip_backup: bool = False) -> "Database":
+    def from_config(
+        config: "Config",
+        run_migrations: bool = True,
+        skip_backup: bool = False,
+        *,
+        read_only: bool = False,
+    ) -> "Database":
         """
         Create a Database instance from a Config instance
 
@@ -294,10 +384,18 @@ class Database:
         config
             The Config instance that includes information about where the database is located
         run_migrations
-            If True, run any outstanding database migrations
+            If True, run any outstanding database migrations.
+            Forced to False when ``read_only=True``.
         skip_backup
             If True, skip creating a backup before running migrations.
             Useful for read-only commands that don't modify the database.
+        read_only
+            If True, open the database in read-only mode.
+
+            For SQLite databases this rewrites the URL to URI form with ``mode=ro&immutable=1``
+            and passes ``uri=True`` to the driver.
+            Migrations and backups are skipped.
+            For other backends this is a no-op.
 
         Returns
         -------
@@ -305,11 +403,16 @@ class Database:
             A new Database instance
         """
         database_url: str = config.db.database_url
+        connect_args: dict[str, Any] = {}
+
+        if read_only:
+            database_url, connect_args = _make_readonly_sqlite_url(database_url)
+            run_migrations = False
 
         database_url = validate_database_url(database_url)
 
         cv = CV.load_from_file(config.paths.dimensions_cv)
-        db = Database(database_url)
+        db = Database(database_url, connect_args=connect_args or None)
 
         if run_migrations:
             # Run any outstanding migrations

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -87,15 +87,18 @@ def _make_readonly_sqlite_url(database_url: str) -> tuple[str, dict[str, Any]]:
         logger.warning("Read-only mode is only supported for SQLite databases; ignoring read-only flag")
         return database_url, {}
 
-    path = urlparse.unquote(split_url.path[1:])
-    if not path or path == ":memory:":
+    # Preserve the original URL encoding — the rewritten URL also needs to be
+    # parseable as a URI, so percent-encoded characters (e.g. spaces as ``%20``)
+    # must not be decoded back into raw characters here.
+    encoded_path = split_url.path[1:]
+    if not encoded_path or encoded_path == ":memory:":
         return database_url, {}
 
-    if path.startswith("file:"):
+    if encoded_path.startswith("file:"):
         # Already URI form — caller is responsible for any ro/immutable flags.
         return database_url, {"uri": True}
 
-    return f"sqlite:///file:{path}?mode=ro&immutable=1&uri=true", {"uri": True}
+    return f"sqlite:///file:{encoded_path}?mode=ro&immutable=1&uri=true", {"uri": True}
 
 
 def _get_database_revision(connection: sqlalchemy.engine.Connection) -> str | None:
@@ -170,11 +173,18 @@ def validate_database_url(database_url: str) -> str:
     split_url = urlparse.urlsplit(database_url)
 
     if split_url.scheme == "sqlite":
-        sqlite_path = _get_sqlite_path(database_url)
-        if sqlite_path is None:
-            logger.warning("Using an in-memory database")
+        # URI-form SQLite URLs (``sqlite:///file:...``) are passed through
+        # verbatim — the caller has supplied an explicit URI, possibly for a
+        # read-only on-disk file, and we should neither treat it as in-memory
+        # nor try to mkdir its (opaque) parent directory.
+        if split_url.path[1:].startswith("file:"):
+            logger.debug("Using URI-form SQLite URL; skipping parent directory creation")
         else:
-            sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+            sqlite_path = _get_sqlite_path(database_url)
+            if sqlite_path is None:
+                logger.warning("Using an in-memory database")
+            else:
+                sqlite_path.parent.mkdir(parents=True, exist_ok=True)
     elif split_url.scheme == "postgresql":
         # We don't need to do anything special for PostgreSQL
         logger.warning("PostgreSQL support is currently experimental and untested")
@@ -390,12 +400,11 @@ class Database:
             If True, skip creating a backup before running migrations.
             Useful for read-only commands that don't modify the database.
         read_only
-            If True, open the database in read-only mode.
+            If True, open the database in read-only mode and skip migrations.
 
-            For SQLite databases this rewrites the URL to URI form with ``mode=ro&immutable=1``
-            and passes ``uri=True`` to the driver.
-            Migrations and backups are skipped.
-            For other backends this is a no-op.
+            SQLite URLs are rewritten to URI form with ``mode=ro&immutable=1``.
+            For other backends, callers must configure the connecting role as
+            read-only themselves.
 
         Returns
         -------

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -10,8 +10,10 @@ from sqlalchemy import inspect
 
 from climate_ref.database import (
     Database,
+    MigrationState,
     _create_backup,
     _get_sqlite_path,
+    _make_readonly_sqlite_url,
     _values_differ,
     validate_database_url,
 )
@@ -402,3 +404,115 @@ class TestValuesDiffer:
         assert _values_differ(True, pd.NA)
         assert _values_differ(False, pd.NA)
         assert _values_differ(pd.NA, True)
+
+
+class TestReadOnlyDatabase:
+    """Tests for the read-only mode of ``Database.from_config``."""
+
+    def test_make_readonly_sqlite_url_rewrites_file_url(self):
+        url, connect_args = _make_readonly_sqlite_url("sqlite:////tmp/foo.db")
+        assert url == "sqlite:///file:/tmp/foo.db?mode=ro&immutable=1&uri=true"
+        assert connect_args == {"uri": True}
+
+    def test_make_readonly_sqlite_url_preserves_uri_form(self):
+        original = "sqlite:///file:/tmp/foo.db?mode=ro&uri=true"
+        url, connect_args = _make_readonly_sqlite_url(original)
+        assert url == original
+        assert connect_args == {"uri": True}
+
+    def test_make_readonly_sqlite_url_passthrough_for_memory(self):
+        url, connect_args = _make_readonly_sqlite_url("sqlite:///:memory:")
+        assert url == "sqlite:///:memory:"
+        assert connect_args == {}
+
+    def test_make_readonly_sqlite_url_passthrough_for_non_sqlite(self):
+        url, connect_args = _make_readonly_sqlite_url("postgresql://localhost/db")
+        assert url == "postgresql://localhost/db"
+        assert connect_args == {}
+
+    def test_get_sqlite_path_returns_none_for_uri_form(self):
+        """URI-form URLs must not be interpreted as plain file paths."""
+        assert _get_sqlite_path("sqlite:///file:/tmp/foo.db?mode=ro&uri=true") is None
+
+    def test_validate_accepts_uri_form_without_mkdir(self, tmp_path):
+        """URI-form URLs are accepted verbatim and do not trigger parent mkdir."""
+        missing = tmp_path / "does-not-exist" / "foo.db"
+        url = f"sqlite:///file:{missing}?mode=ro&immutable=1&uri=true"
+
+        # Should not create the parent directory
+        assert validate_database_url(url) == url
+        assert not missing.parent.exists()
+
+    def test_from_config_read_only_on_existing_db(self, tmp_path, config):
+        """A read-only Database can read but not write to a migrated SQLite file."""
+        db_path = tmp_path / "climate_ref.db"
+        config.db.database_url = f"sqlite:///{db_path}"
+
+        # First, create and migrate the database normally
+        Database.from_config(config, run_migrations=True).close()
+        assert db_path.exists()
+
+        ro_db = Database.from_config(config, read_only=True)
+        try:
+            # Reads work
+            with ro_db._engine.connect() as connection:
+                connection.execute(sqlalchemy.text("SELECT 1"))
+
+            # Writes must fail
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                with ro_db._engine.connect() as connection:
+                    connection.execute(sqlalchemy.text("CREATE TABLE _rw_probe (id INTEGER)"))
+                    connection.commit()
+        finally:
+            ro_db.close()
+
+    def test_from_config_read_only_skips_migrations(self, tmp_path, config, mocker):
+        db_path = tmp_path / "climate_ref.db"
+        config.db.database_url = f"sqlite:///{db_path}"
+        # Seed the file so the read-only open can connect
+        Database.from_config(config, run_migrations=True).close()
+
+        migrate = mocker.patch.object(Database, "migrate")
+        Database.from_config(config, read_only=True).close()
+        migrate.assert_not_called()
+
+
+class TestMigrationStatus:
+    """Tests for ``Database.migration_status``."""
+
+    def test_up_to_date_after_migrate(self, db, config):
+        db.migrate(config)
+        status = db.migration_status(config)
+        assert status["state"] is MigrationState.UP_TO_DATE
+        assert status["current"] == status["head"]
+        assert status["head"] is not None
+
+    def test_unmanaged_before_migrate(self, config, tmp_path):
+        config.db.database_url = f"sqlite:///{tmp_path}/fresh.db"
+        db = Database(config.db.database_url)
+        try:
+            status = db.migration_status(config)
+            assert status["state"] is MigrationState.UNMANAGED
+            assert status["current"] is None
+            assert status["head"] is not None
+        finally:
+            db.close()
+
+    def test_removed_revision(self, db, config, mocker):
+        mocker.patch(
+            "climate_ref.database._get_database_revision",
+            return_value="ea2aa1134cb3",
+        )
+        status = db.migration_status(config)
+        assert status["state"] is MigrationState.REMOVED
+        assert status["current"] == "ea2aa1134cb3"
+
+    def test_behind(self, db, config, mocker):
+        mocker.patch(
+            "climate_ref.database._get_database_revision",
+            return_value="not_the_head_rev",
+        )
+        status = db.migration_status(config)
+        assert status["state"] is MigrationState.BEHIND
+        assert status["current"] == "not_the_head_rev"
+        assert status["head"] != "not_the_head_rev"

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -414,6 +414,13 @@ class TestReadOnlyDatabase:
         assert url == "sqlite:///file:/tmp/foo.db?mode=ro&immutable=1&uri=true"
         assert connect_args == {"uri": True}
 
+    def test_make_readonly_sqlite_url_preserves_percent_encoding(self):
+        """Percent-encoded characters must survive the rewrite unchanged."""
+        original = "sqlite:///path%20with%20spaces/db.sqlite"
+        url, connect_args = _make_readonly_sqlite_url(original)
+        assert url == "sqlite:///file:path%20with%20spaces/db.sqlite?mode=ro&immutable=1&uri=true"
+        assert connect_args == {"uri": True}
+
     def test_make_readonly_sqlite_url_preserves_uri_form(self):
         original = "sqlite:///file:/tmp/foo.db?mode=ro&uri=true"
         url, connect_args = _make_readonly_sqlite_url(original)
@@ -442,6 +449,16 @@ class TestReadOnlyDatabase:
         # Should not create the parent directory
         assert validate_database_url(url) == url
         assert not missing.parent.exists()
+
+    def test_validate_uri_form_does_not_log_as_in_memory(self, tmp_path, mocker):
+        """URI-form on-disk URLs must not emit the 'Using an in-memory database' warning."""
+        warning = mocker.patch("climate_ref.database.logger.warning")
+        url = f"sqlite:///file:{tmp_path}/foo.db?mode=ro&uri=true"
+
+        validate_database_url(url)
+
+        for call in warning.call_args_list:
+            assert "in-memory" not in call.args[0]
 
     def test_from_config_read_only_on_existing_db(self, tmp_path, config):
         """A read-only Database can read but not write to a migrated SQLite file."""


### PR DESCRIPTION
## Description

Enables consumers of `climate_ref` (e.g. `ref-app`) to open the database read-only and introspect migration state without re-deriving Alembic plumbing. The ref-app has custom  `_build_readonly_database` and `_check_migration_status` shims that can be removed with this.

### Changes

- **Read-only `Database`**
  - `Database.__init__` now accepts a `connect_args` kwarg, passed through to `create_engine`.
  - `Database.from_config(..., read_only=True)` rewrites file-based SQLite URLs to URI form (`sqlite:///file:…?mode=ro&immutable=1&uri=true`), wires `{\"uri\": True}` into the driver, and skips migrations/backups.
  - `validate_database_url` now accepts URI-form SQLite URLs verbatim and no longer `mkdir`s their parent — operators can set `REF_DATABASE_URL` to a read-only URI directly.

- **`Database.migration_status(config)`**
  - New library-level helper returning `{current, head, state}` with a `MigrationState` enum (`UP_TO_DATE`, `BEHIND`, `UNMANAGED`, `REMOVED`).
  - `ref db status`, `ref db migrate`, and `ref db history` all consume it instead of re-implementing the check.

- **Packaging regression test**
  - New `packages/climate-ref-core/tests/unit/test_packaging.py` asserts `climate_ref_core.pycmec` is a resource package and that `cv_cmip7_aft.yaml` resolves, is non-empty, and parses. Guards against the wheel ever shipping without bundled CV data again.

## Checklist

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to \`changelog/\`