### PR TITLE
fix(test-cases): do not abort fetch loop when one test case fails

### DIFF
--- a/changelog/639.fix.md
+++ b/changelog/639.fix.md
@@ -1,0 +1,1 @@
+Fixed `ref test-cases fetch` aborting the entire run when a single test case could not be parsed (for example because of a `PermissionError` on a cached CMIP6 file); the failing test case is now logged as a warning and the loop continues.

--- a/packages/climate-ref/src/climate_ref/cli/test_cases.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases.py
@@ -72,6 +72,8 @@ def _build_catalog(dataset_adapter: DatasetAdapter, file_paths: list[Path]) -> p
         except Exception as e:
             logger.warning(f"Failed to parse {parent_dir}: {e}")
 
+    if not catalog_dfs:
+        return pd.DataFrame()
     return pd.concat(catalog_dfs, ignore_index=True)
 
 
@@ -308,7 +310,7 @@ def fetch_test_data(  # noqa: PLR0912, PLR0915
                         _, catalog_written = _fetch_and_build_catalog(diag, tc, force=force)
                         if not catalog_written:
                             logger.info(f"  Catalog unchanged for {tc.name}")
-                    except DatasetResolutionError as e:
+                    except (DatasetResolutionError, ValueError) as e:
                         logger.warning(f"  Could not build catalog for {tc.name}: {e}")
 
 

--- a/packages/climate-ref/tests/unit/cli/test_test_cases.py
+++ b/packages/climate-ref/tests/unit/cli/test_test_cases.py
@@ -127,15 +127,14 @@ class TestBuildCatalog:
         assert "No matching files found" in caplog.text
 
     def test_adapter_exception_logged(self, caplog):
-        """Test exception from adapter is logged as warning and concat fails."""
+        """Failures in every parent_dir are logged and yield an empty DataFrame."""
         mock_adapter = MagicMock()
         mock_adapter.find_local_datasets.side_effect = Exception("Parse error")
 
         file_paths = [Path("/path/to/file.nc")]
-        # When all directories fail, pd.concat([]) raises ValueError
-        with pytest.raises(ValueError, match="No objects to concatenate"):
-            _build_catalog(mock_adapter, file_paths)
+        result = _build_catalog(mock_adapter, file_paths)
 
+        assert result.empty
         assert "Failed to parse" in caplog.text
 
 
@@ -310,6 +309,48 @@ class TestFetchTestDataCommand:
 
         result = invoke_cli(["test-cases", "fetch", "--test-case", "specific-case", "--dry-run"])
         assert result.exit_code == 0
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            DatasetResolutionError("No datasets found for tc1"),
+            ValueError("No valid executions found for diagnostic test-diag"),
+        ],
+    )
+    def test_fetch_continues_on_test_case_failure(self, invoke_cli, mocker, exception):
+        """A per-test-case failure is logged and does not abort the loop.
+
+        Regression test for the cascade where a single bad parent_dir caused
+        ``pd.concat([])`` (or an empty solver result) to crash the entire
+        ``ref test-cases fetch`` command instead of moving on to the next
+        test case.
+        """
+        tc_bad = MagicMock(name="bad", description="bad", requests=[MagicMock()])
+        tc_bad.name = "bad"
+        tc_good = MagicMock(name="good", description="good", requests=[MagicMock()])
+        tc_good.name = "good"
+        mock_spec = MagicMock(test_cases=[tc_bad, tc_good])
+        mock_diag = MagicMock(slug="test-diag", test_data_spec=mock_spec)
+        mock_diag.provider = MagicMock(slug="example")
+
+        mock_provider = MagicMock(slug="example")
+        mock_provider.diagnostics.return_value = [mock_diag]
+        mock_registry = MagicMock(providers=[mock_provider])
+
+        mocker.patch(
+            "climate_ref.provider_registry.ProviderRegistry.build_from_config",
+            return_value=mock_registry,
+        )
+
+        fetch_mock = mocker.patch(
+            "climate_ref.cli.test_cases._fetch_and_build_catalog",
+            side_effect=[exception, (MagicMock(), True)],
+        )
+
+        result = invoke_cli(["test-cases", "fetch"])
+
+        assert result.exit_code == 0
+        assert fetch_mock.call_count == 2
 
 
 class TestListCasesCommand:


### PR DESCRIPTION
## Description

In CI run [25007874179](https://github.com/Climate-REF/climate-ref/actions/runs/25007874179) the `test-cases` job failed with `ValueError: No objects to concatenate`, then 100 downstream pytest cases were SKIPPED with `No catalog file …` and a single test failed with `DatasetResolutionError: … missing the required 'path' column`. The same cascade reproduced on the prior scheduled run.

### Root cause

A `PermissionError: [Errno 13]` reading
`/data/cmip6/CMIP6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/Amon/ts/gn/v20191115/ts_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_185001-201412.nc`
during `pmp/annual-cycle/cmip6-ts` fetch caused `cmip6_parsers.parse_cmip6_complete` to fail. `catalog_builder` returned 0 valid entries; `_build_catalog` caught the per-`parent_dir` error, then called `pd.concat([], ...)` which raises `ValueError: No objects to concatenate`. The fetch loop only caught `DatasetResolutionError`, so the `ValueError` killed the whole `ref test-cases fetch` command before any later catalog could be written.

### Fix

- `_build_catalog`: return an empty `DataFrame` when no `parent_dir` produced a frame.
- `fetch_test_data`: also catch `ValueError` per test case so a single bad case becomes a warning instead of aborting the loop. This also covers the `ValueError` raised by `_solve_test_case` when no executions resolve.

### Tests

- Updated `TestBuildCatalog::test_adapter_exception_logged` to assert the empty-DataFrame contract.
- New `TestFetchTestDataCommand::test_fetch_continues_on_test_case_failure` parametrized over `DatasetResolutionError` and `ValueError`, asserting the loop processes both test cases.
- All 51 cases in `tests/unit/cli/test_test_cases.py` pass.

## Checklist

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
