### PR TITLE
test(dataset_registry): isolate cache-dir tests from REF_DATASET_CACHE_DIR

### DIFF
--- a/changelog/638.trivial.md
+++ b/changelog/638.trivial.md
@@ -1,0 +1,1 @@
+Stabilised the dataset-registry unit tests against environments that preset `REF_DATASET_CACHE_DIR`, so the cache-path assertions hold on the self-hosted CI runner.

--- a/packages/climate-ref-core/tests/unit/test_dataset_registry/test_dataset_registry.py
+++ b/packages/climate-ref-core/tests/unit/test_dataset_registry/test_dataset_registry.py
@@ -87,7 +87,8 @@ class TestDatasetRegistry:
     @pytest.mark.parametrize(
         "cache_name, expected", [(None, "test_registry"), ("custom_cache", "custom_cache")]
     )
-    def test_with_cache_name(self, mocker, fake_registry_file, cache_name, expected):
+    def test_with_cache_name(self, mocker, monkeypatch, fake_registry_file, cache_name, expected):
+        monkeypatch.delenv("REF_DATASET_CACHE_DIR", raising=False)
         registry = DatasetRegistryManager()
         name = "test_registry"
         base_url = "http://example.com"
@@ -117,7 +118,9 @@ class TestDatasetRegistry:
         ],
     )
     def test_with_environment_variable(self, monkeypatch, mocker, fake_registry_file, env, expected_path):
-        if env is not None:
+        if env is None:
+            monkeypatch.delenv("REF_DATASET_CACHE_DIR", raising=False)
+        else:
             monkeypatch.setenv("REF_DATASET_CACHE_DIR", env)
 
         registry = DatasetRegistryManager()


### PR DESCRIPTION
## Description

Three `test_dataset_registry` cases parametrized with `env=None` / `cache_name=None`
expected `_resolve_cache_dir` to fall back to the mocked `pooch.os_cache(...)`
return value. They didn't isolate `REF_DATASET_CACHE_DIR`, so on the self-hosted
CI runner — which presets that variable to `/data/cache/datasets` — the env-var
branch of `_resolve_cache_dir` activated and `pooch.create` was called with a
different `path=` than asserted. Result: `AssertionError: expected call not found.`
on `tests-slow` for two consecutive scheduled main-branch runs.

`monkeypatch.delenv("REF_DATASET_CACHE_DIR", raising=False)` in the None branches
restores the intended scenario without touching production code.

This PR fixes only the unit-test failures. Other CI failures from the same runs
(test-cases cascade, ILAMB cSoil hash mismatch + missing `--registry ilamb`
fetch in CI workflow, ESMValTool `cloud-scatterplots-cli-ta` conda env
regression, 3.13 timeout) are documented separately and out of scope here.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to \`changelog/\`