### PR TITLE
Update ESMValCore to v2.14.0 and ESMValTool to 2.15.0.dev15+gdead90ca8

### DIFF
--- a/changelog/652.improvement.md
+++ b/changelog/652.improvement.md
@@ -1,0 +1,1 @@
+Updated ESMValCore to v2.14.0 and ESMValTool to 2.15.0.dev15+gdead90ca8.

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
@@ -296,11 +296,11 @@ def get_child_and_parent_dataset(
     return [child_dataset, parent_dataset]
 
 
-_ESMVALTOOL_COMMIT = "f5214c9242725fe9a4c3628f304917c7434b361d"
-_ESMVALTOOL_VERSION = f"2.13.0.dev65+g{_ESMVALTOOL_COMMIT[:9]}"
+_ESMVALTOOL_COMMIT = "dead90ca848d3892ed90785b3940909d58d27780"
+_ESMVALTOOL_VERSION = f"2.14.0.dev65+g{_ESMVALTOOL_COMMIT[:9]}"
 _ESMVALTOOL_URL = f"git+https://github.com/ESMValGroup/ESMValTool.git@{_ESMVALTOOL_COMMIT}"
 
-_ESMVALCORE_COMMIT = "da81d5f67158f3d2603831b56ab6b4fb8a388d86"
+_ESMVALCORE_COMMIT = "2cff15ca8a7c4835465a40b2cbac75b179450d4f"
 _ESMVALCORE_URL = f"git+https://github.com/ESMValGroup/ESMValCore.git@{_ESMVALCORE_COMMIT}"
 
 _RECIPES_URL = (

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipes.txt
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipes.txt
@@ -1,7 +1,7 @@
 examples/recipe_python.yml                  ab3f06d269bb2c1368f4dc39da9bcb232fb2adb1fa556ba769e6c16294ffb4a3
-recipe_calculate_gwl_exceedance_stats.yml   5aa266abc9a8029649b689a2b369a47623b0935d609354332ff4148994642d6b
+recipe_calculate_gwl_exceedance_stats.yml   9f28304b85f7043fb76eb29ee84da46e084941c9db80eaa2993c151dbf022472
 recipe_ecs.yml                              0cc57034fcb64e32015b4ff949ece5df8cdb8c6f493618b50ceded119fb37918
-recipe_seaice_sensitivity.yml               f7247c076e161c582d422947c8155f3ca98549e6f2e4c3b1c76414786d7e50c5
+recipe_seaice_sensitivity.yml               07270818ebf04a58713dc989720cc9ace77f28d42b1ea189c3bdaf22f5d64577
 recipe_tcr.yml                              35f9ef035a4e71aff5cac5dd26c49da2162fc00291bf3b0bd16b661b7b2f606b
 recipe_tcre.yml                             48fc9e3baf541bbcef7491853ea3a774053771dca33352b41466425faeaa38af
 recipe_zec.yml                              b0af7f789b7610ab3f29a6617124aa40c40866ead958204fc199eaf82863de51

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/requirements/conda-lock.yml
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/requirements/conda-lock.yml
@@ -26,28 +26,17 @@ metadata:
   sources:
   - packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/requirements/environment.yml
 package:
-- name: _libgcc_mutex
-  version: '0.1'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  hash:
-    md5: d7c89558ba9fa0495403155b64376d81
-    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
-  category: main
-  optional: false
 - name: _openmp_mutex
   version: '4.5'
   manager: conda
   platform: linux-64
   dependencies:
-    _libgcc_mutex: '0.1'
+    __glibc: '>=2.17,<3.0.a0'
     libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   hash:
-    md5: 73aaf86a425cc6e73fcf236a5a46396d
-    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
   category: main
   optional: false
 - name: _openmp_mutex
@@ -228,7 +217,7 @@ package:
   category: main
   optional: false
 - name: aiohttp
-  version: 3.13.3
+  version: 3.13.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -243,18 +232,18 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     yarl: '>=1.17.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.3-py313hd6074c6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py313hd6074c6_0.conda
   hash:
-    md5: 684fb9c78db5024b939a1ed0a107f464
-    sha256: 3557801fd8af31d15ddf0e754a6e6e1a6cc3490eebb9fdae0a6730bd90e01a8b
+    md5: d6af03fc1fda940641f409014de8f1fe
+    sha256: 355cd795b2a75a23b90e9d3e640352cbb27a9b9dc9a6a78c3cd8b483a1aaa7d8
   category: main
   optional: false
 - name: aiohttp
-  version: 3.13.3
+  version: 3.13.5
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     aiohappyeyeballs: '>=2.5.0'
     aiosignal: '>=1.4.0'
     attrs: '>=17.3.0'
@@ -264,14 +253,14 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     yarl: '>=1.17.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.3-py313h537e735_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.13.5-py313h6f5309d_0.conda
   hash:
-    md5: 0f682d864876fd75783e384e923cb4fc
-    sha256: 231fa712cba9ed69e0094523d395057a6473963c7a992ed09422924addc9836b
+    md5: 91658c869e81e2c26e6e6d50cd9c2f92
+    sha256: f45f5f5db4f275f6fce0623374c35b498a68581a1f30d9182cd741ec63e920ee
   category: main
   optional: false
 - name: aiohttp
-  version: 3.13.3
+  version: 3.13.5
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -285,10 +274,10 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     yarl: '>=1.17.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.3-py313h53c0e3e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.13.5-py313h53c0e3e_0.conda
   hash:
-    md5: 3360ba585f70b33d4976766b84bb47e7
-    sha256: 28f88df22b68fce5158e7a26387d5c285c72ff0f067d195a44ee3f687b595c2d
+    md5: 94ad25fb7365048111b9da5981e5ef5e
+    sha256: f120d3cddd1bfbb9d535e3f1272a95f91a8cb8752c6f475ec0a3a98b771e22d3
   category: main
   optional: false
 - name: aiosignal
@@ -370,6 +359,51 @@ package:
   hash:
     md5: 2934f256a8acfe48f6ebb4fce6cde29c
     sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  category: main
+  optional: false
+- name: anyio
+  version: 4.13.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: ''
+    typing_extensions: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  hash:
+    md5: af2df4b9108808da3dc76710fe50eae2
+    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+  category: main
+  optional: false
+- name: anyio
+  version: 4.13.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.10'
+    typing_extensions: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  hash:
+    md5: af2df4b9108808da3dc76710fe50eae2
+    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
+  category: main
+  optional: false
+- name: anyio
+  version: 4.13.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.10'
+    typing_extensions: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
+  hash:
+    md5: af2df4b9108808da3dc76710fe50eae2
+    sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
   category: main
   optional: false
 - name: aom
@@ -411,73 +445,320 @@ package:
     sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
   category: main
   optional: false
-- name: arviz
-  version: 0.23.1
+- name: apsw
+  version: 3.53.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    h5netcdf: '>=1.0.2'
-    h5py: ''
-    matplotlib-base: '>=3.8'
-    numpy: '>=1.26.0'
-    packaging: ''
-    pandas: '>=2.1.0'
-    python: ''
-    scipy: '>=1.11.0'
-    setuptools: '>=60.0.0'
-    typing_extensions: '>=4.1.0'
-    xarray: '>=2023.7.0'
-    xarray-einstats: '>=0.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-0.23.1-pyhcf101f3_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libsqlite: '>=3.53.0,<4.0a0'
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/apsw-3.53.0.0-py313h07c4f96_0.conda
   hash:
-    md5: e05febe3c37910c9d51574c6da9acd07
-    sha256: 3daf9a6c0acc708cc73866b94f97d23d7bde9753d4096b8ce40552eecb485531
+    md5: 06adcc715f85e2a7d9e2bb79551f0d93
+    sha256: 7af2a2e9af143670b7ff23c1aae774622e7fea6fc3f8cf5ee02f6cae0bf53d7c
   category: main
   optional: false
-- name: arviz
-  version: 0.23.1
+- name: apsw
+  version: 3.53.0.0
   manager: conda
   platform: osx-64
   dependencies:
-    h5netcdf: '>=1.0.2'
-    h5py: ''
-    matplotlib-base: '>=3.8'
-    numpy: '>=1.26.0'
-    packaging: ''
-    pandas: '>=2.1.0'
-    python: '>=3.10'
-    scipy: '>=1.11.0'
-    setuptools: '>=60.0.0'
-    typing_extensions: '>=4.1.0'
-    xarray: '>=2023.7.0'
-    xarray-einstats: '>=0.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-0.23.1-pyhcf101f3_0.conda
+    __osx: '>=11.0'
+    libsqlite: '>=3.53.0,<4.0a0'
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/apsw-3.53.0.0-py313hf59fe81_0.conda
   hash:
-    md5: e05febe3c37910c9d51574c6da9acd07
-    sha256: 3daf9a6c0acc708cc73866b94f97d23d7bde9753d4096b8ce40552eecb485531
+    md5: b96e580f23d7880a791104959fa6de05
+    sha256: 864ae44289bc4c476866fac0190fa2afe4c0699b96a8398102edaff8682bdd98
   category: main
   optional: false
-- name: arviz
-  version: 0.23.1
+- name: apsw
+  version: 3.53.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    h5netcdf: '>=1.0.2'
-    h5py: ''
-    matplotlib-base: '>=3.8'
-    numpy: '>=1.26.0'
-    packaging: ''
-    pandas: '>=2.1.0'
-    python: '>=3.10'
-    scipy: '>=1.11.0'
-    setuptools: '>=60.0.0'
-    typing_extensions: '>=4.1.0'
-    xarray: '>=2023.7.0'
-    xarray-einstats: '>=0.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-0.23.1-pyhcf101f3_0.conda
+    __osx: '>=11.0'
+    libsqlite: '>=3.53.0,<4.0a0'
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/apsw-3.53.0.0-py313h0997733_0.conda
   hash:
-    md5: e05febe3c37910c9d51574c6da9acd07
-    sha256: 3daf9a6c0acc708cc73866b94f97d23d7bde9753d4096b8ce40552eecb485531
+    md5: b7278245b1c6a67c2857d23b9f981d54
+    sha256: c8dc70693f0844cedd0c2959749fb1094fd363a55ab2bc8adb12c878e439893d
+  category: main
+  optional: false
+- name: apswutils
+  version: 0.1.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    apsw: ''
+    fastcore: ''
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/apswutils-0.1.2-pyhcf101f3_0.conda
+  hash:
+    md5: 5ada5cc2f41032d430c3b898b4ff8b43
+    sha256: d593ccfe63522b78a2cc511acaa955cfd6d8b02dfc6e1eeb369de2f04e23da12
+  category: main
+  optional: false
+- name: apswutils
+  version: 0.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    apsw: ''
+    fastcore: ''
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/apswutils-0.1.2-pyhcf101f3_0.conda
+  hash:
+    md5: 5ada5cc2f41032d430c3b898b4ff8b43
+    sha256: d593ccfe63522b78a2cc511acaa955cfd6d8b02dfc6e1eeb369de2f04e23da12
+  category: main
+  optional: false
+- name: apswutils
+  version: 0.1.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    apsw: ''
+    fastcore: ''
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/apswutils-0.1.2-pyhcf101f3_0.conda
+  hash:
+    md5: 5ada5cc2f41032d430c3b898b4ff8b43
+    sha256: d593ccfe63522b78a2cc511acaa955cfd6d8b02dfc6e1eeb369de2f04e23da12
+  category: main
+  optional: false
+- name: arviz
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    arviz-base: '>=1.1.0,<1.2.0'
+    arviz-plots: '>=1.1.0,<1.2.0'
+    arviz-stats: '>=1.1.0,<1.2.0'
+    matplotlib-base: '>=3.9'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 1bdec040ccaa9e12ccbfebe45c358485
+    sha256: 97cfef648c974a3dd30817ada5052517b86055565142ac4a77d9a91944c3cbcb
+  category: main
+  optional: false
+- name: arviz
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    arviz-base: '>=1.1.0,<1.2.0'
+    arviz-plots: '>=1.1.0,<1.2.0'
+    arviz-stats: '>=1.1.0,<1.2.0'
+    matplotlib-base: '>=3.9'
+    python: '>=3.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 1bdec040ccaa9e12ccbfebe45c358485
+    sha256: 97cfef648c974a3dd30817ada5052517b86055565142ac4a77d9a91944c3cbcb
+  category: main
+  optional: false
+- name: arviz
+  version: 1.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    arviz-base: '>=1.1.0,<1.2.0'
+    arviz-plots: '>=1.1.0,<1.2.0'
+    arviz-stats: '>=1.1.0,<1.2.0'
+    matplotlib-base: '>=3.9'
+    python: '>=3.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 1bdec040ccaa9e12ccbfebe45c358485
+    sha256: 97cfef648c974a3dd30817ada5052517b86055565142ac4a77d9a91944c3cbcb
+  category: main
+  optional: false
+- name: arviz-base
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    lazy_loader: '>=0.4'
+    numpy: '>=2'
+    python: '>=3.12'
+    typing_extensions: '>=3.10'
+    xarray: '>=2024.11.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a94d579ff5f766bbf8b3cea3fed770e9
+    sha256: 8e3351000e341f9a8d93488d07448b40065e312a698f9d1c02659dc009281e6f
+  category: main
+  optional: false
+- name: arviz-base
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    lazy_loader: '>=0.4'
+    numpy: '>=2'
+    python: '>=3.12'
+    typing_extensions: '>=3.10'
+    xarray: '>=2024.11.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a94d579ff5f766bbf8b3cea3fed770e9
+    sha256: 8e3351000e341f9a8d93488d07448b40065e312a698f9d1c02659dc009281e6f
+  category: main
+  optional: false
+- name: arviz-base
+  version: 1.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    lazy_loader: '>=0.4'
+    numpy: '>=2'
+    python: '>=3.12'
+    typing_extensions: '>=3.10'
+    xarray: '>=2024.11.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a94d579ff5f766bbf8b3cea3fed770e9
+    sha256: 8e3351000e341f9a8d93488d07448b40065e312a698f9d1c02659dc009281e6f
+  category: main
+  optional: false
+- name: arviz-plots
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    arviz-base: '>=1.1,<1.2'
+    arviz-stats: '>=1.1,<1.2'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 61026a34eb9dce29cca3f1ddf223f3be
+    sha256: 4b2dcf51a01523e1b6eaa27b1ec9b3bb1c4163d1f27d2765f6eb885e74fddcb9
+  category: main
+  optional: false
+- name: arviz-plots
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    arviz-base: '>=1.1,<1.2'
+    arviz-stats: '>=1.1,<1.2'
+    python: '>=3.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 61026a34eb9dce29cca3f1ddf223f3be
+    sha256: 4b2dcf51a01523e1b6eaa27b1ec9b3bb1c4163d1f27d2765f6eb885e74fddcb9
+  category: main
+  optional: false
+- name: arviz-plots
+  version: 1.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    arviz-base: '>=1.1,<1.2'
+    arviz-stats: '>=1.1,<1.2'
+    python: '>=3.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 61026a34eb9dce29cca3f1ddf223f3be
+    sha256: 4b2dcf51a01523e1b6eaa27b1ec9b3bb1c4163d1f27d2765f6eb885e74fddcb9
+  category: main
+  optional: false
+- name: arviz-stats
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    arviz-base: '>=1.1.0,<1.2.0'
+    arviz-stats-core: ==1.1.0
+    python: ''
+    xarray: '>=2024.11.0'
+    xarray-einstats: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.1.0-pyhd721c7e_0.conda
+  hash:
+    md5: 0ad838e88323a0ab00e5c23d73e294c7
+    sha256: 73e9cff67f93ba698c18dd49a11fbd6075af9628e74c5a9e2abdf52e9c2e80cf
+  category: main
+  optional: false
+- name: arviz-stats
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    arviz-base: '>=1.1.0,<1.2.0'
+    arviz-stats-core: ==1.1.0
+    python: '>=3.12'
+    xarray: '>=2024.11.0'
+    xarray-einstats: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.1.0-pyhd721c7e_0.conda
+  hash:
+    md5: 0ad838e88323a0ab00e5c23d73e294c7
+    sha256: 73e9cff67f93ba698c18dd49a11fbd6075af9628e74c5a9e2abdf52e9c2e80cf
+  category: main
+  optional: false
+- name: arviz-stats
+  version: 1.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    arviz-base: '>=1.1.0,<1.2.0'
+    arviz-stats-core: ==1.1.0
+    python: '>=3.12'
+    xarray: '>=2024.11.0'
+    xarray-einstats: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.1.0-pyhd721c7e_0.conda
+  hash:
+    md5: 0ad838e88323a0ab00e5c23d73e294c7
+    sha256: 73e9cff67f93ba698c18dd49a11fbd6075af9628e74c5a9e2abdf52e9c2e80cf
+  category: main
+  optional: false
+- name: arviz-stats-core
+  version: 1.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    numpy: '>=2'
+    python: ''
+    scipy: '>=1.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 569718751577f8663a0996cf7303aa87
+    sha256: 8ed0c2728b2c0ec9560ab2fe063f635fb7767718957b0b8481ba11ce7ee44284
+  category: main
+  optional: false
+- name: arviz-stats-core
+  version: 1.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    numpy: '>=2'
+    python: '>=3.12'
+    scipy: '>=1.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 569718751577f8663a0996cf7303aa87
+    sha256: 8ed0c2728b2c0ec9560ab2fe063f635fb7767718957b0b8481ba11ce7ee44284
+  category: main
+  optional: false
+- name: arviz-stats-core
+  version: 1.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    numpy: '>=2'
+    python: '>=3.12'
+    scipy: '>=1.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.1.0-pyhc364b38_0.conda
+  hash:
+    md5: 569718751577f8663a0996cf7303aa87
+    sha256: 8ed0c2728b2c0ec9560ab2fe063f635fb7767718957b0b8481ba11ce7ee44284
   category: main
   optional: false
 - name: asttokens
@@ -593,53 +874,40 @@ package:
     sha256: b0747f9b1bc03d1932b4d8c586f39a35ac97e7e72fe6e63f2b2a2472d466f3c1
   category: main
   optional: false
-- name: attr
-  version: 2.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
-  hash:
-    md5: 791365c5f65975051e4e017b5da3abf5
-    sha256: a9c114cbfeda42a226e2db1809a538929d2f118ef855372293bd188f71711c48
-  category: main
-  optional: false
 - name: attrs
-  version: 25.4.0
+  version: 26.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
-    md5: 537296d57ea995666c68c821b00e360b
-    sha256: c13d5e42d187b1d0255f591b7ce91201d4ed8a5370f0d986707a802c20c9d32f
+    md5: c6b0543676ecb1fb2d7643941fe375f2
+    sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
   category: main
   optional: false
 - name: attrs
-  version: 25.4.0
+  version: 26.1.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
-    md5: 537296d57ea995666c68c821b00e360b
-    sha256: c13d5e42d187b1d0255f591b7ce91201d4ed8a5370f0d986707a802c20c9d32f
+    md5: c6b0543676ecb1fb2d7643941fe375f2
+    sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
   category: main
   optional: false
 - name: attrs
-  version: 25.4.0
+  version: 26.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   hash:
-    md5: 537296d57ea995666c68c821b00e360b
-    sha256: c13d5e42d187b1d0255f591b7ce91201d4ed8a5370f0d986707a802c20c9d32f
+    md5: c6b0543676ecb1fb2d7643941fe375f2
+    sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
   category: main
   optional: false
 - name: aws-c-auth
@@ -1259,95 +1527,95 @@ package:
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.16.1
+  version: 1.16.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libcurl: '>=8.14.1,<9.0a0'
+    libcurl: '>=8.18.0,<9.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
     openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.1-h3a458e0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.2-h206d751_0.conda
   hash:
-    md5: 1d4e0d37da5f3c22ecd44033f673feba
-    sha256: cba633571e7368953520a4f66dc74c3942cc12f735e0afa8d3d5fc3edf35c866
+    md5: 5492abf806c45298ae642831c670bba0
+    sha256: 321d1070905e467b6bc6f5067b97c1868d7345c272add82b82e08a0224e326f0
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.16.1
+  version: 1.16.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcurl: '>=8.14.1,<9.0a0'
+    libcurl: '>=8.18.0,<9.0a0'
     libcxx: '>=19'
     openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.16.1-he2a98a9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.16.2-h87f1c7e_0.conda
   hash:
-    md5: 9f39c22aad61e76bfb73bb7d4114efac
-    sha256: 923a0f9fab0c922e17f8bb27c8210d8978111390ff4e0cf6c1adff3c1a4d13bc
+    md5: 24997c4c96d1875956abd9ce37f262eb
+    sha256: bc2cde0d7204b3574084de1d83d80bceb7eb1550a17a0f0ccedbb312145475d3
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.16.1
+  version: 1.16.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcurl: '>=8.14.1,<9.0a0'
+    libcurl: '>=8.18.0,<9.0a0'
     libcxx: '>=19'
     openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.1-h88fedcc_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.2-he5ae378_0.conda
   hash:
-    md5: fbe485a39b05090c0b5f8bb4febcd343
-    sha256: d995413e4daf19ee3120f3ab9f0c9e330771787f33cbd4a33d8e5445f52022e3
+    md5: 7efe92d28599c224a24de11bb14d395e
+    sha256: d9a04af33d9200fcd9f6c954e2a882c5ac78af4b82025623e59cb7f7e590b451
   category: main
   optional: false
 - name: azure-identity-cpp
-  version: 1.13.2
+  version: 1.13.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.2-h3a5f585_1.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.3-hed0cdb0_1.conda
   hash:
-    md5: 4e921d9c85e6559c60215497978b3cdb
-    sha256: fc1df5ea2595f4f16d0da9f7713ce5fed20cb1bfc7fb098eda7925c7d23f0c45
+    md5: 68bfb556bdf56d56e9f38da696e752ca
+    sha256: 2beb6ae8406f946b8963a67e72fe74453e1411c5ae7e992978340de6c512d13c
   category: main
   optional: false
 - name: azure-identity-cpp
-  version: 1.13.2
+  version: 1.13.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     libcxx: '>=19'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.13.2-h0e8e1c8_1.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.13.3-h1135191_1.conda
   hash:
-    md5: 32eb613f88ae1530ca78481bdce41cdd
-    sha256: 555e9c9262b996f8c688598760b4cddf4d16ae1cb2f0fd0a31cb76c2fdc7d628
+    md5: 14d2491d2dfcbb127fa0ff6219704ab5
+    sha256: 182769c18c23e2b29bb35f6fca4c233f0125f84418dacb2c36912298dafbe42e
   category: main
   optional: false
 - name: azure-identity-cpp
-  version: 1.13.2
+  version: 1.13.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     libcxx: '>=19'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.2-h853621b_1.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h810541e_1.conda
   hash:
-    md5: fac63edc393d7035ab23fbccdeda34f4
-    sha256: a4ed52062025035d9c1b3d8c70af39496fc5153cc741420139a770bc1312cfd6
+    md5: ca46cc84466b5e05f15a4c4f263b6e80
+    sha256: 428fa73808a688a252639080b6751953ad7ecd8a4cbd8f23147b954d6902b31b
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -1356,14 +1624,14 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     azure-storage-common-cpp: '>=12.12.0,<12.12.1.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.16.0-h75daedc_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.16.0-hdd73cc9_1.conda
   hash:
-    md5: e88f8e816ae46c12cbe912c8f4d9d3bc
-    sha256: c155301bd9287480939b505b101db188b17564353366f1314080c7d8084077df
+    md5: 939d9ce324e51961c7c4c0046733dbb7
+    sha256: cef75b91bdd5a65c560b501df78905437cc2090a64b4c5ecd7da9e08e9e9af7c
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -1372,13 +1640,13 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     azure-storage-common-cpp: '>=12.12.0,<12.12.1.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.16.0-ha4e89a6_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.16.0-h9b4319f_1.conda
   hash:
-    md5: 5f76a3745c0eb7021845161c9a1bfee3
-    sha256: 446abd2fad0aa6b74207733534efc5e3ac4624bee981f40495cd4b8ae02d65ed
+    md5: 2d5fe7cce366e8b01d4b45985c131fb8
+    sha256: e4756a363d3abf2de78c068df050d7db53072c27f5a12666e008bd027ab5610a
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -1387,13 +1655,13 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     azure-storage-common-cpp: '>=12.12.0,<12.12.1.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.16.0-h6507aac_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.16.0-hc57151b_1.conda
   hash:
-    md5: ebcb072935c1595c39e2c62f0d3e50cc
-    sha256: fbf0d01d29dae190346f294ade76d7fda9b869e12176cb368b10c3fa2588e568
+    md5: f08b3b9d7333dc427b79897e6e3e7f29
+    sha256: 9de2f050a49597e5b98b59bf90880e00bfdff79a3afbb18828565c3a645d62d6
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -1402,16 +1670,16 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.12.0-h3d7a050_0.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.12.0-ha7a2c86_1.conda
   hash:
-    md5: e6f12de3a9b016cea81a87db04d85ff3
-    sha256: b1f91b15e46d9c33129374a5cbca302070311711838ae135bb3f6767af95f707
+    md5: 6400f73fe5ebe19fe7aca3616f1f1de7
+    sha256: ef7d1cae36910b21385d0816f8524a84dee1513e0306927e41a6bd32b5b9a0d0
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -1420,15 +1688,15 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     libcxx: '>=19'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.12.0-h2a5eb39_0.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.12.0-h7373072_1.conda
   hash:
-    md5: 53d1b2dc90315c3b8e4ecc86966ab7bd
-    sha256: b0ca0c4896fcc94ed1756a41c38fac2a95d28748ca89a90f99f6ceb8b4db0c26
+    md5: 743d031253118e250b26f32809910191
+    sha256: 4ecd8e48c9222fce1c69d25e85056ab60c44e65b7a160484aae86a65c684b7e8
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -1437,15 +1705,15 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     libcxx: '>=19'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.12.0-ha416c23_0.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.12.0-he467506_1.conda
   hash:
-    md5: 327799f2eb655ddf596b3e0ba2658979
-    sha256: e20bb2e6abf1d6823cd89db7a8ad91084560ba1a4d144f5dc6baa25711a30a3f
+    md5: b658a3fb0fc412b2a4d30da3fcec036f
+    sha256: 541be427e681d129c8722e81548d2e51c4b1a817f88333f3fbb3dcdef7eacafb
   category: main
   optional: false
 - name: azure-storage-files-datalake-cpp
@@ -1454,15 +1722,15 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     azure-storage-blobs-cpp: '>=12.16.0,<12.16.1.0a0'
     azure-storage-common-cpp: '>=12.12.0,<12.12.1.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.14.0-hd454692_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.14.0-h52c5a47_1.conda
   hash:
-    md5: 55986e49b7aafe9aa09d7f4c70a56a18
-    sha256: e9a64773488382997f28944612525f9cb7d8a3f8cbb0be2f0a07dc0881311925
+    md5: 6d10339800840562b7dad7775f5d2c16
+    sha256: 55aa8ad5217d358e0ccf4a715bd1f9bafef3cd1c2ea4021f0e916f174c20f8e3
   category: main
   optional: false
 - name: azure-storage-files-datalake-cpp
@@ -1471,14 +1739,14 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     azure-storage-blobs-cpp: '>=12.16.0,<12.16.1.0a0'
     azure-storage-common-cpp: '>=12.12.0,<12.12.1.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.14.0-h7f37a48_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.14.0-he1781d6_1.conda
   hash:
-    md5: 30ca75c03ba3166f44852b33f07f077c
-    sha256: f3aabb7c5023828aba930b82046b81b87a794b0c5c8a1db82043e88b3f5ca136
+    md5: cd3513aad4fac4078622d18538244fdc
+    sha256: 1ae895785ce2947686ba55126e8ebda4a42f9e0c992bf2c710436d95c85ac756
   category: main
   optional: false
 - name: azure-storage-files-datalake-cpp
@@ -1487,18 +1755,18 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     azure-storage-blobs-cpp: '>=12.16.0,<12.16.1.0a0'
     azure-storage-common-cpp: '>=12.12.0,<12.12.1.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.14.0-hcfc4f22_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.14.0-hf8a9d22_1.conda
   hash:
-    md5: a49804e4c4ad182a8de7b251d77f3b0c
-    sha256: f8d1ec719f3e3047d0f5be4be6973e5b4218c00b83b0707c327384304bcc2a72
+    md5: 601ac4f945ba078955557edf743f1f78
+    sha256: 1891df88b68768bc042ea766c1be279bff0fdaf471470bfa3fa599284dbd0975
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.3.0
+  version: 1.4.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1507,82 +1775,197 @@ package:
     python: ''
     python_abi: 3.13.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py313h18e8e13_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.4.0-py313h18e8e13_0.conda
   hash:
-    md5: d9e90792551a527200637e23a915dd79
-    sha256: 9552afbec37c4d8d0e83a5c4c6b3c7f4b8785f935094ce3881e0a249045909ce
+    md5: cfe95f3eab50bc3dbd4c3a03f2674bd8
+    sha256: f92ccaef33713bb66d563e8e829dcdb643e1de8c0d29246a999943c68bb8eb6e
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.3.0
+  version: 1.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    python: ''
+    python_abi: 3.13.*
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.4.0-py313h116f8bd_0.conda
+  hash:
+    md5: 1e37c8d0616c3964d3b7e47ecaa70294
+    sha256: 553b05a3b42d16873248629c71b939b76a076d33aff91a5d2714583f1e5c7ed4
+  category: main
+  optional: false
+- name: backports.zstd
+  version: 1.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: ''
+    python_abi: 3.13.*
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.4.0-py313h7208f8c_0.conda
+  hash:
+    md5: 84e922fe79295051f6925d7f8d71c98c
+    sha256: 257b234caffc760e48c8d7e642d6d0d8bac4341ca19c7df098421358eff636a1
+  category: main
+  optional: false
+- name: base58
+  version: 2.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/base58-2.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: ad0415de02475b397ad9be8ec953482d
+    sha256: c18deea456435c2032b6ce49a1332d0d2c91b68d5d8ed8c03f7e60e4f965b922
+  category: main
+  optional: false
+- name: base58
+  version: 2.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/base58-2.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: ad0415de02475b397ad9be8ec953482d
+    sha256: c18deea456435c2032b6ce49a1332d0d2c91b68d5d8ed8c03f7e60e4f965b922
+  category: main
+  optional: false
+- name: base58
+  version: 2.1.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/base58-2.1.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: ad0415de02475b397ad9be8ec953482d
+    sha256: c18deea456435c2032b6ce49a1332d0d2c91b68d5d8ed8c03f7e60e4f965b922
+  category: main
+  optional: false
+- name: beautifulsoup4
+  version: 4.14.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.10'
+    soupsieve: '>=1.2'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+  hash:
+    md5: 5267bef8efea4127aacd1f4e1f149b6e
+    sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
+  category: main
+  optional: false
+- name: beautifulsoup4
+  version: 4.14.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+    soupsieve: '>=1.2'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+  hash:
+    md5: 5267bef8efea4127aacd1f4e1f149b6e
+    sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
+  category: main
+  optional: false
+- name: beautifulsoup4
+  version: 4.14.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+    soupsieve: '>=1.2'
+    typing-extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+  hash:
+    md5: 5267bef8efea4127aacd1f4e1f149b6e
+    sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
+  category: main
+  optional: false
+- name: blake3
+  version: 1.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    python: ''
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/blake3-1.0.8-py313h843e2db_1.conda
+  hash:
+    md5: 28cf873e43e820c3a7c6fad745018982
+    sha256: 56ae56a96a3a3b126fd9f6d01c0547ec7db4c7943927760556faa04136f2e852
+  category: main
+  optional: false
+- name: blake3
+  version: 1.0.8
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     python: ''
     python_abi: 3.13.*
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.3.0-py313h591e92b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/blake3-1.0.8-py313hcc225dc_1.conda
   hash:
-    md5: c602f30b6c45567cd5cfb074631beb5d
-    sha256: 4133ba0e5ab6a0955b57a49ad4014148df6e4b79bef4309a1cdd407afd853444
+    md5: b5596f8ece0c5e7a1cf73c049398d1fa
+    sha256: 53188a257d49f52e27cb998a24213fa1b93852ede5ccddf2987c0b760352ab2d
   category: main
   optional: false
-- name: backports.zstd
-  version: 1.3.0
+- name: blake3
+  version: 1.0.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: 3.13.*
     python_abi: 3.13.*
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.3.0-py313h48bb75e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/blake3-1.0.8-py313h2c089d5_1.conda
   hash:
-    md5: 54008c5cc8928e5cb5a0f9206b829451
-    sha256: f3047ca3b41bb444b4b5a71a6eee182623192c77019746dd4685fd260becb249
+    md5: 2e5d10990b25b730793598cc33ef95aa
+    sha256: 851418228caa006d61842870044f62c0a98bf787322ed1ec0407ef6c0fc7ef1a
   category: main
   optional: false
-- name: beautifulsoup4
-  version: 4.14.3
+- name: blinker
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
-    soupsieve: '>=1.2'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
   hash:
-    md5: 5267bef8efea4127aacd1f4e1f149b6e
-    sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
   category: main
   optional: false
-- name: beautifulsoup4
-  version: 4.14.3
+- name: blinker
+  version: 1.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.10'
-    soupsieve: '>=1.2'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
   hash:
-    md5: 5267bef8efea4127aacd1f4e1f149b6e
-    sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
   category: main
   optional: false
-- name: beautifulsoup4
-  version: 4.14.3
+- name: blinker
+  version: 1.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.10'
-    soupsieve: '>=1.2'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
   hash:
-    md5: 5267bef8efea4127aacd1f4e1f149b6e
-    sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
+    md5: 42834439227a4551b939beeeb8a4b085
+    sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
   category: main
   optional: false
 - name: blosc
@@ -1638,7 +2021,7 @@ package:
   category: main
   optional: false
 - name: bokeh
-  version: 3.8.2
+  version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1647,20 +2030,19 @@ package:
     narwhals: '>=1.13'
     numpy: '>=1.16'
     packaging: '>=16.8'
-    pandas: '>=1.2'
     pillow: '>=7.1.0'
     python: '>=3.10'
     pyyaml: '>=3.10'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0b830ba4947de6d60dd9d96827a1cacb
-    sha256: 5e1aaaa2d193c1d4acea261b8cf822ee84cb59b4cf8c26ad40ca172584ab2a85
+    md5: b9a6da57e94cd12bd71e7ab0713ef052
+    sha256: 96a6486d4fe27c02c1092a40096dfd82043929b3a7da156a49b28d851159c551
   category: main
   optional: false
 - name: bokeh
-  version: 3.8.2
+  version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -1669,20 +2051,19 @@ package:
     narwhals: '>=1.13'
     numpy: '>=1.16'
     packaging: '>=16.8'
-    pandas: '>=1.2'
     pillow: '>=7.1.0'
     python: '>=3.10'
     pyyaml: '>=3.10'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0b830ba4947de6d60dd9d96827a1cacb
-    sha256: 5e1aaaa2d193c1d4acea261b8cf822ee84cb59b4cf8c26ad40ca172584ab2a85
+    md5: b9a6da57e94cd12bd71e7ab0713ef052
+    sha256: 96a6486d4fe27c02c1092a40096dfd82043929b3a7da156a49b28d851159c551
   category: main
   optional: false
 - name: bokeh
-  version: 3.8.2
+  version: 3.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1691,16 +2072,15 @@ package:
     narwhals: '>=1.13'
     numpy: '>=1.16'
     packaging: '>=16.8'
-    pandas: '>=1.2'
     pillow: '>=7.1.0'
     python: '>=3.10'
     pyyaml: '>=3.10'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.8.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 0b830ba4947de6d60dd9d96827a1cacb
-    sha256: 5e1aaaa2d193c1d4acea261b8cf822ee84cb59b4cf8c26ad40ca172584ab2a85
+    md5: b9a6da57e94cd12bd71e7ab0713ef052
+    sha256: 96a6486d4fe27c02c1092a40096dfd82043929b3a7da156a49b28d851159c551
   category: main
   optional: false
 - name: brotli
@@ -1894,10 +2274,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   hash:
-    md5: 51a19bba1b8ebfb60df25cde030b7ebc
-    sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
+    md5: d2ffd7602c02f2b316fd921d39876885
+    sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   category: main
   optional: false
 - name: bzip2
@@ -1906,10 +2286,10 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
   hash:
-    md5: 97c4b3bd8a90722104798175a1bdddbf
-    sha256: 8f50b58efb29c710f3cecf2027a8d7325ba769ab10c746eff75cea3ac050b10c
+    md5: 4173ac3b19ec0a4f400b4f782910368b
+    sha256: 9f242f13537ef1ce195f93f0cc162965d6cc79da578568d6d8e50f70dd025c42
   category: main
   optional: false
 - name: bzip2
@@ -1918,10 +2298,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
   hash:
-    md5: 58fd217444c2a5701a44244faf518206
-    sha256: b456200636bd5fecb2bec63f7e0985ad2097cf1b83d60ce0b6968dffa6d02aa1
+    md5: 620b85a3f45526a8bc4d23fd78fc22f0
+    sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
   category: main
   optional: false
 - name: c-ares
@@ -1962,7 +2342,7 @@ package:
   category: main
   optional: false
 - name: c-blosc2
-  version: 2.22.0
+  version: 3.0.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1970,152 +2350,80 @@ package:
     libgcc: '>=14'
     libstdcxx: '>=14'
     lz4-c: '>=1.10.0,<1.11.0a0'
-    zlib-ng: '>=2.3.1,<2.4.0a0'
+    zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.22.0-hc31b594_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.0.1-hc31b594_0.conda
   hash:
-    md5: 52019609422a72ec80c32bbc16a889d8
-    sha256: efe06a982fe7f4e483a2043c4b43fc3598a538a66ed11364ee5b25d3400ef415
+    md5: d21cf8ca2e3e175299022c6f29d5ace7
+    sha256: 9b1567193a6b063d3992e6bb2c7e1d084bde3fea9a7012cb6e52955ffa26d5a9
   category: main
   optional: false
 - name: c-blosc2
-  version: 2.22.0
+  version: 3.0.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     lz4-c: '>=1.10.0,<1.11.0a0'
-    zlib-ng: '>=2.3.1,<2.4.0a0'
+    zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-2.22.0-hedb7e5f_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-3.0.1-h32e32c0_0.conda
   hash:
-    md5: 13038523111830630683530ea54eb503
-    sha256: f529640f28822172017b8159c5d1f149ceda2c44707bcf8732b812e806cff669
+    md5: b62e1a290f5a1f15e3e82739b3735ffc
+    sha256: 715b9c34b901afd806d930476ced1d0fbcb85bcfd928039a3d733729fd4c0f56
   category: main
   optional: false
 - name: c-blosc2
-  version: 2.22.0
+  version: 3.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
     lz4-c: '>=1.10.0,<1.11.0a0'
-    zlib-ng: '>=2.3.1,<2.4.0a0'
+    zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-2.22.0-hb83781b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-blosc2-3.0.1-hf9886e1_0.conda
   hash:
-    md5: 5e4bdded23f6d61d8351223db98bc8f3
-    sha256: 4c1afcc78418a5d171f94238bae8b798c288deb8ba454113cf11f10d72b09ff6
+    md5: 6e70c8beb3555676f21800b49f3d26d6
+    sha256: f2be6f2d03dd28a3ff0af22636dcf0900c7a3d248af58c73e8c4c41c939c4080
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.1.4
+  version: 2026.4.22
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
   hash:
-    md5: bddacf101bb4dd0e51811cb69c7790e2
-    sha256: b5974ec9b50e3c514a382335efa81ed02b05906849827a34061c496f4defa0b2
+    md5: e18ad67cf881dcadee8b8d9e2f8e5f73
+    sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.1.4
+  version: 2026.4.22
   manager: conda
   platform: osx-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
   hash:
-    md5: bddacf101bb4dd0e51811cb69c7790e2
-    sha256: b5974ec9b50e3c514a382335efa81ed02b05906849827a34061c496f4defa0b2
+    md5: e18ad67cf881dcadee8b8d9e2f8e5f73
+    sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
   category: main
   optional: false
 - name: ca-certificates
-  version: 2026.1.4
+  version: 2026.4.22
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
   hash:
-    md5: bddacf101bb4dd0e51811cb69c7790e2
-    sha256: b5974ec9b50e3c514a382335efa81ed02b05906849827a34061c496f4defa0b2
-  category: main
-  optional: false
-- name: cached-property
-  version: 1.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cached_property: '>=1.5.2,<1.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  category: main
-  optional: false
-- name: cached-property
-  version: 1.5.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    cached_property: '>=1.5.2,<1.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  category: main
-  optional: false
-- name: cached-property
-  version: 1.5.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cached_property: '>=1.5.2,<1.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  category: main
-  optional: false
-- name: cached_property
-  version: 1.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
-  category: main
-  optional: false
-- name: cached_property
-  version: 1.5.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
-  category: main
-  optional: false
-- name: cached_property
-  version: 1.5.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+    md5: e18ad67cf881dcadee8b8d9e2f8e5f73
+    sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
   category: main
   optional: false
 - name: cairo
@@ -2259,22 +2567,22 @@ package:
   category: main
   optional: false
 - name: cattrs
-  version: 25.3.0
+  version: 26.1.0
   manager: conda
   platform: linux-64
   dependencies:
     attrs: '>=25.4.0'
     exceptiongroup: '>=1.1.1'
-    python: '>=3.10'
+    python: ''
     typing_extensions: '>=4.14.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-25.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-26.1.0-pyhcf101f3_1.conda
   hash:
-    md5: e78e411a2d5a999f2b1536f6c9481801
-    sha256: 67ebbaa37cabf19fe39fee82d4b2e0a6c1cde58bc974b1963c86961ff91f6184
+    md5: eb57a77657c275d8d0b3542b070f484c
+    sha256: c3c5772e8f3c9080b3b89765bb9e9d88972792b54d96d546c29672965bbb8d6c
   category: main
   optional: false
 - name: cattrs
-  version: 25.3.0
+  version: 26.1.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -2282,14 +2590,14 @@ package:
     exceptiongroup: '>=1.1.1'
     python: '>=3.10'
     typing_extensions: '>=4.14.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-25.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-26.1.0-pyhcf101f3_1.conda
   hash:
-    md5: e78e411a2d5a999f2b1536f6c9481801
-    sha256: 67ebbaa37cabf19fe39fee82d4b2e0a6c1cde58bc974b1963c86961ff91f6184
+    md5: eb57a77657c275d8d0b3542b070f484c
+    sha256: c3c5772e8f3c9080b3b89765bb9e9d88972792b54d96d546c29672965bbb8d6c
   category: main
   optional: false
 - name: cattrs
-  version: 25.3.0
+  version: 26.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2297,10 +2605,10 @@ package:
     exceptiongroup: '>=1.1.1'
     python: '>=3.10'
     typing_extensions: '>=4.14.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-25.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cattrs-26.1.0-pyhcf101f3_1.conda
   hash:
-    md5: e78e411a2d5a999f2b1536f6c9481801
-    sha256: 67ebbaa37cabf19fe39fee82d4b2e0a6c1cde58bc974b1963c86961ff91f6184
+    md5: eb57a77657c275d8d0b3542b070f484c
+    sha256: c3c5772e8f3c9080b3b89765bb9e9d88972792b54d96d546c29672965bbb8d6c
   category: main
   optional: false
 - name: cdo
@@ -2310,27 +2618,27 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     eccodes: ''
-    fftw: '>=3.3.10,<4.0a0'
+    fftw: '>=3.3.11,<4.0a0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    jasper: '>=4.2.8,<5.0a0'
-    libcurl: '>=8.14.1,<9.0a0'
+    jasper: '>=4.2.9,<5.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
     libudunits2: '>=2.2.28,<3.0a0'
-    libuuid: '>=2.41.1,<3.0a0'
+    libuuid: '>=2.42,<3.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libxml2-devel: ''
     magics: ''
-    proj: '>=9.7.0,<9.8.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
     udunits2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/cdo-2.5.0-hbf53078_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cdo-2.5.0-h54830fc_8.conda
   hash:
-    md5: 529f01c326bcd9bca4f393eb379c4cf5
-    sha256: c0e261e9f2507ab380f654a178ac270c25072198cb86b51d4094161f31fd675e
+    md5: d5680a8d57350d69a5c549271633e0cb
+    sha256: 39f1e103e17cec455b899c7df0bd18b11ce9bc658e90006a657fbb4917f2a0fc
   category: main
   optional: false
 - name: cdo
@@ -2338,29 +2646,29 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     eccodes: ''
-    fftw: '>=3.3.10,<4.0a0'
+    fftw: '>=3.3.11,<4.0a0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    jasper: '>=4.2.8,<5.0a0'
-    libcurl: '>=8.14.1,<9.0a0'
+    jasper: '>=4.2.9,<5.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
+    libgfortran5: '>=14.3.0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libudunits2: '>=2.2.28,<3.0a0'
-    libuuid: '>=2.41.1,<3.0a0'
+    libuuid: '>=2.42,<3.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libxml2-devel: ''
     llvm-openmp: '>=19.1.7'
     magics: ''
-    proj: '>=9.7.0,<9.8.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
     udunits2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/cdo-2.5.0-hf416b4d_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/cdo-2.5.0-hb9e711c_8.conda
   hash:
-    md5: 0b9dd182461fb0e1020cc0bebea10629
-    sha256: 83d283001dcf61991d34c7769fadb54aa56b7a30e79192228a947c15dd19efa4
+    md5: 495fca9c1a38cddf277adc827b8199cf
+    sha256: 32413fbb5d9acb4e0b34f28a6347968953398c3ca6387dea46c479de9ac9983a
   category: main
   optional: false
 - name: cdo
@@ -2370,27 +2678,27 @@ package:
   dependencies:
     __osx: '>=11.0'
     eccodes: ''
-    fftw: '>=3.3.10,<4.0a0'
+    fftw: '>=3.3.11,<4.0a0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    jasper: '>=4.2.8,<5.0a0'
-    libcurl: '>=8.14.1,<9.0a0'
+    jasper: '>=4.2.9,<5.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
+    libgfortran5: '>=14.3.0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libudunits2: '>=2.2.28,<3.0a0'
-    libuuid: '>=2.41.1,<3.0a0'
+    libuuid: '>=2.42,<3.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libxml2-devel: ''
     llvm-openmp: '>=19.1.7'
     magics: ''
-    proj: '>=9.7.0,<9.8.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
     udunits2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cdo-2.5.0-hba3e7ea_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cdo-2.5.0-hd730a89_8.conda
   hash:
-    md5: d50fe4c2c6b407d152acc136560fa7dc
-    sha256: dc6c04a29fad21e0c369e844ea5cee13adef43a5191cbbbebcd91927b68d67f0
+    md5: 27402689a418da35b7cbfb7f5395598f
+    sha256: 1ab8954cc3848ecc72479eef0fdb31132f993f9ac701723a04edeebc09591db0
   category: main
   optional: false
 - name: cdsapi
@@ -2439,39 +2747,39 @@ package:
   category: main
   optional: false
 - name: certifi
-  version: 2026.1.4
+  version: 2026.4.22
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
   hash:
-    md5: eacc711330cd46939f66cd401ff9c44b
-    sha256: 110338066d194a715947808611b763857c15458f8b3b97197387356844af9450
+    md5: 929471569c93acefb30282a22060dcd5
+    sha256: 989db6e5957c4b44fa600c68c681ec2f36a55e48f7c7f1c073d5e91caa8cd878
   category: main
   optional: false
 - name: certifi
-  version: 2026.1.4
+  version: 2026.4.22
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
   hash:
-    md5: eacc711330cd46939f66cd401ff9c44b
-    sha256: 110338066d194a715947808611b763857c15458f8b3b97197387356844af9450
+    md5: 929471569c93acefb30282a22060dcd5
+    sha256: 989db6e5957c4b44fa600c68c681ec2f36a55e48f7c7f1c073d5e91caa8cd878
   category: main
   optional: false
 - name: certifi
-  version: 2026.1.4
+  version: 2026.4.22
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
   hash:
-    md5: eacc711330cd46939f66cd401ff9c44b
-    sha256: 110338066d194a715947808611b763857c15458f8b3b97197387356844af9450
+    md5: 929471569c93acefb30282a22060dcd5
+    sha256: 989db6e5957c4b44fa600c68c681ec2f36a55e48f7c7f1c073d5e91caa8cd878
   category: main
   optional: false
 - name: cf-units
@@ -2533,81 +2841,81 @@ package:
   category: main
   optional: false
 - name: cf-xarray
-  version: 0.10.10
+  version: 0.11.0
   manager: conda
   platform: linux-64
   dependencies:
-    cf_xarray: '>=0.10.10,<0.10.11.0a0'
+    cf_xarray: '>=0.11.0,<0.11.1.0a0'
     python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.10.10-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 99c2653fe4e1ac389e7f10a963fd92df
-    sha256: 57dabc62726bfd888fae7b07147d65aa7a6ceff03e886fe2bb890b824df2814e
+    md5: 50beaf91f1534adb49bc9b32975070d7
+    sha256: c035778b241aa4c850c597dd17bedf1472fd196a1b542cbdbab8db7dc263c481
   category: main
   optional: false
 - name: cf-xarray
-  version: 0.10.10
+  version: 0.11.0
   manager: conda
   platform: osx-64
   dependencies:
-    cf_xarray: '>=0.10.10,<0.10.11.0a0'
+    cf_xarray: '>=0.11.0,<0.11.1.0a0'
     python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.10.10-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 99c2653fe4e1ac389e7f10a963fd92df
-    sha256: 57dabc62726bfd888fae7b07147d65aa7a6ceff03e886fe2bb890b824df2814e
+    md5: 50beaf91f1534adb49bc9b32975070d7
+    sha256: c035778b241aa4c850c597dd17bedf1472fd196a1b542cbdbab8db7dc263c481
   category: main
   optional: false
 - name: cf-xarray
-  version: 0.10.10
+  version: 0.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    cf_xarray: '>=0.10.10,<0.10.11.0a0'
+    cf_xarray: '>=0.11.0,<0.11.1.0a0'
     python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.10.10-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cf-xarray-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 99c2653fe4e1ac389e7f10a963fd92df
-    sha256: 57dabc62726bfd888fae7b07147d65aa7a6ceff03e886fe2bb890b824df2814e
+    md5: 50beaf91f1534adb49bc9b32975070d7
+    sha256: c035778b241aa4c850c597dd17bedf1472fd196a1b542cbdbab8db7dc263c481
   category: main
   optional: false
 - name: cf_xarray
-  version: 0.10.10
+  version: 0.11.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.11'
-    xarray: '>=2023.09.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.10-pyhd8ed1ab_0.conda
+    xarray: '>=2024.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 522ce00d4ee558be56aa2e93528a3d0f
-    sha256: 69df83309b2f546007cc7512053d7a47f3015aab02004953587de88175c57405
+    md5: a45b58ebb586e8148b1535acde3669a4
+    sha256: 57ea66ea693ca02a07d6a7550b2ce14bdca363212e7c74d2070936eb3d7f9f10
   category: main
   optional: false
 - name: cf_xarray
-  version: 0.10.10
+  version: 0.11.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.11'
-    xarray: '>=2023.09.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.10-pyhd8ed1ab_0.conda
+    xarray: '>=2024.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 522ce00d4ee558be56aa2e93528a3d0f
-    sha256: 69df83309b2f546007cc7512053d7a47f3015aab02004953587de88175c57405
+    md5: a45b58ebb586e8148b1535acde3669a4
+    sha256: 57ea66ea693ca02a07d6a7550b2ce14bdca363212e7c74d2070936eb3d7f9f10
   category: main
   optional: false
 - name: cf_xarray
-  version: 0.10.10
+  version: 0.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.11'
-    xarray: '>=2023.09.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.10.10-pyhd8ed1ab_0.conda
+    xarray: '>=2024.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 522ce00d4ee558be56aa2e93528a3d0f
-    sha256: 69df83309b2f546007cc7512053d7a47f3015aab02004953587de88175c57405
+    md5: a45b58ebb586e8148b1535acde3669a4
+    sha256: 57ea66ea693ca02a07d6a7550b2ce14bdca363212e7c74d2070936eb3d7f9f10
   category: main
   optional: false
 - name: cffi
@@ -2763,76 +3071,79 @@ package:
   category: main
   optional: false
 - name: charls
-  version: 2.4.2
+  version: 2.4.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/charls-2.4.2-h59595ed_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/charls-2.4.3-hecca717_0.conda
   hash:
-    md5: 4336bd67920dd504cd8c6761d6a99645
-    sha256: 18f1c43f91ccf28297f92b094c2c8dbe9c6e8241c0d3cbd6cda014a990660fdd
+    md5: 937ca49a245fcf2b88d51b6b52959426
+    sha256: 53504e965499b4845ca3dc63d5905d5a1e686fcb9ab17e83c018efa479e787d0
   category: main
   optional: false
 - name: charls
-  version: 2.4.2
+  version: 2.4.3
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-64/charls-2.4.2-he965462_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/charls-2.4.3-hcc62823_0.conda
   hash:
-    md5: c267b3955138953f8ca4cb4d1f4f2d84
-    sha256: 5167aafc0bcc3849373dd8afb448cc387078210236e597f2ef8d2b1fe3d0b1a2
+    md5: 04d7337a89a1def07cf2b2bd96e2b04a
+    sha256: 8755decbc126ed207da4618b104ee2a8a3336c1511264d5549b22dd21d356667
   category: main
   optional: false
 - name: charls
-  version: 2.4.2
+  version: 2.4.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/charls-2.4.2-h13dd4ca_0.conda
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/charls-2.4.3-hf6b4638_0.conda
   hash:
-    md5: 6faf3cf8df25572c7f70138a45f37363
-    sha256: b9f79954e6d37ad59016b434abfdd096a75ff08c6de14e5198bcea497a10fae5
+    md5: 91f1daf22f72792e11382938bb0dd9ac
+    sha256: 1009bd6c2bb26e41dada4015793a1edf44d1320c7ca14fc646f89b0b51236e20
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.4.4
+  version: 3.4.7
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
   hash:
-    md5: a22d1fd9bf98827e280a02875d9a007a
-    sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
+    md5: a9167b9571f3baa9d448faa2139d1089
+    sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.4.4
+  version: 3.4.7
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
   hash:
-    md5: a22d1fd9bf98827e280a02875d9a007a
-    sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
+    md5: a9167b9571f3baa9d448faa2139d1089
+    sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.4.4
+  version: 3.4.7
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
   hash:
-    md5: a22d1fd9bf98827e280a02875d9a007a
-    sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
+    md5: a9167b9571f3baa9d448faa2139d1089
+    sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
   category: main
   optional: false
 - name: chart-studio
@@ -2884,42 +3195,42 @@ package:
   category: main
   optional: false
 - name: click
-  version: 8.3.1
+  version: 8.3.3
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
   hash:
-    md5: ea8a6c3256897cc31263de9f455e25d9
-    sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
+    md5: 2266262ce8a425ecb6523d765f79b303
+    sha256: 37a5d8b10ea3516e2c42f870c9c351b9f7b31ff48c66d83490039f417e1e5228
   category: main
   optional: false
 - name: click
-  version: 8.3.1
+  version: 8.3.3
   manager: conda
   platform: osx-64
   dependencies:
     __unix: ''
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
   hash:
-    md5: ea8a6c3256897cc31263de9f455e25d9
-    sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
+    md5: 2266262ce8a425ecb6523d765f79b303
+    sha256: 37a5d8b10ea3516e2c42f870c9c351b9f7b31ff48c66d83490039f417e1e5228
   category: main
   optional: false
 - name: click
-  version: 8.3.1
+  version: 8.3.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
   hash:
-    md5: ea8a6c3256897cc31263de9f455e25d9
-    sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
+    md5: 2266262ce8a425ecb6523d765f79b303
+    sha256: 37a5d8b10ea3516e2c42f870c9c351b9f7b31ff48c66d83490039f417e1e5228
   category: main
   optional: false
 - name: click-plugins
@@ -3196,39 +3507,42 @@ package:
   category: main
   optional: false
 - name: configargparse
-  version: 1.7.1
+  version: 1.7.5
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.1-pyhe01879c_0.conda
+    toml: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
   hash:
-    md5: 18dfeef40f049992f4b46b06e6f3b497
-    sha256: 61d31e5181e29b5bcd47e0a5ef590caf0aec3ec1a6c8f19f50b42ed5bdc065d2
+    md5: 12389a21e7f69704b0ae77f44355e30b
+    sha256: 7f8ea42a8411b433ec7244dfd30637d90564256c13a114dbe42455fe032ae89c
   category: main
   optional: false
 - name: configargparse
-  version: 1.7.1
+  version: 1.7.5
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.1-pyhe01879c_0.conda
+    python: '>=3.10'
+    toml: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
   hash:
-    md5: 18dfeef40f049992f4b46b06e6f3b497
-    sha256: 61d31e5181e29b5bcd47e0a5ef590caf0aec3ec1a6c8f19f50b42ed5bdc065d2
+    md5: 12389a21e7f69704b0ae77f44355e30b
+    sha256: 7f8ea42a8411b433ec7244dfd30637d90564256c13a114dbe42455fe032ae89c
   category: main
   optional: false
 - name: configargparse
-  version: 1.7.1
+  version: 1.7.5
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.1-pyhe01879c_0.conda
+    python: '>=3.10'
+    toml: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
   hash:
-    md5: 18dfeef40f049992f4b46b06e6f3b497
-    sha256: 61d31e5181e29b5bcd47e0a5ef590caf0aec3ec1a6c8f19f50b42ed5bdc065d2
+    md5: 12389a21e7f69704b0ae77f44355e30b
+    sha256: 7f8ea42a8411b433ec7244dfd30637d90564256c13a114dbe42455fe032ae89c
   category: main
   optional: false
 - name: contourpy
@@ -3281,91 +3595,91 @@ package:
   category: main
   optional: false
 - name: cpython
-  version: 3.13.11
+  version: 3.13.13
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.13,<3.14.0a0'
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.11-py313hd8ed1ab_101.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
   hash:
-    md5: c74a6b9e8694e5122949f611d1552df5
-    sha256: f851800da77f360e39235383d685b6e3be4edf28fe233f3bcf09c45293f39ae1
+    md5: 3a8a8b87e72f95b54689fb588e154ec9
+    sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
   category: main
   optional: false
 - name: cpython
-  version: 3.13.11
+  version: 3.13.13
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.13,<3.14.0a0'
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.11-py313hd8ed1ab_101.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
   hash:
-    md5: c74a6b9e8694e5122949f611d1552df5
-    sha256: f851800da77f360e39235383d685b6e3be4edf28fe233f3bcf09c45293f39ae1
+    md5: 3a8a8b87e72f95b54689fb588e154ec9
+    sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
   category: main
   optional: false
 - name: cpython
-  version: 3.13.11
+  version: 3.13.13
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.13,<3.14.0a0'
     python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.11-py313hd8ed1ab_101.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
   hash:
-    md5: c74a6b9e8694e5122949f611d1552df5
-    sha256: f851800da77f360e39235383d685b6e3be4edf28fe233f3bcf09c45293f39ae1
+    md5: 3a8a8b87e72f95b54689fb588e154ec9
+    sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
   category: main
   optional: false
 - name: cryptography
-  version: 46.0.4
+  version: 46.0.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cffi: '>=1.14'
     libgcc: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.4-py313heb322e3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py313heb322e3_0.conda
   hash:
-    md5: 8831066b7226ee1c5c75e8d0832517e6
-    sha256: f92d767380fa956d1d0e5d3e454463fb104cd85e1315c626948ba3f4c0dc8c40
+    md5: 9702a147e144f2e197c7dc5f0b4d059e
+    sha256: 02d6aad8b3f0fb92f22efb02aa9dd7605aab6c761fe27a86ab24b82fbb068f24
   category: main
   optional: false
 - name: cryptography
-  version: 46.0.4
+  version: 46.0.7
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     cffi: '>=1.14'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-46.0.4-py313h6e3882f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-46.0.7-py313ha8d32cc_0.conda
   hash:
-    md5: f660db31ac6999d4a21b019e1c5a5afc
-    sha256: 8bf2ea41d3112066f56ecbdf8242c83f336ffb589415bc992ac7709494788b7b
+    md5: d0138cd13c217847a74ecb592b6e9053
+    sha256: b7043ef70f07223cfeb5729b4432507853439271155b6665bf05267ed3d8bc1c
   category: main
   optional: false
 - name: cryptography
-  version: 46.0.4
+  version: 46.0.7
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cffi: '>=1.14'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.4-py313he3f6fad_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-46.0.7-py313he3f6fad_0.conda
   hash:
-    md5: 7818c7f27bd07437fc93843dad900e7b
-    sha256: f08c315c97e98c3343a45a4e5141dcc56b58363d9d3f1420bff6826eb1f24e4a
+    md5: 1a39847ae5d8944cb93b886b3b88abd8
+    sha256: 6f9ea002baa16146b97c627475c7e4dbb01fdcacce239a1d2776e1c7ef74803a
   category: main
   optional: false
 - name: cycler
@@ -3460,10 +3774,10 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py313h07c4f96_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py313h07c4f96_2.conda
   hash:
-    md5: bcca9afd203fe05d9582249ac12762da
-    sha256: a8ffc7cf31a698a57a46bf7977185ed1e644c5e35d4e166d8f260dca93af6ffb
+    md5: 7e7e3c5a8a28c6b8eb430183e0554adf
+    sha256: fd33f531288fb08afef72a65414d29caefbba31cb398533534794475af35b1b3
   category: main
   optional: false
 - name: cytoolz
@@ -3475,10 +3789,10 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py313hf050af9_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py313h36bb7f5_2.conda
   hash:
-    md5: 9eb5b350c5a60139b32c72bf8695139c
-    sha256: e2458af0964417f6ca0be05a82af20647c632362cc319c7a29eb268cef28e897
+    md5: bdeebe589a7c1d098f7db85f2d03604a
+    sha256: f88f35acd597f275f83a16fa0d370f439206ae310bf028fd90ec242cecb2e8ed
   category: main
   optional: false
 - name: cytoolz
@@ -3490,77 +3804,77 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py313h6535dbc_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py313h0997733_2.conda
   hash:
-    md5: cfd9eda010114a19249e394e58704cdb
-    sha256: 4b00a25e9bf8b5d702b82dd5c6816d104856845a4e3ea7536abbc90017de7999
+    md5: 5b7dd41f7974dd5d52bf37cbc0322e84
+    sha256: d272fa92cbf6b4de83a47702878e1ac75efc665d7f60f1c2818c8c33ebd4cfa6
   category: main
   optional: false
 - name: dask
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: linux-64
   dependencies:
     bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.0'
-    dask-core: '>=2026.1.1,<2026.1.2.0a0'
-    distributed: '>=2026.1.1,<2026.1.2.0a0'
+    cytoolz: '>=0.11.2'
+    dask-core: '>=2026.3.0,<2026.3.1.0a0'
+    distributed: '>=2026.3.0,<2026.3.1.0a0'
     jinja2: '>=2.10.3'
     lz4: '>=4.3.2'
-    numpy: '>=1.24'
+    numpy: '>=1.26'
     pandas: '>=2.0'
-    pyarrow: '>=14.0.1'
+    pyarrow: '>=16.0'
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.1.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: a86541105aa7920d2147d48bf370dc08
-    sha256: cc3a106881051c9a4bdaf05fdf7e175f0d63885b4624728101e7996a0e6e8ae3
+    md5: f9761ef056ba0ccef16e01cfceee62c2
+    sha256: fe59c26dc20a47aa56fc38a2326f2a62403f3eed366837c1a0fba166a220d2b7
   category: main
   optional: false
 - name: dask
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: osx-64
   dependencies:
     bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.0'
-    dask-core: '>=2026.1.1,<2026.1.2.0a0'
-    distributed: '>=2026.1.1,<2026.1.2.0a0'
+    cytoolz: '>=0.11.2'
+    dask-core: '>=2026.3.0,<2026.3.1.0a0'
+    distributed: '>=2026.3.0,<2026.3.1.0a0'
     jinja2: '>=2.10.3'
     lz4: '>=4.3.2'
-    numpy: '>=1.24'
+    numpy: '>=1.26'
     pandas: '>=2.0'
-    pyarrow: '>=14.0.1'
+    pyarrow: '>=16.0'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.1.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: a86541105aa7920d2147d48bf370dc08
-    sha256: cc3a106881051c9a4bdaf05fdf7e175f0d63885b4624728101e7996a0e6e8ae3
+    md5: f9761ef056ba0ccef16e01cfceee62c2
+    sha256: fe59c26dc20a47aa56fc38a2326f2a62403f3eed366837c1a0fba166a220d2b7
   category: main
   optional: false
 - name: dask
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     bokeh: '>=3.1.0'
-    cytoolz: '>=0.11.0'
-    dask-core: '>=2026.1.1,<2026.1.2.0a0'
-    distributed: '>=2026.1.1,<2026.1.2.0a0'
+    cytoolz: '>=0.11.2'
+    dask-core: '>=2026.3.0,<2026.3.1.0a0'
+    distributed: '>=2026.3.0,<2026.3.1.0a0'
     jinja2: '>=2.10.3'
     lz4: '>=4.3.2'
-    numpy: '>=1.24'
+    numpy: '>=1.26'
     pandas: '>=2.0'
-    pyarrow: '>=14.0.1'
+    pyarrow: '>=16.0'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.1.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: a86541105aa7920d2147d48bf370dc08
-    sha256: cc3a106881051c9a4bdaf05fdf7e175f0d63885b4624728101e7996a0e6e8ae3
+    md5: f9761ef056ba0ccef16e01cfceee62c2
+    sha256: fe59c26dc20a47aa56fc38a2326f2a62403f3eed366837c1a0fba166a220d2b7
   category: main
   optional: false
 - name: dask-core
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3573,14 +3887,14 @@ package:
     python: ''
     pyyaml: '>=5.3.1'
     toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.1.1-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: 91e3b2a0d014ac032c066a2e18051686
-    sha256: f279cecdcc132861e49c8f779ff3bfd42b8de811ca97b82566b6c7b23a136b11
+    md5: 809f4cde7c853f437becc43415a2ecdf
+    sha256: 5497e56b12b8a07921668f6469d725be9826ffe5ae8a2f6f71d26369400b41ca
   category: main
   optional: false
 - name: dask-core
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -3593,14 +3907,14 @@ package:
     python: '>=3.10'
     pyyaml: '>=5.3.1'
     toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.1.1-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: 91e3b2a0d014ac032c066a2e18051686
-    sha256: f279cecdcc132861e49c8f779ff3bfd42b8de811ca97b82566b6c7b23a136b11
+    md5: 809f4cde7c853f437becc43415a2ecdf
+    sha256: 5497e56b12b8a07921668f6469d725be9826ffe5ae8a2f6f71d26369400b41ca
   category: main
   optional: false
 - name: dask-core
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3613,10 +3927,10 @@ package:
     python: '>=3.10'
     pyyaml: '>=5.3.1'
     toolz: '>=0.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.1.1-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: 91e3b2a0d014ac032c066a2e18051686
-    sha256: f279cecdcc132861e49c8f779ff3bfd42b8de811ca97b82566b6c7b23a136b11
+    md5: 809f4cde7c853f437becc43415a2ecdf
+    sha256: 5497e56b12b8a07921668f6469d725be9826ffe5ae8a2f6f71d26369400b41ca
   category: main
   optional: false
 - name: dask-jobqueue
@@ -3827,14 +4141,14 @@ package:
   category: main
   optional: false
 - name: distributed
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=8.0'
     cloudpickle: '>=3.0.0'
     cytoolz: '>=0.12.0'
-    dask-core: '>=2026.1.1,<2026.1.2.0a0'
+    dask-core: '>=2026.3.0,<2026.3.1.0a0'
     jinja2: '>=2.10.3'
     locket: '>=1.0.0'
     msgpack-python: '>=1.0.2'
@@ -3848,21 +4162,21 @@ package:
     tornado: '>=6.2.0'
     urllib3: '>=1.26.5'
     zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.1-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: c15e359a982395be86a7576a91f9c5f5
-    sha256: cc3dc8383c6693e387dba37a7feb360df0c7f3d8c5c11c92f4ca173e9a18476f
+    md5: 8efb90a27e3b948514a428cb99f3fc70
+    sha256: 49cbb318f7a1797b9f17c135c9b5c48ba2086570a58c99054d3b40bf13a5b815
   category: main
   optional: false
 - name: distributed
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: osx-64
   dependencies:
     click: '>=8.0'
     cloudpickle: '>=3.0.0'
     cytoolz: '>=0.12.0'
-    dask-core: '>=2026.1.1,<2026.1.2.0a0'
+    dask-core: '>=2026.3.0,<2026.3.1.0a0'
     jinja2: '>=2.10.3'
     locket: '>=1.0.0'
     msgpack-python: '>=1.0.2'
@@ -3876,21 +4190,21 @@ package:
     tornado: '>=6.2.0'
     urllib3: '>=1.26.5'
     zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.1-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: c15e359a982395be86a7576a91f9c5f5
-    sha256: cc3dc8383c6693e387dba37a7feb360df0c7f3d8c5c11c92f4ca173e9a18476f
+    md5: 8efb90a27e3b948514a428cb99f3fc70
+    sha256: 49cbb318f7a1797b9f17c135c9b5c48ba2086570a58c99054d3b40bf13a5b815
   category: main
   optional: false
 - name: distributed
-  version: 2026.1.1
+  version: 2026.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     click: '>=8.0'
     cloudpickle: '>=3.0.0'
     cytoolz: '>=0.12.0'
-    dask-core: '>=2026.1.1,<2026.1.2.0a0'
+    dask-core: '>=2026.3.0,<2026.3.1.0a0'
     jinja2: '>=2.10.3'
     locket: '>=1.0.0'
     msgpack-python: '>=1.0.2'
@@ -3904,10 +4218,10 @@ package:
     tornado: '>=6.2.0'
     urllib3: '>=1.26.5'
     zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.1-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.3.0-pyhc364b38_0.conda
   hash:
-    md5: c15e359a982395be86a7576a91f9c5f5
-    sha256: cc3dc8383c6693e387dba37a7feb360df0c7f3d8c5c11c92f4ca173e9a18476f
+    md5: 8efb90a27e3b948514a428cb99f3fc70
+    sha256: 49cbb318f7a1797b9f17c135c9b5c48ba2086570a58c99054d3b40bf13a5b815
   category: main
   optional: false
 - name: docopt-ng
@@ -3986,67 +4300,67 @@ package:
   category: main
   optional: false
 - name: eccodes
-  version: 2.45.0
+  version: 2.47.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    jasper: '>=4.2.8,<5.0a0'
-    libaec: '>=1.1.4,<2.0a0'
+    jasper: '>=4.2.9,<5.0a0'
+    libaec: '>=1.1.5,<2.0a0'
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.45.0-h83bc92c_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.47.0-h1c03fa5_0.conda
   hash:
-    md5: a981ecc85b1ff6307b8f09cf66b77083
-    sha256: 118573f583a3a9476fad02e66eaec25b9c1114f6d75b98f57b0df8901219fd7e
+    md5: 4c40448d88f34277a43e806f29a6e339
+    sha256: e7bdd3e270497484773b9d4e6d6ddc18471735083d27bdc7641ef4271b05d2a7
   category: main
   optional: false
 - name: eccodes
-  version: 2.45.0
+  version: 2.47.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    jasper: '>=4.2.8,<5.0a0'
-    libaec: '>=1.1.4,<2.0a0'
+    jasper: '>=4.2.9,<5.0a0'
+    libaec: '>=1.1.5,<2.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/eccodes-2.45.0-hef68630_0.conda
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/eccodes-2.47.0-hf4a17e4_0.conda
   hash:
-    md5: c2d8f6d37131139dbaeba869b036b9cb
-    sha256: e749dd9457e97b9e391461e5706c009102e039c218fc7f8651ca877ea3dd45ac
+    md5: 3205fe1db0400b86730601172aea8fd5
+    sha256: 0b1f311a0a612655d5c4ec6e476ac2b105aac12e4328946fa2adeb9265c1d0de
   category: main
   optional: false
 - name: eccodes
-  version: 2.45.0
+  version: 2.47.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    jasper: '>=4.2.8,<5.0a0'
-    libaec: '>=1.1.4,<2.0a0'
+    jasper: '>=4.2.9,<5.0a0'
+    libaec: '>=1.1.5,<2.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/eccodes-2.45.0-h768f3a7_0.conda
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/eccodes-2.47.0-h10ae4f9_0.conda
   hash:
-    md5: 73c9f89679eb90386f2787e7681e95b7
-    sha256: 378ed51575fe268f90704663b7fcb5f80f7c77865d46d0643124546225773d00
+    md5: 6a12014e60e8fc7ee6ca51f7d8a372bc
+    sha256: e55717902b6202e4869e4398899c29bbeba5a92889c6662ce8c320a91839cfdf
   category: main
   optional: false
 - name: ecmwf-api-client
@@ -4086,7 +4400,7 @@ package:
   category: main
   optional: false
 - name: ecmwf-datastores-client
-  version: 0.4.2
+  version: 0.5.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -4095,14 +4409,14 @@ package:
     python: '>=3.9'
     requests: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d957f10f516dcdeb9e382c91d771df12
-    sha256: c9e08781d043ab18ea83d2523a17d0bd763ae01274fb854c3024f2fee27aaecf
+    md5: fc8b15af108a2fdb15ef04d12fbfe87d
+    sha256: 65143f563da904873fe3c69cdef3f9fb3b9501fb81d20b4d3ae89eab6ad6b6d3
   category: main
   optional: false
 - name: ecmwf-datastores-client
-  version: 0.4.2
+  version: 0.5.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -4111,14 +4425,14 @@ package:
     python: '>=3.9'
     requests: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d957f10f516dcdeb9e382c91d771df12
-    sha256: c9e08781d043ab18ea83d2523a17d0bd763ae01274fb854c3024f2fee27aaecf
+    md5: fc8b15af108a2fdb15ef04d12fbfe87d
+    sha256: 65143f563da904873fe3c69cdef3f9fb3b9501fb81d20b4d3ae89eab6ad6b6d3
   category: main
   optional: false
 - name: ecmwf-datastores-client
-  version: 0.4.2
+  version: 0.5.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4127,10 +4441,10 @@ package:
     python: '>=3.9'
     requests: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d957f10f516dcdeb9e382c91d771df12
-    sha256: c9e08781d043ab18ea83d2523a17d0bd763ae01274fb854c3024f2fee27aaecf
+    md5: fc8b15af108a2fdb15ef04d12fbfe87d
+    sha256: 65143f563da904873fe3c69cdef3f9fb3b9501fb81d20b4d3ae89eab6ad6b6d3
   category: main
   optional: false
 - name: eofs
@@ -4285,13 +4599,13 @@ package:
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_h8d4c64c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/esmf-8.9.1-nompi_hdb11210_3.conda
   hash:
-    md5: f9f36d9d61c0c643308f9f6a842e5834
-    sha256: eb384411ec32da964a5ecc3dae5d64f5ee873ba6dcff7109a60317d6dc21f690
+    md5: 144faaa844d09420adacfde2f411f4e7
+    sha256: 2146c5e8819d177c8a216a01cb07c6deb9cf6e67c22e0219f2bf875a8cb30e70
   category: main
   optional: false
 - name: esmf
@@ -4299,19 +4613,17 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    mpich: '>=4.3.2,<5.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-    parallelio: '>=2.6.7,<2.6.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/esmf-8.9.1-mpi_mpich_h48b6a00_100.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/esmf-8.9.1-nompi_hf33107f_3.conda
   hash:
-    md5: c9c7b677392ea79f5f3afe27e51f5c68
-    sha256: ccc2a31360a76f01e5bf2c281ca92e3e97f407f15ce2aa8c8ce05892ac454fa6
+    md5: c74285020f2258dd510acf7b75e11917
+    sha256: e0bc9706cc0bce931c70b6c77d24077062ccab2401954b5d9018550592c66365
   category: main
   optional: false
 - name: esmf
@@ -4324,14 +4636,12 @@ package:
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    mpich: '>=4.3.2,<5.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
     netcdf-fortran: '>=4.6.2,<4.7.0a0'
-    parallelio: '>=2.6.7,<2.6.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/esmf-8.9.1-mpi_mpich_h88cd865_100.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/esmf-8.9.1-nompi_he3ea908_3.conda
   hash:
-    md5: a538c55ff4c97534dc3ce1ffac41692c
-    sha256: 7b0f911230a7fb2c4593c8b1eddb920a9ac7853950f56607b54aed214f88dec5
+    md5: ecc49bbfa1c4ad174623d615a01fd655
+    sha256: 81043fccd22651a9425ce15a4ea6ce30dacfc49371304aa7d5f26137025121e8
   category: main
   optional: false
 - name: esmpy
@@ -4377,7 +4687,7 @@ package:
   category: main
   optional: false
 - name: esmvalcore
-  version: 2.13.0
+  version: 2.14.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4389,15 +4699,15 @@ package:
     dask-jobqueue: ''
     distributed: ''
     esgf-pyclient: '>=0.3.1'
-    esmpy: ''
     esmvaltool-sample-data: ''
     filelock: ''
     fiona: ''
     fire: ''
     geopy: ''
     humanfriendly: ''
+    intake-esgf: '>=2025.10.22'
     intake-esm: ''
-    iris: '>=3.12.2'
+    iris: ''
     iris-esmf-regrid: '>=0.11.0'
     iris-grib: '>=0.20.0'
     isodate: '>=0.7.0'
@@ -4425,14 +4735,14 @@ package:
     xarray: ''
     yamale: ''
     zarr: '>3'
-  url: https://conda.anaconda.org/conda-forge/noarch/esmvalcore-2.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/esmvalcore-2.14.0-pyhc364b38_0.conda
   hash:
-    md5: 7246c0dc734db3281e090f26ecf2ba65
-    sha256: 3e2ecc97d4caa816d9cab8e9083b26e68491286b4969e99e449faf21c56bc328
+    md5: e4d7acc47b23802da419a8de8a49bbea
+    sha256: c4cc1a0c84900421add513684c79a80467ebfdf3d3c5a8a4f7859f48779a2cc3
   category: main
   optional: false
 - name: esmvalcore
-  version: 2.13.0
+  version: 2.14.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -4444,15 +4754,15 @@ package:
     dask-jobqueue: ''
     distributed: ''
     esgf-pyclient: '>=0.3.1'
-    esmpy: ''
     esmvaltool-sample-data: ''
     filelock: ''
     fiona: ''
     fire: ''
     geopy: ''
     humanfriendly: ''
+    intake-esgf: '>=2025.10.22'
     intake-esm: ''
-    iris: '>=3.12.2'
+    iris: ''
     iris-esmf-regrid: '>=0.11.0'
     iris-grib: '>=0.20.0'
     isodate: '>=0.7.0'
@@ -4470,7 +4780,7 @@ package:
     psutil: ''
     py-cordex: ''
     pybtex: ''
-    python: '>=3.11'
+    python: '>=3.12'
     python-stratify: '>=0.3'
     pyyaml: ''
     requests: ''
@@ -4480,14 +4790,14 @@ package:
     xarray: ''
     yamale: ''
     zarr: '>3'
-  url: https://conda.anaconda.org/conda-forge/noarch/esmvalcore-2.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/esmvalcore-2.14.0-pyhc364b38_0.conda
   hash:
-    md5: 7246c0dc734db3281e090f26ecf2ba65
-    sha256: 3e2ecc97d4caa816d9cab8e9083b26e68491286b4969e99e449faf21c56bc328
+    md5: e4d7acc47b23802da419a8de8a49bbea
+    sha256: c4cc1a0c84900421add513684c79a80467ebfdf3d3c5a8a4f7859f48779a2cc3
   category: main
   optional: false
 - name: esmvalcore
-  version: 2.13.0
+  version: 2.14.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4499,15 +4809,15 @@ package:
     dask-jobqueue: ''
     distributed: ''
     esgf-pyclient: '>=0.3.1'
-    esmpy: ''
     esmvaltool-sample-data: ''
     filelock: ''
     fiona: ''
     fire: ''
     geopy: ''
     humanfriendly: ''
+    intake-esgf: '>=2025.10.22'
     intake-esm: ''
-    iris: '>=3.12.2'
+    iris: ''
     iris-esmf-regrid: '>=0.11.0'
     iris-grib: '>=0.20.0'
     isodate: '>=0.7.0'
@@ -4525,7 +4835,7 @@ package:
     psutil: ''
     py-cordex: ''
     pybtex: ''
-    python: '>=3.11'
+    python: '>=3.12'
     python-stratify: '>=0.3'
     pyyaml: ''
     requests: ''
@@ -4535,14 +4845,14 @@ package:
     xarray: ''
     yamale: ''
     zarr: '>3'
-  url: https://conda.anaconda.org/conda-forge/noarch/esmvalcore-2.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/esmvalcore-2.14.0-pyhc364b38_0.conda
   hash:
-    md5: 7246c0dc734db3281e090f26ecf2ba65
-    sha256: 3e2ecc97d4caa816d9cab8e9083b26e68491286b4969e99e449faf21c56bc328
+    md5: e4d7acc47b23802da419a8de8a49bbea
+    sha256: c4cc1a0c84900421add513684c79a80467ebfdf3d3c5a8a4f7859f48779a2cc3
   category: main
   optional: false
 - name: esmvaltool-python
-  version: 2.13.0
+  version: 2.14.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4561,7 +4871,7 @@ package:
     ecmwf-api-client: ''
     eofs: ''
     esmpy: ''
-    esmvalcore: 2.13.*
+    esmvalcore: '>=2.14.0'
     fiona: ''
     fire: ''
     fsspec: ''
@@ -4579,7 +4889,7 @@ package:
     nc-time-axis: ''
     netcdf4: ''
     numba: ''
-    numpy: '!=1.24.3'
+    numpy: '>=2.0.0'
     openpyxl: ''
     packaging: ''
     pandas: ''
@@ -4593,7 +4903,6 @@ package:
     pyyaml: ''
     rasterio: '>=1.3.10'
     requests: ''
-    ruamel.yaml: ''
     scikit-image: ''
     scikit-learn: '>=1.4.0'
     scipy: ''
@@ -4605,14 +4914,14 @@ package:
     xgboost: '>1.6.1'
     xlsxwriter: ''
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/esmvaltool-python-2.13.0-pyhcf101f3_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/esmvaltool-python-2.14.0-pyhc364b38_0.conda
   hash:
-    md5: 206949d59b7a6bc7e2b4704bc6f56c86
-    sha256: 9617b430abf1e2b12db8ef37e3f7c9fedba92028da6150261b912b3e38d35225
+    md5: 26923a84f0a36849b8fc681023f41b34
+    sha256: 2ea7260745c54869ce9032e7e9fc684a8e829d5062fceda7a72f7f31d35e8a6f
   category: main
   optional: false
 - name: esmvaltool-python
-  version: 2.13.0
+  version: 2.14.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -4631,7 +4940,7 @@ package:
     ecmwf-api-client: ''
     eofs: ''
     esmpy: ''
-    esmvalcore: 2.13.*
+    esmvalcore: '>=2.14.0'
     fiona: ''
     fire: ''
     fsspec: ''
@@ -4649,7 +4958,7 @@ package:
     nc-time-axis: ''
     netcdf4: ''
     numba: ''
-    numpy: '!=1.24.3'
+    numpy: '>=2.0.0'
     openpyxl: ''
     packaging: ''
     pandas: ''
@@ -4657,13 +4966,12 @@ package:
     prov: ''
     pyproj: '>=2.1'
     pys2index: '>=0.1.5'
-    python: '>=3.11'
+    python: '>=3.12'
     python-cdo: ''
     python-dateutil: ''
     pyyaml: ''
     rasterio: '>=1.3.10'
     requests: ''
-    ruamel.yaml: ''
     scikit-image: ''
     scikit-learn: '>=1.4.0'
     scipy: ''
@@ -4675,14 +4983,14 @@ package:
     xgboost: '>1.6.1'
     xlsxwriter: ''
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/esmvaltool-python-2.13.0-pyhcf101f3_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/esmvaltool-python-2.14.0-pyhc364b38_0.conda
   hash:
-    md5: 206949d59b7a6bc7e2b4704bc6f56c86
-    sha256: 9617b430abf1e2b12db8ef37e3f7c9fedba92028da6150261b912b3e38d35225
+    md5: 26923a84f0a36849b8fc681023f41b34
+    sha256: 2ea7260745c54869ce9032e7e9fc684a8e829d5062fceda7a72f7f31d35e8a6f
   category: main
   optional: false
 - name: esmvaltool-python
-  version: 2.13.0
+  version: 2.14.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4701,7 +5009,7 @@ package:
     ecmwf-api-client: ''
     eofs: ''
     esmpy: ''
-    esmvalcore: 2.13.*
+    esmvalcore: '>=2.14.0'
     fiona: ''
     fire: ''
     fsspec: ''
@@ -4719,7 +5027,7 @@ package:
     nc-time-axis: ''
     netcdf4: ''
     numba: ''
-    numpy: '!=1.24.3'
+    numpy: '>=2.0.0'
     openpyxl: ''
     packaging: ''
     pandas: ''
@@ -4727,13 +5035,12 @@ package:
     prov: ''
     pyproj: '>=2.1'
     pys2index: '>=0.1.5'
-    python: '>=3.11'
+    python: '>=3.12'
     python-cdo: ''
     python-dateutil: ''
     pyyaml: ''
     rasterio: '>=1.3.10'
     requests: ''
-    ruamel.yaml: ''
     scikit-image: ''
     scikit-learn: '>=1.4.0'
     scipy: ''
@@ -4745,10 +5052,10 @@ package:
     xgboost: '>1.6.1'
     xlsxwriter: ''
     zarr: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/esmvaltool-python-2.13.0-pyhcf101f3_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/esmvaltool-python-2.14.0-pyhc364b38_0.conda
   hash:
-    md5: 206949d59b7a6bc7e2b4704bc6f56c86
-    sha256: 9617b430abf1e2b12db8ef37e3f7c9fedba92028da6150261b912b3e38d35225
+    md5: 26923a84f0a36849b8fc681023f41b34
+    sha256: 2ea7260745c54869ce9032e7e9fc684a8e829d5062fceda7a72f7f31d35e8a6f
   category: main
   optional: false
 - name: esmvaltool-sample-data
@@ -4908,83 +5215,170 @@ package:
   category: main
   optional: false
 - name: expat
-  version: 2.7.3
+  version: 2.8.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libexpat: 2.7.3
+    libexpat: 2.8.0
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.7.3-hecca717_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.8.0-hecca717_0.conda
   hash:
-    md5: c81f6fa1865526f5ab1e6b669b3ee877
-    sha256: c5d573e6831fb41177fb5ae0f1ee09caed55a868ec9887bc80ccc22c3e57b9b4
+    md5: 992e529e407c9d67d50be1d7543fde4c
+    sha256: ca4dc1da00a8aaa56c1088e7f45f1859ecea6f75874e67584f1af6e5cf8179f8
   category: main
   optional: false
 - name: expat
-  version: 2.7.3
+  version: 2.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libexpat: 2.7.3
-  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.7.3-heffb93a_0.conda
+    __osx: '>=11.0'
+    libexpat: 2.8.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.8.0-hcc62823_0.conda
   hash:
-    md5: 84e2a6d95d3a63f3971da8f7b810c7a7
-    sha256: 3a43defa87a48a77e46700302e6298967c14dfdaa326d26e7431ab6da3d6060f
+    md5: aac1a2404877c651fa14b89a6b738b0d
+    sha256: d4b2c29f10f46d27a6636f13649496574e7b777561b24c04bc5de8e15437268a
   category: main
   optional: false
 - name: expat
-  version: 2.7.3
+  version: 2.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libexpat: 2.7.3
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.7.3-haf25636_0.conda
+    libexpat: 2.8.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.8.0-hf6b4638_0.conda
   hash:
-    md5: 884f1698556805bc43c42e80c9c19f3d
-    sha256: 43175c9c1f8a259776a215fe2a77c6a29cf79cc47ee1a98f5267ae47f904c9c8
+    md5: 90f3b6fa818b07e9402d5ee89f3892d5
+    sha256: 9f8657c32bcff353b218b1bd7369de34c0534dc5a461630b296265e65e94e2d8
   category: main
   optional: false
-- name: fastprogress
-  version: 1.0.3
+- name: fastcore
+  version: 1.12.44
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.0.3-pyhd8ed1ab_1.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fastcore-1.12.44-pyhcf101f3_0.conda
   hash:
-    md5: a1f997959ce49fe4d554a8ae6d3ef494
-    sha256: f8e8319c9fd9e11752c3efcd8ae98c07ea04afea389bb2e87414c8ed3bc73ff5
+    md5: 470e668e2cdd1e01cdcd94bc6eee018e
+    sha256: d0ac4051494d880d7768398219566d13a81152dfa60871d128c001226658f8c3
   category: main
   optional: false
-- name: fastprogress
-  version: 1.0.3
+- name: fastcore
+  version: 1.12.44
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.0.3-pyhd8ed1ab_1.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastcore-1.12.44-pyhcf101f3_0.conda
   hash:
-    md5: a1f997959ce49fe4d554a8ae6d3ef494
-    sha256: f8e8319c9fd9e11752c3efcd8ae98c07ea04afea389bb2e87414c8ed3bc73ff5
+    md5: 470e668e2cdd1e01cdcd94bc6eee018e
+    sha256: d0ac4051494d880d7768398219566d13a81152dfa60871d128c001226658f8c3
   category: main
   optional: false
-- name: fastprogress
-  version: 1.0.3
+- name: fastcore
+  version: 1.12.44
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.0.3-pyhd8ed1ab_1.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastcore-1.12.44-pyhcf101f3_0.conda
   hash:
-    md5: a1f997959ce49fe4d554a8ae6d3ef494
-    sha256: f8e8319c9fd9e11752c3efcd8ae98c07ea04afea389bb2e87414c8ed3bc73ff5
+    md5: 470e668e2cdd1e01cdcd94bc6eee018e
+    sha256: d0ac4051494d880d7768398219566d13a81152dfa60871d128c001226658f8c3
+  category: main
+  optional: false
+- name: fastlite
+  version: 0.2.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    apswutils: '>=0.1.2'
+    fastcore: '>=1.7.1'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fastlite-0.2.3-pyhcf101f3_0.conda
+  hash:
+    md5: b103c9bbb54df351522ff468dfbf10e4
+    sha256: 93ea05c4012ddbe233d6a6b42162ca7687a010df1ce1fb6e52f89fb57e827814
+  category: main
+  optional: false
+- name: fastlite
+  version: 0.2.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    apswutils: '>=0.1.2'
+    fastcore: '>=1.7.1'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastlite-0.2.3-pyhcf101f3_0.conda
+  hash:
+    md5: b103c9bbb54df351522ff468dfbf10e4
+    sha256: 93ea05c4012ddbe233d6a6b42162ca7687a010df1ce1fb6e52f89fb57e827814
+  category: main
+  optional: false
+- name: fastlite
+  version: 0.2.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    apswutils: '>=0.1.2'
+    fastcore: '>=1.7.1'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastlite-0.2.3-pyhcf101f3_0.conda
+  hash:
+    md5: b103c9bbb54df351522ff468dfbf10e4
+    sha256: 93ea05c4012ddbe233d6a6b42162ca7687a010df1ce1fb6e52f89fb57e827814
+  category: main
+  optional: false
+- name: fastprogress
+  version: 1.1.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    fastcore: '>=1.10.0'
+    ipython: ''
+    python: '>=3.10'
+    python-fasthtml: '>=0.12.34'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4d9db96a9e4540ea5337efd7d9801759
+    sha256: 6643cf7578d5ef2b230ecc242b88ff6f4970488ae18d57a3eddcd81b0195c807
+  category: main
+  optional: false
+- name: fastprogress
+  version: 1.1.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    fastcore: '>=1.10.0'
+    ipython: ''
+    python: '>=3.10'
+    python-fasthtml: '>=0.12.34'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4d9db96a9e4540ea5337efd7d9801759
+    sha256: 6643cf7578d5ef2b230ecc242b88ff6f4970488ae18d57a3eddcd81b0195c807
+  category: main
+  optional: false
+- name: fastprogress
+  version: 1.1.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    fastcore: '>=1.10.0'
+    ipython: ''
+    python: '>=3.10'
+    python-fasthtml: '>=0.12.34'
+  url: https://conda.anaconda.org/conda-forge/noarch/fastprogress-1.1.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4d9db96a9e4540ea5337efd7d9801759
+    sha256: 6643cf7578d5ef2b230ecc242b88ff6f4970488ae18d57a3eddcd81b0195c807
   category: main
   optional: false
 - name: fftw
-  version: 3.3.10
+  version: 3.3.11
   manager: conda
   platform: linux-64
   dependencies:
@@ -4993,78 +5387,78 @@ package:
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.10-nompi_h3b011a4_111.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.11-nompi_h3b011a4_100.conda
   hash:
-    md5: f6612d7b30fdd5b5db1c8c39313f9787
-    sha256: c29a9196c344620267287d6cd931f6defda13874a25f9547fc153a12f3377ade
+    md5: 0717f4eb3d18259358a1fa77edb18917
+    sha256: 6fd5d681fba20adaca771f138ac52dbf0a52e0dc2ac31b9ce7406068d102a9a7
   category: main
   optional: false
 - name: fftw
-  version: 3.3.10
+  version: 3.3.11
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     libgfortran: ''
-    libgfortran5: '>=15.2.0'
+    libgfortran5: '>=14.3.0'
     llvm-openmp: '>=19.1.7'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fftw-3.3.10-nompi_h871bbb0_111.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fftw-3.3.11-nompi_h54214ab_100.conda
   hash:
-    md5: 01af7710bd32c6792ac074cd81497c56
-    sha256: 6528a1c0108662e6e4db3be0d053d83c45edabe453e935eac08d04d2f654e66c
+    md5: 5174eb59171c77781c90fbff9eaf5c89
+    sha256: c234b8f1be5b630236675a006172edd768ca2685fbf0713ec007f3d373f5ee27
   category: main
   optional: false
 - name: fftw
-  version: 3.3.10
+  version: 3.3.11
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
     libgfortran: ''
-    libgfortran5: '>=15.2.0'
+    libgfortran5: '>=14.3.0'
     llvm-openmp: '>=19.1.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fftw-3.3.10-nompi_hea23c72_111.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fftw-3.3.11-nompi_haf1500d_100.conda
   hash:
-    md5: 037c36cc8b8720d1019e3968a96ac7cc
-    sha256: ea23a6fae642040958441ab0e6159459a3cae1d968024b7c269b8be22bbc6b67
+    md5: 58628fdc0c614982f1dafd2116916288
+    sha256: fc6c507d7c68db156d6c8c5f6a79ca6b34c2a4c0c6222d8d4ecd0e4b97d3fd5e
   category: main
   optional: false
 - name: filelock
-  version: 3.20.3
+  version: 3.29.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2cfaaccf085c133a477f0a7a8657afe9
-    sha256: 8b90dc21f00167a7e58abb5141a140bdb31a7c5734fe1361b5f98f4a4183fd32
+    md5: 8fa8358d022a3a9bd101384a808044c6
+    sha256: 6b471a18372bbd52bdf32fc965f71de3bc1b5219418b8e6b3875a67a7b08c483
   category: main
   optional: false
 - name: filelock
-  version: 3.20.3
+  version: 3.29.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2cfaaccf085c133a477f0a7a8657afe9
-    sha256: 8b90dc21f00167a7e58abb5141a140bdb31a7c5734fe1361b5f98f4a4183fd32
+    md5: 8fa8358d022a3a9bd101384a808044c6
+    sha256: 6b471a18372bbd52bdf32fc965f71de3bc1b5219418b8e6b3875a67a7b08c483
   category: main
   optional: false
 - name: filelock
-  version: 3.20.3
+  version: 3.29.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2cfaaccf085c133a477f0a7a8657afe9
-    sha256: 8b90dc21f00167a7e58abb5141a140bdb31a7c5734fe1361b5f98f4a4183fd32
+    md5: 8fa8358d022a3a9bd101384a808044c6
+    sha256: 6b471a18372bbd52bdf32fc965f71de3bc1b5219418b8e6b3875a67a7b08c483
   category: main
   optional: false
 - name: findlibs
@@ -5342,50 +5736,53 @@ package:
   category: main
   optional: false
 - name: fontconfig
-  version: 2.15.0
+  version: 2.17.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
-    libgcc: '>=13'
-    libuuid: '>=2.38.1,<3.0a0'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.1'
+    libfreetype6: '>=2.14.1'
+    libgcc: '>=14'
+    libuuid: '>=2.41.3,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
   hash:
-    md5: 8f5b0b297b59e1ac160ad4beec99dbee
-    sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+    md5: 867127763fbe935bab59815b6e0b7b5c
+    sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
   category: main
   optional: false
 - name: fontconfig
-  version: 2.15.0
+  version: 2.17.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    freetype: '>=2.12.1,<3.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
+    __osx: '>=11.0'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.1'
+    libfreetype6: '>=2.14.1'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.15.0-h37eeddb_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.17.1-h7a4440b_0.conda
   hash:
-    md5: 84ccec5ee37eb03dd352db0a3f89ada3
-    sha256: 61a9aa1d2dd115ffc1ab372966dc8b1ac7b69870e6b1744641da276b31ea5c0b
+    md5: 4646a20e8bbb54903d6b8e631ceb550d
+    sha256: a972a114e618891bb50e50d8b13f5accb0085847f3aab1cf208e4552c1ab9c24
   category: main
   optional: false
 - name: fontconfig
-  version: 2.15.0
+  version: 2.17.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    freetype: '>=2.12.1,<3.0a0'
-    libexpat: '>=2.6.3,<3.0a0'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.1'
+    libfreetype6: '>=2.14.1'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.17.1-h2b252f5_0.conda
   hash:
-    md5: 7b29f48742cea5d1ccb5edd839cb5621
-    sha256: f79d3d816fafbd6a2b0f75ebc3251a30d3294b08af9bb747194121f5efa364bc
+    md5: d06ae1a11b46cc4c74177ecd28de7c7a
+    sha256: 851e9c778bfc54645dcab7038c0383445cbebf16f6bb2d3f62ce422b1605385a
   category: main
   optional: false
 - name: fonts-conda-ecosystem
@@ -5470,7 +5867,7 @@ package:
   category: main
   optional: false
 - name: fonttools
-  version: 4.61.1
+  version: 4.62.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -5480,30 +5877,30 @@ package:
     munkres: ''
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.61.1-py313h3dea7bd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.62.1-py313h3dea7bd_0.conda
   hash:
-    md5: c0f36dfbb130da4f6ce2df31f6b25ea8
-    sha256: 97f225199e6e5dfb93f551087c0951fee92db2d29a9dcb6a0346d66bff06fea4
+    md5: 98082dfa338d9f0dca885e4865c69a20
+    sha256: 45fbd480b4bece6a2eb674ba87390e75d5b06b2114c8f57210e7ca0d19e2509e
   category: main
   optional: false
 - name: fonttools
-  version: 4.61.1
+  version: 4.62.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     brotli: ''
     munkres: ''
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.61.1-py313h0f4d31d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.62.1-py313h035b7d0_0.conda
   hash:
-    md5: 77978c974cba250d6ee95a4c29aad08e
-    sha256: 5375b893af274c09b265e65af8ff49016e0d23c8e03509d830be09eda46585e9
+    md5: 85eab9ef1ebe3937ab86d5e488c27f71
+    sha256: 0d48d71e9ed6d7cb6754e979b4342c0f903773764ba92be74a48526572c1840b
   category: main
   optional: false
 - name: fonttools
-  version: 4.61.1
+  version: 4.62.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5512,10 +5909,10 @@ package:
     munkres: ''
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.61.1-py313h7d74516_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.62.1-py313h65a2061_0.conda
   hash:
-    md5: 894eb0c3e9a17643906a6da3209bf045
-    sha256: 52d4aacd7c154adff1f0e86609bf1b0e63b7049c947c4df1e78eedb9f2913091
+    md5: c188e37e2a1d41ef35f4d35031fb39ed
+    sha256: e9fd806e7c34039468202755e642e5ab24d259dfedf21d4339ad0878556babf5
   category: main
   optional: false
 - name: freeglut
@@ -5523,57 +5920,61 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.16,<2.0.0a0'
-    xorg-libx11: '>=1.8.9,<2.0a0'
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxfixes: ''
-    xorg-libxi: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libgl: '>=1.7.0,<2.0a0'
+    libglu: '>=9.0.3,<9.1.0a0'
+    libstdcxx: '>=14'
+    libxcb: '>=1.17.0,<2.0a0'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+    xorg-libxau: '>=1.0.12,<2.0a0'
+    xorg-libxext: '>=1.3.7,<2.0a0'
+    xorg-libxfixes: '>=6.0.2,<7.0a0'
+    xorg-libxi: '>=1.8.2,<2.0a0'
+    xorg-libxxf86vm: '>=1.1.7,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-h215f996_4.conda
   hash:
-    md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
-    sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
+    md5: b39dccf5af984bcb68ee2aa0f3213ea6
+    sha256: f94040a0d7c449038811097e145f223bd3b2ab4c5181870c6e27e1b9dd777d48
   category: main
   optional: false
 - name: freetype
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: linux-64
   dependencies:
-    libfreetype: 2.14.1
-    libfreetype6: 2.14.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+    libfreetype: 2.14.3
+    libfreetype6: 2.14.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
   hash:
-    md5: 4afc585cd97ba8a23809406cd8a9eda8
-    sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
+    md5: 8462b5322567212beeb025f3519fb3e2
+    sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
   category: main
   optional: false
 - name: freetype
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: osx-64
   dependencies:
-    libfreetype: 2.14.1
-    libfreetype6: 2.14.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.1-h694c41f_0.conda
+    libfreetype: 2.14.3
+    libfreetype6: 2.14.3
+  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.3-h694c41f_0.conda
   hash:
-    md5: ca641fdf8b7803f4b7212b6d66375930
-    sha256: 9f8282510db291496e89618fc66a58a1124fe7a6276fbd57ed18c602ce2576e9
+    md5: 6ab1403cc6cb284d56d0464f19251075
+    sha256: 5ddd46a88a0b6483e3dec52cabb62414504c94ee0e77369a4717f61a656c535a
   category: main
   optional: false
 - name: freetype
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libfreetype: 2.14.1
-    libfreetype6: 2.14.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.1-hce30654_0.conda
+    libfreetype: 2.14.3
+    libfreetype6: 2.14.3
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_0.conda
   hash:
-    md5: 1ec9a1ee7a2c9339774ad9bb6fe6caec
-    sha256: 14427aecd72e973a73d5f9dfd0e40b6bc3791d253de09b7bf233f6a9a190fd17
+    md5: 6dcc75ba2e04c555e881b72793d3282f
+    sha256: 5952bd9db12207a18a112e8924aa2ce8c2f9d57b62584d58a97d2f6afe1ea324
   category: main
   optional: false
 - name: freexl
@@ -5706,145 +6107,145 @@ package:
   category: main
   optional: false
 - name: fsspec
-  version: 2026.1.0
+  version: 2026.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1daaf94a304a27ba3446a306235a37ea
-    sha256: bfba6c280366f48b00a6a7036988fc2bc3fea5ac1d8303152c9da69d72a22936
+    md5: 2c11aa96ea85ced419de710c1c3a78ff
+    sha256: 079701b4ff3b317a1a158cabd48cf2b856b8b8d3ef44f152809d9acf20cc8e10
   category: main
   optional: false
 - name: fsspec
-  version: 2026.1.0
+  version: 2026.4.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1daaf94a304a27ba3446a306235a37ea
-    sha256: bfba6c280366f48b00a6a7036988fc2bc3fea5ac1d8303152c9da69d72a22936
+    md5: 2c11aa96ea85ced419de710c1c3a78ff
+    sha256: 079701b4ff3b317a1a158cabd48cf2b856b8b8d3ef44f152809d9acf20cc8e10
   category: main
   optional: false
 - name: fsspec
-  version: 2026.1.0
+  version: 2026.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1daaf94a304a27ba3446a306235a37ea
-    sha256: bfba6c280366f48b00a6a7036988fc2bc3fea5ac1d8303152c9da69d72a22936
+    md5: 2c11aa96ea85ced419de710c1c3a78ff
+    sha256: 079701b4ff3b317a1a158cabd48cf2b856b8b8d3ef44f152809d9acf20cc8e10
   category: main
   optional: false
 - name: gdal
-  version: 3.12.1
+  version: 3.12.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libgdal-core: 3.12.1.*
+    libgdal-core: 3.12.3.*
     libstdcxx: '>=14'
     numpy: '>=1.23,<3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.1-py313h60f829d_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.3-py313h1ee8c46_4.conda
   hash:
-    md5: 54cd7771b48c0fb0fa1811a46f5c6379
-    sha256: 1b2565c410d895b16c1e6a19e0c89ea346a4ce7e0c34c61c1b9eef4fa8b96db9
+    md5: 2add63ec2eba071e325401de22c687a5
+    sha256: fee40e86c51a9b9875818e77043b516072b1edb0775fb32c66f5232d4899ee7e
   category: main
   optional: false
 - name: gdal
-  version: 3.12.1
+  version: 3.12.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-    libgdal-core: 3.12.1.*
+    libgdal-core: 3.12.3.*
     numpy: '>=1.23,<3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.1-py313h5e27e46_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.3-py313h369b93d_3.conda
   hash:
-    md5: 1748d32d1061436d6060543ec152d7b8
-    sha256: 4fb9c08cb045d07668c80e4e2f6fe76f4a1d4dea9779a6062ac5df0d4f985e53
+    md5: 64843099c1dbabd67f17e9a9f36502bf
+    sha256: 3f2838dcdceeaaab3ad42cf9b887c2f383abf4dfd7321f7afa888211f6079dac
   category: main
   optional: false
 - name: gdal
-  version: 3.12.1
+  version: 3.12.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    libgdal-core: 3.12.1.*
+    libgdal-core: 3.12.3.*
     numpy: '>=1.23,<3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.1-py313h83041ef_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.3-py313h543f8f2_4.conda
   hash:
-    md5: 7f2df22b33766ea117597eb5717c2e35
-    sha256: 9d157168350210325b09efe9973e7835015d3a7ca0321bea8f8977cc09c64dd7
+    md5: 3369059d0a1666f7ce8e88f24c5c95b9
+    sha256: 0eb26ffc8603cbed97ba1fcc052f82f729381d428acdc4c71e96860350a4effa
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.4
+  version: 2.44.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libglib: '>=2.86.0,<3.0a0'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libpng: '>=1.6.50,<1.7.0a0'
+    libglib: '>=2.86.4,<3.0a0'
+    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    liblzma: '>=5.8.2,<6.0a0'
+    libpng: '>=1.6.56,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.6-h2b0a6b4_0.conda
   hash:
-    md5: c379d67c686fb83475c1a6ed41cc41ff
-    sha256: f47222f58839bcc77c15f11a8814c1d8cb8080c5ca6ba83398a12b640fd3c85c
+    md5: 7892f39a39ed39591a89a28eba03e987
+    sha256: c5594497f0646e9079705b3199dbb2d5b13c48173cf110000fa1c8818e2b3e0c
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.4
+  version: 2.44.6
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libglib: '>=2.86.0,<3.0a0'
+    __osx: '>=11.0'
+    libglib: '>=2.86.4,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libpng: '>=1.6.50,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    liblzma: '>=5.8.2,<6.0a0'
+    libpng: '>=1.6.56,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.44.4-h07555a4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.44.6-hae309b2_0.conda
   hash:
-    md5: bb9e17e69566ded88342156e58de3f87
-    sha256: f1d85cf18cba23f9fac3c01f5aaf0a8d44822b531d3fc132f81e7cf25f589a4e
+    md5: 5f0f81650af65aa247f6fbc25ebcbdd4
+    sha256: 27a223201fd86f85284c7e218121ac9ecf0be16e0a73eea42776701c8c90c50b
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.4
+  version: 2.44.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libglib: '>=2.86.0,<3.0a0'
+    libglib: '>=2.86.4,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libpng: '>=1.6.50,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    liblzma: '>=5.8.2,<6.0a0'
+    libpng: '>=1.6.56,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.4-h7542897_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.6-h4e57454_0.conda
   hash:
-    md5: 0b349c0400357e701cf2fa69371e5d39
-    sha256: 1164ba63360736439c6e50f2d390e93f04df86901e7711de41072a32d9b8bfc9
+    md5: e67ebd2f639f46e52af8531622fa6051
+    sha256: 07cbba4e12430de35ea608eb3006cf1f7f63832c4f89a081cd6f3872944c1aa6
   category: main
   optional: false
 - name: geographiclib
@@ -6037,45 +6438,96 @@ package:
   category: main
   optional: false
 - name: glib-tools
-  version: 2.86.3
+  version: 2.88.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    libffi: ''
     libgcc: '>=14'
-    libglib: 2.86.3
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.3-hf516916_0.conda
+    libglib: ==2.88.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-h040f060_0.conda
   hash:
-    md5: fd6acbf37b40cbe919450fa58309fbe1
-    sha256: 591e948c56f40e7fbcbd63362814736d9c9a3f0cd3cf4284002eff0bec7abe4e
+    md5: 55e7cea32f68a173635bcd4ea3d6e02c
+    sha256: edeabb898f3ab893473f9eb6ec0a072337f6e81a5bc4f91ac1387aae40698058
   category: main
   optional: false
 - name: glib-tools
-  version: 2.86.3
+  version: 2.88.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libglib: 2.86.3
+    __osx: '>=11.0'
+    libffi: ''
+    libglib: ==2.88.1
     libintl: '>=0.25.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.86.3-h8650975_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/glib-tools-2.88.1-h264c857_0.conda
   hash:
-    md5: 16ce4f8eddf8ad9233631f79404a4267
-    sha256: f8563491a04c1aa2ccc2d730382949797316674d1c9bdde42f023924081e8295
+    md5: 74811df31fc7f9c2a593334571fbb0f0
+    sha256: ceffdb70d6bc49f4eb2367af05b34dc28722a3eb8ade6556b72ab5e5d2ff1219
   category: main
   optional: false
 - name: glib-tools
-  version: 2.86.3
+  version: 2.88.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libglib: 2.86.3
+    libffi: ''
+    libglib: ==2.88.1
     libintl: '>=0.25.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.86.3-hb9d6e3a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.1-h281fc19_0.conda
   hash:
-    md5: 07cf8a6e2d3f9c25ee3f123bf955b34b
-    sha256: a4630914a543d7ae6bdce031f63da32af039d4d7d76b445b4f5d09f0b6e4ddcb
+    md5: eade437f383ab6b108cf710a6b6d1337
+    sha256: a0149cf09d3fa1f17f5ed6b560a6a2ceb8d6db1eaa0288a0e671d4b63ae1a76a
+  category: main
+  optional: false
+- name: globus-sdk
+  version: 3.65.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: '>=3.3.1,!=3.4.0'
+    pyjwt: '>=2.0.0,<3.0.0'
+    python: '>=3.10'
+    requests: '>=2.19.1,<3.0.0'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/globus-sdk-3.65.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 61efb574b08a3fafa0980d5981b2732d
+    sha256: 5becaa8da08b0533fff9b4ff4b6e74d8630effc9580630a546c22e3c36654148
+  category: main
+  optional: false
+- name: globus-sdk
+  version: 3.65.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cryptography: '>=3.3.1,!=3.4.0'
+    pyjwt: '>=2.0.0,<3.0.0'
+    python: '>=3.10'
+    requests: '>=2.19.1,<3.0.0'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/globus-sdk-3.65.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 61efb574b08a3fafa0980d5981b2732d
+    sha256: 5becaa8da08b0533fff9b4ff4b6e74d8630effc9580630a546c22e3c36654148
+  category: main
+  optional: false
+- name: globus-sdk
+  version: 3.65.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cryptography: '>=3.3.1,!=3.4.0'
+    pyjwt: '>=2.0.0,<3.0.0'
+    python: '>=3.10'
+    requests: '>=2.19.1,<3.0.0'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/globus-sdk-3.65.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 61efb574b08a3fafa0980d5981b2732d
+    sha256: 5becaa8da08b0533fff9b4ff4b6e74d8630effc9580630a546c22e3c36654148
   category: main
   optional: false
 - name: glog
@@ -6286,7 +6738,7 @@ package:
   category: main
   optional: false
 - name: gtk3
-  version: 3.24.43
+  version: 3.24.52
   manager: conda
   platform: linux-64
   dependencies:
@@ -6295,66 +6747,70 @@ package:
     atk-1.0: '>=2.38.0'
     cairo: '>=1.18.4,<2.0a0'
     epoxy: '>=1.5.10,<1.6.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
+    fontconfig: '>=2.17.1,<3.0a0'
     fonts-conda-ecosystem: ''
     fribidi: '>=1.0.16,<2.0a0'
-    gdk-pixbuf: '>=2.44.4,<3.0a0'
+    gdk-pixbuf: '>=2.44.5,<3.0a0'
     glib-tools: ''
-    harfbuzz: '>=11.5.1'
+    harfbuzz: '>=13.2.1'
     hicolor-icon-theme: ''
     libcups: '>=2.3.3,<3.0a0'
-    libexpat: '>=2.7.1,<3.0a0'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.2'
+    libfreetype6: '>=2.14.2'
     libgcc: '>=14'
-    libglib: '>=2.86.0,<3.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxkbcommon: '>=1.12.2,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libglib: '>=2.86.4,<3.0a0'
+    liblzma: '>=5.8.2,<6.0a0'
+    libxkbcommon: '>=1.13.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     pango: '>=1.56.4,<2.0a0'
-    wayland: '>=1.24.0,<2.0a0'
-    xorg-libx11: '>=1.8.12,<2.0a0'
-    xorg-libxcomposite: '>=0.4.6,<1.0a0'
+    wayland: '>=1.25.0,<2.0a0'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+    xorg-libxcomposite: '>=0.4.7,<1.0a0'
     xorg-libxcursor: '>=1.2.3,<2.0a0'
     xorg-libxdamage: '>=1.1.6,<2.0a0'
-    xorg-libxext: '>=1.3.6,<2.0a0'
+    xorg-libxext: '>=1.3.7,<2.0a0'
     xorg-libxfixes: '>=6.0.2,<7.0a0'
     xorg-libxi: '>=1.8.2,<2.0a0'
-    xorg-libxinerama: '>=1.1.5,<1.2.0a0'
-    xorg-libxrandr: '>=1.5.4,<2.0a0'
+    xorg-libxinerama: '>=1.1.6,<1.2.0a0'
+    xorg-libxrandr: '>=1.5.5,<2.0a0'
     xorg-libxrender: '>=0.9.12,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h993cebd_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.52-ha5ea40c_0.conda
   hash:
-    md5: f9f33c65b20e6a61f21714785e3613ec
-    sha256: 004688fbb2c479b200a6d85ef38c3129fcd4ce13537b7ee2371d962b372761c1
+    md5: bcaea22d85999a4f17918acfab877e61
+    sha256: c6bb4f06331bcb0a566d84e0f0fad7af4b9035a03b13e2d5ecfaf13be57e6e10
   category: main
   optional: false
 - name: gtk3
-  version: 3.24.43
+  version: 3.24.52
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     atk-1.0: '>=2.38.0'
     cairo: '>=1.18.4,<2.0a0'
     epoxy: '>=1.5.10,<1.6.0a0'
     fribidi: '>=1.0.16,<2.0a0'
-    gdk-pixbuf: '>=2.44.4,<3.0a0'
+    gdk-pixbuf: '>=2.44.5,<3.0a0'
     glib-tools: ''
-    harfbuzz: '>=11.5.1'
+    harfbuzz: '>=13.2.1'
     hicolor-icon-theme: ''
-    libexpat: '>=2.7.1,<3.0a0'
-    libglib: '>=2.86.0,<3.0a0'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.2'
+    libfreetype6: '>=2.14.2'
+    libglib: '>=2.86.4,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    liblzma: '>=5.8.2,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.43-h5e629aa_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/gtk3-3.24.52-hf2d442a_0.conda
   hash:
-    md5: dbd0346e44fcbda7fe4f6eaf42597ef9
-    sha256: 5911ee39ababbd29794f958b129fd0254eb106ea4b4f750a03306c251bb20bae
+    md5: 76be17e448c23c6d1c99a56c15b15925
+    sha256: c69a03b1eec71c0a764658d67f81eaf9a316276ae900b107cd8d77766bc13cf8
   category: main
   optional: false
 - name: gtk3
-  version: 3.24.43
+  version: 3.24.52
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6363,20 +6819,22 @@ package:
     cairo: '>=1.18.4,<2.0a0'
     epoxy: '>=1.5.10,<1.6.0a0'
     fribidi: '>=1.0.16,<2.0a0'
-    gdk-pixbuf: '>=2.44.4,<3.0a0'
+    gdk-pixbuf: '>=2.44.5,<3.0a0'
     glib-tools: ''
-    harfbuzz: '>=11.5.1'
+    harfbuzz: '>=13.2.1'
     hicolor-icon-theme: ''
-    libexpat: '>=2.7.1,<3.0a0'
-    libglib: '>=2.86.0,<3.0a0'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.2'
+    libfreetype6: '>=2.14.2'
+    libglib: '>=2.86.4,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    liblzma: '>=5.8.2,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.43-h5febe37_6.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk3-3.24.52-hc0f3e19_0.conda
   hash:
-    md5: a99f96906158ebae5e3c0904bcd45145
-    sha256: bd66a3325bf3ce63ada3bf12eaafcfe036698741ee4bb595e83e5fdd3dba9f3d
+    md5: 5557a2433b1339b8e536c264afea41ef
+    sha256: 26862a9898054b8552e55e609e5ce73c7ef1eb28bbe6fb87f0b9109d73cd09df
   category: main
   optional: false
 - name: gts
@@ -6417,6 +6875,45 @@ package:
   hash:
     md5: 21b4dd3098f63a74cf2aa9159cbef57d
     sha256: e0f8c7bc1b9ea62ded78ffa848e37771eeaaaf55b3146580513c7266862043ba
+  category: main
+  optional: false
+- name: h11
+  version: 0.16.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+  hash:
+    md5: b8993c19b0c32a2f7b66cbb58ca27069
+    sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
+  category: main
+  optional: false
+- name: h11
+  version: 0.16.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+  hash:
+    md5: b8993c19b0c32a2f7b66cbb58ca27069
+    sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
+  category: main
+  optional: false
+- name: h11
+  version: 0.16.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+  hash:
+    md5: b8993c19b0c32a2f7b66cbb58ca27069
+    sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
   category: main
   optional: false
 - name: h2
@@ -6461,165 +6958,68 @@ package:
     sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   category: main
   optional: false
-- name: h5netcdf
-  version: 1.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    h5py: ''
-    numpy: ''
-    packaging: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.8.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ca7f9ba8762d3e360e47917a10e23760
-    sha256: 5bf081c0f21a57fc84b5000d53f043d63638b77dcc2137f87511a4581838c9f6
-  category: main
-  optional: false
-- name: h5netcdf
-  version: 1.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    h5py: ''
-    numpy: ''
-    packaging: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.8.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ca7f9ba8762d3e360e47917a10e23760
-    sha256: 5bf081c0f21a57fc84b5000d53f043d63638b77dcc2137f87511a4581838c9f6
-  category: main
-  optional: false
-- name: h5netcdf
-  version: 1.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    h5py: ''
-    numpy: ''
-    packaging: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.8.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ca7f9ba8762d3e360e47917a10e23760
-    sha256: 5bf081c0f21a57fc84b5000d53f043d63638b77dcc2137f87511a4581838c9f6
-  category: main
-  optional: false
-- name: h5py
-  version: 3.15.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cached-property: ''
-    hdf5: '>=1.14.6,<1.14.7.0a0'
-    libgcc: '>=14'
-    numpy: '>=1.23,<3'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py313h253c126_101.conda
-  hash:
-    md5: 5d90c98527ecc832287115d57c121062
-    sha256: 2de2c63ad6e7483456f6ff359380df63edf32770c140ec08c904ff89b6ed3903
-  category: main
-  optional: false
-- name: h5py
-  version: 3.15.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    cached-property: ''
-    hdf5: '>=1.14.6,<1.14.7.0a0'
-    numpy: '>=1.23,<3'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py313h2a429bc_101.conda
-  hash:
-    md5: de9fd6ce4bb0957d1909069fad48aafb
-    sha256: 61343fbe32e8f665918f4e976bb0bcc217ed2ca2aab3f182f479f76ff15188b2
-  category: main
-  optional: false
-- name: h5py
-  version: 3.15.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cached-property: ''
-    hdf5: '>=1.14.6,<1.14.7.0a0'
-    numpy: '>=1.23,<3'
-    python: '>=3.13,<3.14.0a0'
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py313h7aa1c8b_101.conda
-  hash:
-    md5: af275e004ef52480fccdde18f4bdcd12
-    sha256: 72261e805d73e520417a1b0f659968ea410be925bda8e808bf1c78f1fb4270da
-  category: main
-  optional: false
 - name: harfbuzz
-  version: 12.3.2
+  version: 14.2.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.2,<79.0a0'
-    libexpat: '>=2.7.3,<3.0a0'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
+    icu: '>=78.3,<79.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.3,<3.0a0'
+    libglib: '>=2.86.4,<3.0a0'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
   hash:
-    md5: d170a70fc1d5c605fcebdf16851bd54a
-    sha256: 92015faf283f9c0a8109e2761042cd47ae7a4505e24af42a53bc3767cb249912
+    md5: e194f6a2f498f0c7b1e6498bd0b12645
+    sha256: 232c95b56d16d33d8256026a3b1ad34f7f9a75c179d388854be0fd624ddba9e3
   category: main
   optional: false
 - name: harfbuzz
-  version: 12.3.2
+  version: 14.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.2,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libcxx: '>=19'
-    libexpat: '>=2.7.3,<3.0a0'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
-    libglib: '>=2.86.3,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-12.3.2-h8b84c26_0.conda
+    libexpat: '>=2.7.5,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.86.4,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-14.2.0-hf0bc557_0.conda
   hash:
-    md5: 8f6cf0a04e0de00a0df87dd452a512ce
-    sha256: aac46d01ee8ee8e7ca0e8faa69ad4babcffcc7100b5fdbd7ca3b20c8963900c7
+    md5: e7fd9056aa65f6dac6558b39c332c907
+    sha256: ab070b8961569fbdd3e414bee89887f1ca97522c73afb0fa2f055ad775c7dd20
   category: main
   optional: false
 - name: harfbuzz
-  version: 12.3.2
+  version: 14.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
     graphite2: '>=1.3.14,<2.0a0'
-    icu: '>=78.2,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libcxx: '>=19'
-    libexpat: '>=2.7.3,<3.0a0'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
-    libglib: '>=2.86.3,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-12.3.2-h3103d1b_0.conda
+    libexpat: '>=2.7.5,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.86.4,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.0-h3103d1b_0.conda
   hash:
-    md5: d0af4858d81c0c7abddc6b71fd8c0340
-    sha256: f68c6704610396012124a3d86b087581174c2cf7968a46b6d95ba84cd87063c7
+    md5: ea75b03886981362d93bb4708ee14811
+    sha256: 40ccd6a589c60a4cedb2f9921dfa60ea5845b5ce323477b042b6f90218b239f6
   category: main
   optional: false
 - name: hdf4
@@ -6671,18 +7071,18 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libaec: '>=1.1.4,<2.0a0'
-    libcurl: '>=8.18.0,<9.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h1b119a7_105.conda
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_109.conda
   hash:
-    md5: d58cd79121dd51128f2a5dab44edf1ea
-    sha256: aa85acd07b8f60d1760c6b3fa91dd8402572766e763f3989c759ecd266ed8e9f
+    md5: c0ca97fff3fff46f837c69efedf838b1
+    sha256: 9d2ea00599e2874b295baa7e719c79823ed61fec885e25c55e7dad666fb1cf50
   category: main
   optional: false
 - name: hdf5
@@ -6690,19 +7090,18 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libaec: '>=1.1.4,<2.0a0'
-    libcurl: '>=8.18.0,<9.0a0'
+    __osx: '>=11.0'
+    libaec: '>=1.1.5,<2.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libzlib: '>=1.3.1,<2.0a0'
-    mpich: '>=4.3.2,<5.0a0'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-mpi_mpich_hd52a628_5.conda
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_109.conda
   hash:
-    md5: 80f3f23c6d324382fa333f42301029c9
-    sha256: 4c57888616c6ac95aae79c5a23dc08463c22c3ffe9d864541210f901142b53ef
+    md5: 030598e3ee8d7d842918a9ebfa54ff92
+    sha256: 1e12111fbde6d1754038487d639339d54d32e22b8e6266d217c9b1d6183c532c
   category: main
   optional: false
 - name: hdf5
@@ -6711,18 +7110,17 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libaec: '>=1.1.4,<2.0a0'
-    libcurl: '>=8.18.0,<9.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libzlib: '>=1.3.1,<2.0a0'
-    mpich: '>=4.3.2,<5.0a0'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-mpi_mpich_h05d5b64_5.conda
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_109.conda
   hash:
-    md5: 86cc67e06d68ed6b7f401b9d3f15039b
-    sha256: fd817bbfe26ada92caa4dcb36d9fd0635c65017504a552ad80d1bb212af1e374
+    md5: fa70cb619977ab679abfe4b4c4202a35
+    sha256: 5c49a8d636c4cd712652012a4a6d96188cff26032eb0c56a80e428c121b1596f
   category: main
   optional: false
 - name: hicolor-icon-theme
@@ -6730,10 +7128,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
   hash:
-    md5: bbf6f174dcd3254e19a2f5d2295ce808
-    sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
+    md5: 129e404c5b001f3ef5581316971e3ea0
+    sha256: 6d7e6e1286cb521059fe69696705100a03b006efb914ffe82a2ae97ecbae66b7
   category: main
   optional: false
 - name: hicolor-icon-theme
@@ -6741,10 +7139,10 @@ package:
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/hicolor-icon-theme-0.17-h694c41f_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-64/hicolor-icon-theme-0.17-h694c41f_3.conda
   hash:
-    md5: f64218f19d9a441e80343cea13be1afb
-    sha256: a5cb0c03d731bfb09b4262a3afdeae33bef98bc73972f1bd6b7e3fcd240bea41
+    md5: 690e5077aaccf8d280a4284d7c9ec6b4
+    sha256: 3321e8d2c2198ac796b0ae800473173ade528b49f84b6c6e4e112a9704698b41
   category: main
   optional: false
 - name: hicolor-icon-theme
@@ -6752,10 +7150,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
   hash:
-    md5: 237b05b7eb284d7eebc3c5d93f5e4bca
-    sha256: 286e33fb452f61133a3a61d002890235d1d1378554218ab063d6870416440281
+    md5: cfb39109ac5fa8601eb595d66d5bf156
+    sha256: 46a4958f2f916c5938f2a6dc0709f78b175ece42f601d79a04e0276d55d25d07
   category: main
   optional: false
 - name: hpack
@@ -6792,6 +7190,105 @@ package:
   hash:
     md5: 0a802cb9888dd14eeefc611f05c40b6e
     sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
+  category: main
+  optional: false
+- name: httpcore
+  version: 1.0.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: '>=4.0,<5.0'
+    certifi: ''
+    h11: '>=0.16'
+    h2: '>=3,<5'
+    python: ''
+    sniffio: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+  hash:
+    md5: 4f14640d58e2cc0aa0819d9d8ba125bb
+    sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
+  category: main
+  optional: false
+- name: httpcore
+  version: 1.0.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    anyio: '>=4.0,<5.0'
+    certifi: ''
+    h11: '>=0.16'
+    h2: '>=3,<5'
+    python: '>=3.9'
+    sniffio: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+  hash:
+    md5: 4f14640d58e2cc0aa0819d9d8ba125bb
+    sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
+  category: main
+  optional: false
+- name: httpcore
+  version: 1.0.9
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    anyio: '>=4.0,<5.0'
+    certifi: ''
+    h11: '>=0.16'
+    h2: '>=3,<5'
+    python: '>=3.9'
+    sniffio: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+  hash:
+    md5: 4f14640d58e2cc0aa0819d9d8ba125bb
+    sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
+  category: main
+  optional: false
+- name: httpx
+  version: 0.28.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: ''
+    certifi: ''
+    httpcore: 1.*
+    idna: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: d6989ead454181f4f9bc987d3dc4e285
+    sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  category: main
+  optional: false
+- name: httpx
+  version: 0.28.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    anyio: ''
+    certifi: ''
+    httpcore: 1.*
+    idna: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: d6989ead454181f4f9bc987d3dc4e285
+    sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  category: main
+  optional: false
+- name: httpx
+  version: 0.28.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    anyio: ''
+    certifi: ''
+    httpcore: 1.*
+    idna: ''
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: d6989ead454181f4f9bc987d3dc4e285
+    sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
   category: main
   optional: false
 - name: humanfriendly
@@ -6870,81 +7367,81 @@ package:
   category: main
   optional: false
 - name: icu
-  version: '78.2'
+  version: '78.3'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   hash:
-    md5: 186a18e3ba246eccfc7cff00cd19a870
-    sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
+    md5: c80d8a3b84358cb967fa81e7075fbc8a
+    sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   category: main
   optional: false
 - name: icu
-  version: '78.2'
+  version: '78.3'
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.2-h14c5de8_0.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
   hash:
-    md5: 30334add4de016489b731c6662511684
-    sha256: f3066beae7fe3002f09c8a412cdf1819f49a2c9a485f720ec11664330cf9f1fe
+    md5: 627eca44e62e2b665eeec57a984a7f00
+    sha256: 1294117122d55246bb83ad5b589e2a031aacdf2d0b1f99fd338aa4394f881735
   category: main
   optional: false
 - name: icu
-  version: '78.2'
+  version: '78.3'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
   hash:
-    md5: 1e93aca311da0210e660d2247812fa02
-    sha256: d4cefbca587429d1192509edc52c88de52bc96c2447771ddc1f8bee928aed5ef
+    md5: f1182c91c0de31a7abd40cedf6a5ebef
+    sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
   category: main
   optional: false
 - name: idna
-  version: '3.11'
+  version: '3.13'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
   hash:
-    md5: 53abe63df7e10a6ba605dc5f9f961d36
-    sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
+    md5: fb7130c190f9b4ec91219840a05ba3ac
+    sha256: 9ab620e6f64bb67737bd7bc1ad6f480770124e304c6710617aba7fe60b089f48
   category: main
   optional: false
 - name: idna
-  version: '3.11'
+  version: '3.13'
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
   hash:
-    md5: 53abe63df7e10a6ba605dc5f9f961d36
-    sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
+    md5: fb7130c190f9b4ec91219840a05ba3ac
+    sha256: 9ab620e6f64bb67737bd7bc1ad6f480770124e304c6710617aba7fe60b089f48
   category: main
   optional: false
 - name: idna
-  version: '3.11'
+  version: '3.13'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.13-pyhcf101f3_0.conda
   hash:
-    md5: 53abe63df7e10a6ba605dc5f9f961d36
-    sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
+    md5: fb7130c190f9b4ec91219840a05ba3ac
+    sha256: 9ab620e6f64bb67737bd7bc1ad6f480770124e304c6710617aba7fe60b089f48
   category: main
   optional: false
 - name: imagecodecs
-  version: 2026.1.14
+  version: 2026.3.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -6952,92 +7449,92 @@ package:
     blosc: '>=1.21.6,<2.0a0'
     brunsli: '>=0.1,<1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    c-blosc2: '>=2.22.0,<2.23.0a0'
-    charls: '>=2.4.2,<2.5.0a0'
+    c-blosc2: '>=3.0.1,<3.1.0a0'
+    charls: '>=2.4.3,<2.5.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     jxrlib: '>=1.1,<1.2.0a0'
-    lcms2: '>=2.18,<3.0a0'
-    lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.4,<2.0a0'
-    libavif16: '>=1.3.0,<2.0a0'
+    lcms2: '>=2.19,<3.0a0'
+    lerc: '>=4.1.0,<5.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libavif16: '>=1.4.1,<2.0a0'
     libbrotlicommon: '>=1.2.0,<1.3.0a0'
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libdeflate: '>=1.25,<1.26.0a0'
     libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libjxl: '>=0.11,<0.12.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    libjxl: '>=0.11,<1.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libstdcxx: '>=14'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     libzopfli: '>=1.0.3,<1.1.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     numpy: '>=1.23,<3'
     openjpeg: '>=2.5.4,<3.0a0'
-    openjph: '>=0.26.0,<0.27.0a0'
+    openjph: '>=0.27.0,<0.28.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     snappy: '>=1.2.2,<1.3.0a0'
     zfp: '>=1.0.1,<2.0a0'
-    zlib-ng: '>=2.3.2,<2.4.0a0'
+    zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.1.14-py313h3815048_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.3.6-py313h7b635f6_3.conda
   hash:
-    md5: 9aedc235ebef4ac9d63f6cdb5a2caffa
-    sha256: af467ff2027ffd26fd57d39b6b70056bd310579219f6e1e7f4ca2a315839c72d
+    md5: 4d223cfbc49635112171e179c6cc5df8
+    sha256: 92b7ea0ac48c13a0ee85141dc8c8ff33d3ad650dcd69dce57da28add9c554049
   category: main
   optional: false
 - name: imagecodecs
-  version: 2026.1.14
+  version: 2026.3.6
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     blosc: '>=1.21.6,<2.0a0'
     brunsli: '>=0.1,<1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    c-blosc2: '>=2.22.0,<2.23.0a0'
-    charls: '>=2.4.2,<2.5.0a0'
+    c-blosc2: '>=3.0.1,<3.1.0a0'
+    charls: '>=2.4.3,<2.5.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     jxrlib: '>=1.1,<1.2.0a0'
-    lcms2: '>=2.18,<3.0a0'
-    lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.4,<2.0a0'
-    libavif16: '>=1.3.0,<2.0a0'
+    lcms2: '>=2.19,<3.0a0'
+    lerc: '>=4.1.0,<5.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libavif16: '>=1.4.1,<2.0a0'
     libbrotlicommon: '>=1.2.0,<1.3.0a0'
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcxx: '>=19'
     libdeflate: '>=1.25,<1.26.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libjxl: '>=0.11,<0.12.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    libjxl: '>=0.11,<1.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     libzopfli: '>=1.0.3,<1.1.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     numpy: '>=1.23,<3'
     openjpeg: '>=2.5.4,<3.0a0'
-    openjph: '>=0.26.0,<0.27.0a0'
+    openjph: '>=0.27.0,<0.28.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     snappy: '>=1.2.2,<1.3.0a0'
     zfp: '>=1.0.1,<2.0a0'
-    zlib-ng: '>=2.3.2,<2.4.0a0'
+    zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/imagecodecs-2026.1.14-py313h3b6009c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/imagecodecs-2026.3.6-py313had26ed6_3.conda
   hash:
-    md5: 8fbe76ff777f2bdeba23bf1d07748ac8
-    sha256: 24a5bbf53ca9f0dfa3926403b0672815d331c5d5b2787e23f70eb962a56f0070
+    md5: f5126aa1203668962a2f8f1e232d371f
+    sha256: 11f9058bc9305eefa8f8d9cf2b0faeb607a2592cf285a923a456afcf6b134181
   category: main
   optional: false
 - name: imagecodecs
-  version: 2026.1.14
+  version: 2026.3.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7045,41 +7542,41 @@ package:
     blosc: '>=1.21.6,<2.0a0'
     brunsli: '>=0.1,<1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    c-blosc2: '>=2.22.0,<2.23.0a0'
-    charls: '>=2.4.2,<2.5.0a0'
+    c-blosc2: '>=3.0.1,<3.1.0a0'
+    charls: '>=2.4.3,<2.5.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     jxrlib: '>=1.1,<1.2.0a0'
-    lcms2: '>=2.18,<3.0a0'
-    lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.4,<2.0a0'
-    libavif16: '>=1.3.0,<2.0a0'
+    lcms2: '>=2.19,<3.0a0'
+    lerc: '>=4.1.0,<5.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libavif16: '>=1.4.1,<2.0a0'
     libbrotlicommon: '>=1.2.0,<1.3.0a0'
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcxx: '>=19'
     libdeflate: '>=1.25,<1.26.0a0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
-    libjxl: '>=0.11,<0.12.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    libjxl: '>=0.11,<1.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     libzopfli: '>=1.0.3,<1.1.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     numpy: '>=1.23,<3'
     openjpeg: '>=2.5.4,<3.0a0'
-    openjph: '>=0.26.0,<0.27.0a0'
+    openjph: '>=0.27.0,<0.28.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     snappy: '>=1.2.2,<1.3.0a0'
     zfp: '>=1.0.1,<2.0a0'
-    zlib-ng: '>=2.3.2,<2.4.0a0'
+    zlib-ng: '>=2.3.3,<2.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/imagecodecs-2026.1.14-py313hb9776e6_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/imagecodecs-2026.3.6-py313h42a24b6_3.conda
   hash:
-    md5: 125e95b7a7cf11fa84c00fa5567295d1
-    sha256: aa3debce20d429ec59d1640ccefdab7a44efea3e61ee6987efc5f52e303da519
+    md5: c33a23b2b90f08ad981cd345604f8eef
+    sha256: da3bfbe2c57f3fc9751d9fc9fd406c1fb170dc1f7190bd2d4fc82697386bedb1
   category: main
   optional: false
 - name: imagehash
@@ -7173,42 +7670,42 @@ package:
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.7.0
+  version: 8.8.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
     zipp: '>=3.20'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
   hash:
-    md5: 63ccfdc3a3ce25b027b8767eb722fca8
-    sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
+    md5: 080594bf4493e6bae2607e65390c520a
+    sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.7.0
+  version: 8.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     zipp: '>=3.20'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
   hash:
-    md5: 63ccfdc3a3ce25b027b8767eb722fca8
-    sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
+    md5: 080594bf4493e6bae2607e65390c520a
+    sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.7.0
+  version: 8.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
+    python: '>=3.10'
     zipp: '>=3.20'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
   hash:
-    md5: 63ccfdc3a3ce25b027b8767eb722fca8
-    sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
+    md5: 080594bf4493e6bae2607e65390c520a
+    sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
   category: main
   optional: false
 - name: iniconfig
@@ -7248,51 +7745,123 @@ package:
   category: main
   optional: false
 - name: intake
-  version: 2.0.8
+  version: 2.0.9
   manager: conda
   platform: linux-64
   dependencies:
     fsspec: '>=2023.0.0'
     networkx: ''
     platformdirs: ''
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.9-pyhd8ed1ab_0.conda
   hash:
-    md5: bcd8513a2f3b9b8d83fc7f04302cf800
-    sha256: 54b81550dbacdedb8aa272859233f7455bdd89e89fcb154beb7022f61af3af4a
+    md5: e8501489d6720634f0a165ebf32d42d1
+    sha256: a857279d40df4dc61d99dc3685754cbe62eccc96e48134c346d4304e3eea1c9b
   category: main
   optional: false
 - name: intake
-  version: 2.0.8
+  version: 2.0.9
   manager: conda
   platform: osx-64
   dependencies:
     fsspec: '>=2023.0.0'
     networkx: ''
     platformdirs: ''
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.9-pyhd8ed1ab_0.conda
   hash:
-    md5: bcd8513a2f3b9b8d83fc7f04302cf800
-    sha256: 54b81550dbacdedb8aa272859233f7455bdd89e89fcb154beb7022f61af3af4a
+    md5: e8501489d6720634f0a165ebf32d42d1
+    sha256: a857279d40df4dc61d99dc3685754cbe62eccc96e48134c346d4304e3eea1c9b
   category: main
   optional: false
 - name: intake
-  version: 2.0.8
+  version: 2.0.9
   manager: conda
   platform: osx-arm64
   dependencies:
     fsspec: '>=2023.0.0'
     networkx: ''
     platformdirs: ''
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-2.0.9-pyhd8ed1ab_0.conda
   hash:
-    md5: bcd8513a2f3b9b8d83fc7f04302cf800
-    sha256: 54b81550dbacdedb8aa272859233f7455bdd89e89fcb154beb7022f61af3af4a
+    md5: e8501489d6720634f0a165ebf32d42d1
+    sha256: a857279d40df4dc61d99dc3685754cbe62eccc96e48134c346d4304e3eea1c9b
+  category: main
+  optional: false
+- name: intake-esgf
+  version: 2026.4.28
+  manager: conda
+  platform: linux-64
+  dependencies:
+    dask: ''
+    globus-sdk: <4
+    netcdf4: ''
+    numpy: ''
+    pandas: ''
+    py-multihash: ''
+    pystac-client: ''
+    python: '>=3.12'
+    pyyaml: ''
+    requests: ''
+    requests-cache: ''
+    tqdm: ''
+    xarray: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-esgf-2026.4.28-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38580d81bd25088d2d1cebc873339cb5
+    sha256: ce2a87ba54445c33dff9928f7e2a7ea7fae29628a77a716f5ad104c4ec2cd34c
+  category: main
+  optional: false
+- name: intake-esgf
+  version: 2026.4.28
+  manager: conda
+  platform: osx-64
+  dependencies:
+    dask: ''
+    globus-sdk: <4
+    netcdf4: ''
+    numpy: ''
+    pandas: ''
+    py-multihash: ''
+    pystac-client: ''
+    python: '>=3.12'
+    pyyaml: ''
+    requests: ''
+    requests-cache: ''
+    tqdm: ''
+    xarray: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-esgf-2026.4.28-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38580d81bd25088d2d1cebc873339cb5
+    sha256: ce2a87ba54445c33dff9928f7e2a7ea7fae29628a77a716f5ad104c4ec2cd34c
+  category: main
+  optional: false
+- name: intake-esgf
+  version: 2026.4.28
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    dask: ''
+    globus-sdk: <4
+    netcdf4: ''
+    numpy: ''
+    pandas: ''
+    py-multihash: ''
+    pystac-client: ''
+    python: '>=3.12'
+    pyyaml: ''
+    requests: ''
+    requests-cache: ''
+    tqdm: ''
+    xarray: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/intake-esgf-2026.4.28-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38580d81bd25088d2d1cebc873339cb5
+    sha256: ce2a87ba54445c33dff9928f7e2a7ea7fae29628a77a716f5ad104c4ec2cd34c
   category: main
   optional: false
 - name: intake-esm
@@ -7377,72 +7946,75 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 9.9.0
+  version: 9.13.0
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-    decorator: '>=4.3.2'
+    decorator: '>=5.1.0'
     ipython_pygments_lexers: '>=1.0.0'
-    jedi: '>=0.18.1'
-    matplotlib-inline: '>=0.1.5'
-    pexpect: '>4.3'
+    jedi: '>=0.18.2'
+    matplotlib-inline: '>=0.1.6'
+    pexpect: '>4.6'
     prompt-toolkit: '>=3.0.41,<3.1.0'
-    pygments: '>=2.11.0'
+    psutil: '>=7'
+    pygments: '>=2.14.0'
     python: ''
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.9.0-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
   hash:
-    md5: 8481978caa2f108e6ddbf8008a345546
-    sha256: 4ff1733c59b72cf0c8ed9ddb6e948e99fc6b79b76989282c0c7a46aab56e6176
+    md5: 73e9657cd19605740d21efb14d8d0cb9
+    sha256: a0af49948a1842dfd15a0b0b2fd56c94ddbd07e07a6c8b4bc70d43015eafaff0
   category: main
   optional: false
 - name: ipython
-  version: 9.9.0
+  version: 9.13.0
   manager: conda
   platform: osx-64
   dependencies:
     __unix: ''
-    decorator: '>=4.3.2'
+    decorator: '>=5.1.0'
     ipython_pygments_lexers: '>=1.0.0'
-    jedi: '>=0.18.1'
-    matplotlib-inline: '>=0.1.5'
-    pexpect: '>4.3'
+    jedi: '>=0.18.2'
+    matplotlib-inline: '>=0.1.6'
+    pexpect: '>4.6'
     prompt-toolkit: '>=3.0.41,<3.1.0'
-    pygments: '>=2.11.0'
+    psutil: '>=7'
+    pygments: '>=2.14.0'
     python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.9.0-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
   hash:
-    md5: 8481978caa2f108e6ddbf8008a345546
-    sha256: 4ff1733c59b72cf0c8ed9ddb6e948e99fc6b79b76989282c0c7a46aab56e6176
+    md5: 73e9657cd19605740d21efb14d8d0cb9
+    sha256: a0af49948a1842dfd15a0b0b2fd56c94ddbd07e07a6c8b4bc70d43015eafaff0
   category: main
   optional: false
 - name: ipython
-  version: 9.9.0
+  version: 9.13.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-    decorator: '>=4.3.2'
+    decorator: '>=5.1.0'
     ipython_pygments_lexers: '>=1.0.0'
-    jedi: '>=0.18.1'
-    matplotlib-inline: '>=0.1.5'
-    pexpect: '>4.3'
+    jedi: '>=0.18.2'
+    matplotlib-inline: '>=0.1.6'
+    pexpect: '>4.6'
     prompt-toolkit: '>=3.0.41,<3.1.0'
-    pygments: '>=2.11.0'
+    psutil: '>=7'
+    pygments: '>=2.14.0'
     python: '>=3.11'
     stack_data: '>=0.6.0'
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.9.0-pyh53cf698_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
   hash:
-    md5: 8481978caa2f108e6ddbf8008a345546
-    sha256: 4ff1733c59b72cf0c8ed9ddb6e948e99fc6b79b76989282c0c7a46aab56e6176
+    md5: 73e9657cd19605740d21efb14d8d0cb9
+    sha256: a0af49948a1842dfd15a0b0b2fd56c94ddbd07e07a6c8b4bc70d43015eafaff0
   category: main
   optional: false
 - name: ipython_pygments_lexers
@@ -7485,7 +8057,7 @@ package:
   category: main
   optional: false
 - name: iris
-  version: 3.14.1
+  version: 3.15.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7498,18 +8070,18 @@ package:
     netcdf4: ''
     numpy: '>=1.24,!=1.24.3'
     pyproj: ''
-    python: '>=3.11'
+    python: '>=3.12'
     python-xxhash: ''
     scipy: ''
     shapely: '!=1.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-3.14.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-3.15.0-pyha770c72_0.conda
   hash:
-    md5: 0b6f532e907ce57be6905bd6d44fbe71
-    sha256: 8c2b3b526f4c5ea584c76e921c81f4aca607b05218b2671f5745085716c9b3bc
+    md5: bfe6588cbbd6e2e97e9439f95de02af8
+    sha256: 720a53111cdc2d3ce3b6b8597fec2b0955b20287265803da3f231aa16e42c949
   category: main
   optional: false
 - name: iris
-  version: 3.14.1
+  version: 3.15.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -7522,18 +8094,18 @@ package:
     netcdf4: ''
     numpy: '>=1.24,!=1.24.3'
     pyproj: ''
-    python: '>=3.11'
+    python: '>=3.12'
     python-xxhash: ''
     scipy: ''
     shapely: '!=1.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-3.14.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-3.15.0-pyha770c72_0.conda
   hash:
-    md5: 0b6f532e907ce57be6905bd6d44fbe71
-    sha256: 8c2b3b526f4c5ea584c76e921c81f4aca607b05218b2671f5745085716c9b3bc
+    md5: bfe6588cbbd6e2e97e9439f95de02af8
+    sha256: 720a53111cdc2d3ce3b6b8597fec2b0955b20287265803da3f231aa16e42c949
   category: main
   optional: false
 - name: iris
-  version: 3.14.1
+  version: 3.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7546,18 +8118,18 @@ package:
     netcdf4: ''
     numpy: '>=1.24,!=1.24.3'
     pyproj: ''
-    python: '>=3.11'
+    python: '>=3.12'
     python-xxhash: ''
     scipy: ''
     shapely: '!=1.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-3.14.1-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-3.15.0-pyha770c72_0.conda
   hash:
-    md5: 0b6f532e907ce57be6905bd6d44fbe71
-    sha256: 8c2b3b526f4c5ea584c76e921c81f4aca607b05218b2671f5745085716c9b3bc
+    md5: bfe6588cbbd6e2e97e9439f95de02af8
+    sha256: 720a53111cdc2d3ce3b6b8597fec2b0955b20287265803da3f231aa16e42c949
   category: main
   optional: false
 - name: iris-esmf-regrid
-  version: 0.13.1
+  version: 0.14.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7567,16 +8139,16 @@ package:
     esmpy: '>=7.0'
     iris: '>=3'
     numpy: '>=1.14'
-    python: '>=3.11'
+    python: '>=3.12'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-esmf-regrid-0.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-esmf-regrid-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 3d62ebf0e004d713c6bc18f1fe421c14
-    sha256: ac7b19c9b64445a2bd86a67777284f816bdd32d00bd7c0eddd691447a5706b6a
+    md5: ea5bf82d692b17313a0cdb3f259b8c21
+    sha256: 31202f3d8944c9de59e1ec7aae83d3283535737c7c6d03051962b5c0918d1642
   category: main
   optional: false
 - name: iris-esmf-regrid
-  version: 0.13.1
+  version: 0.14.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -7586,16 +8158,16 @@ package:
     esmpy: '>=7.0'
     iris: '>=3'
     numpy: '>=1.14'
-    python: '>=3.11'
+    python: '>=3.12'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-esmf-regrid-0.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-esmf-regrid-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 3d62ebf0e004d713c6bc18f1fe421c14
-    sha256: ac7b19c9b64445a2bd86a67777284f816bdd32d00bd7c0eddd691447a5706b6a
+    md5: ea5bf82d692b17313a0cdb3f259b8c21
+    sha256: 31202f3d8944c9de59e1ec7aae83d3283535737c7c6d03051962b5c0918d1642
   category: main
   optional: false
 - name: iris-esmf-regrid
-  version: 0.13.1
+  version: 0.14.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7605,57 +8177,57 @@ package:
     esmpy: '>=7.0'
     iris: '>=3'
     numpy: '>=1.14'
-    python: '>=3.11'
+    python: '>=3.12'
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-esmf-regrid-0.13.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-esmf-regrid-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 3d62ebf0e004d713c6bc18f1fe421c14
-    sha256: ac7b19c9b64445a2bd86a67777284f816bdd32d00bd7c0eddd691447a5706b6a
+    md5: ea5bf82d692b17313a0cdb3f259b8c21
+    sha256: 31202f3d8944c9de59e1ec7aae83d3283535737c7c6d03051962b5c0918d1642
   category: main
   optional: false
 - name: iris-grib
-  version: 0.21.0
+  version: 0.22.0
   manager: conda
   platform: linux-64
   dependencies:
     eccodes: '>=2.33'
-    iris: '>=3.0.2'
-    python: '>=3.10'
+    iris: '>=3.10'
+    python: '>=3.12'
     python-eccodes: '>=1.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-grib-0.21.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-grib-0.22.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d5a110459acc9669c58e5d516fc2e165
-    sha256: a6606814c73603ab0fe5da703a969c7c1b96dd9887d3aa8f827b6e07a4248dce
+    md5: 7d4ea402d5f65a97e88d49ba616ac196
+    sha256: bf8f91e2c90d6fc4f06a5ac01e33eed14e2b821370ceb2a4804bbdcdf430c42d
   category: main
   optional: false
 - name: iris-grib
-  version: 0.21.0
+  version: 0.22.0
   manager: conda
   platform: osx-64
   dependencies:
     eccodes: '>=2.33'
-    iris: '>=3.0.2'
-    python: '>=3.10'
+    iris: '>=3.10'
+    python: '>=3.12'
     python-eccodes: '>=1.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-grib-0.21.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-grib-0.22.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d5a110459acc9669c58e5d516fc2e165
-    sha256: a6606814c73603ab0fe5da703a969c7c1b96dd9887d3aa8f827b6e07a4248dce
+    md5: 7d4ea402d5f65a97e88d49ba616ac196
+    sha256: bf8f91e2c90d6fc4f06a5ac01e33eed14e2b821370ceb2a4804bbdcdf430c42d
   category: main
   optional: false
 - name: iris-grib
-  version: 0.21.0
+  version: 0.22.0
   manager: conda
   platform: osx-arm64
   dependencies:
     eccodes: '>=2.33'
-    iris: '>=3.0.2'
-    python: '>=3.10'
+    iris: '>=3.10'
+    python: '>=3.12'
     python-eccodes: '>=1.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/iris-grib-0.21.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/iris-grib-0.22.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d5a110459acc9669c58e5d516fc2e165
-    sha256: a6606814c73603ab0fe5da703a969c7c1b96dd9887d3aa8f827b6e07a4248dce
+    md5: 7d4ea402d5f65a97e88d49ba616ac196
+    sha256: bf8f91e2c90d6fc4f06a5ac01e33eed14e2b821370ceb2a4804bbdcdf430c42d
   category: main
   optional: false
 - name: isodate
@@ -7695,39 +8267,39 @@ package:
   category: main
   optional: false
 - name: itables
-  version: 2.6.2
+  version: 2.7.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/itables-2.6.2-pyh0398c0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/itables-2.7.3-pyhbbac1ac_0.conda
   hash:
-    md5: db8ef90c9c8bd18b61ccdb3afb5ca181
-    sha256: a531469820487a72971196aff77aa17b5a7fe9782767318e7cd2c842d1fd2619
+    md5: 20104f9459e0c1a912acbfe41cd01ccb
+    sha256: c8984abf0a6be730951552aed40662faed72f9865e88fb9b4247c91a6d920566
   category: main
   optional: false
 - name: itables
-  version: 2.6.2
+  version: 2.7.3
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/itables-2.6.2-pyh0398c0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/itables-2.7.3-pyhbbac1ac_0.conda
   hash:
-    md5: db8ef90c9c8bd18b61ccdb3afb5ca181
-    sha256: a531469820487a72971196aff77aa17b5a7fe9782767318e7cd2c842d1fd2619
+    md5: 20104f9459e0c1a912acbfe41cd01ccb
+    sha256: c8984abf0a6be730951552aed40662faed72f9865e88fb9b4247c91a6d920566
   category: main
   optional: false
 - name: itables
-  version: 2.6.2
+  version: 2.7.3
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/itables-2.6.2-pyh0398c0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/itables-2.7.3-pyhbbac1ac_0.conda
   hash:
-    md5: db8ef90c9c8bd18b61ccdb3afb5ca181
-    sha256: a531469820487a72971196aff77aa17b5a7fe9782767318e7cd2c842d1fd2619
+    md5: 20104f9459e0c1a912acbfe41cd01ccb
+    sha256: c8984abf0a6be730951552aed40662faed72f9865e88fb9b4247c91a6d920566
   category: main
   optional: false
 - name: itsdangerous
@@ -7767,45 +8339,47 @@ package:
   category: main
   optional: false
 - name: jasper
-  version: 4.2.8
+  version: 4.2.9
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     freeglut: '>=3.2.2,<4.0a0'
+    libexpat: '>=2.7.4,<3.0a0'
     libgcc: '>=14'
+    libgl: '>=1.7.0,<2.0a0'
     libglu: '>=9.0.3,<9.1.0a0'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.8-he3c4edf_0.conda
+    libjpeg-turbo: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.9-h1588d4d_1.conda
   hash:
-    md5: a04073db11c2c86c555fb088acc8f8c1
-    sha256: 0e919ec86d980901d8cbb665e91f5e9bddb5ff662178f25aed6d63f999fd9afc
+    md5: 115ecf05370670f93bc81a8c4f7fd57f
+    sha256: a6a9858eadb4c794b56a1c954c1d4f4b57d96c9fb87092dd46f5bff9b0697b35
   category: main
   optional: false
 - name: jasper
-  version: 4.2.8
+  version: 4.2.9
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.8-h9ce442b_0.conda
+    __osx: '>=11.0'
+    libjpeg-turbo: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.9-hbeb4536_1.conda
   hash:
-    md5: 155c61380cc98685f4d6237cb19c5f97
-    sha256: b095874f61125584d99b4f55a2bba3e4bd9aa61b2d2e4ab8d03372569f0ca01c
+    md5: ba331350354f69260f18733403411157
+    sha256: dc013823ea75791ec93889455bf64680db4f756111f9ea791f4336f002973dd2
   category: main
   optional: false
 - name: jasper
-  version: 4.2.8
+  version: 4.2.9
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libjpeg-turbo: '>=3.1.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.8-hc0e5025_0.conda
+    libjpeg-turbo: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.9-h7543a42_1.conda
   hash:
-    md5: 54d2328b8db98729ab21f60a4aba9f7c
-    sha256: 0d8a77e026a441c2c65616046a6ddcfffa42c5987bce1c51d352959653e2fb07
+    md5: e3f3a2a62fbaad99f327440dfd8a3ac3
+    sha256: 58bfd15b7426f99ca2b1854535d4ede1ca2a35be4f8c43c5e34b6ffdcfd7a5c8
   category: main
   optional: false
 - name: jedi
@@ -7997,7 +8571,7 @@ package:
   category: main
   optional: false
 - name: kerchunk
-  version: 0.2.9
+  version: 0.2.10
   manager: conda
   platform: linux-64
   dependencies:
@@ -8006,14 +8580,14 @@ package:
     python: '>=3.11'
     ujson: ''
     zarr: '>=3.0.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 1ac32c617d6029d926c38775db939e0a
-    sha256: c398236e08ba439835b87ba6f667a40071eeefbe87a266a8b553329213aa48f5
+    md5: 942b809ecbdbeb225e2e22592521f8e8
+    sha256: 9d8ed042bfde99c5c2c6c859fd0c9bce4137d42ea2033ce68aabd9c66564fbff
   category: main
   optional: false
 - name: kerchunk
-  version: 0.2.9
+  version: 0.2.10
   manager: conda
   platform: osx-64
   dependencies:
@@ -8022,14 +8596,14 @@ package:
     python: '>=3.11'
     ujson: ''
     zarr: '>=3.0.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 1ac32c617d6029d926c38775db939e0a
-    sha256: c398236e08ba439835b87ba6f667a40071eeefbe87a266a8b553329213aa48f5
+    md5: 942b809ecbdbeb225e2e22592521f8e8
+    sha256: 9d8ed042bfde99c5c2c6c859fd0c9bce4137d42ea2033ce68aabd9c66564fbff
   category: main
   optional: false
 - name: kerchunk
-  version: 0.2.9
+  version: 0.2.10
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -8038,10 +8612,10 @@ package:
     python: '>=3.11'
     ujson: ''
     zarr: '>=3.0.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 1ac32c617d6029d926c38775db939e0a
-    sha256: c398236e08ba439835b87ba6f667a40071eeefbe87a266a8b553329213aa48f5
+    md5: 942b809ecbdbeb225e2e22592521f8e8
+    sha256: 9d8ed042bfde99c5c2c6c859fd0c9bce4137d42ea2033ce68aabd9c66564fbff
   category: main
   optional: false
 - name: keyutils
@@ -8058,7 +8632,7 @@ package:
   category: main
   optional: false
 - name: kiwisolver
-  version: 1.4.9
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8067,29 +8641,29 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py313hc8edb43_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py313hc8edb43_0.conda
   hash:
-    md5: 3e0e65595330e26515e31b7fc6d933c7
-    sha256: 60d7d525db89401f88f5c91bdbb79d3afbf005e7d7c1326318659fa097607e51
+    md5: b81883b9dbf5069821c2fb09a8ba1407
+    sha256: 0447d2901639f295989c5ccba7b1c367ed78b216e0d2705327a8c8a87a31177e
   category: main
   optional: false
 - name: kiwisolver
-  version: 1.4.9
+  version: 1.5.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.9-py313ha1c5e85_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.5.0-py313h224b87c_0.conda
   hash:
-    md5: cadc416f7c960ce1436bb6cc8a0f75e4
-    sha256: 011e58aac5a2c0e22643b81339c3f35bff7ec52c46ef403ced227ac87aaab313
+    md5: 3370a484980e344984cb38c24d910ede
+    sha256: 72c8c0cf8ed9fa1058ed6a95e6a40d81dc48c2566c5c563915ff3c1f0d8a4f8e
   category: main
   optional: false
 - name: kiwisolver
-  version: 1.4.9
+  version: 1.5.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -8097,56 +8671,57 @@ package:
     libcxx: '>=19'
     python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.9-py313h7add70c_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.5.0-py313h2af2deb_0.conda
   hash:
-    md5: 9583687276aaa393e723f3b7970be69f
-    sha256: adc6b89070b6858b81fbe24dd034a73295e8fa9ccb68ed871bf04f1ed498f51c
+    md5: bd1e04d017f340e42431706402db8b02
+    sha256: b0ac975a7eb40638b1405c8092835c47222ce758eb26114afee50a8d1ce98569
   category: main
   optional: false
 - name: krb5
-  version: 1.21.3
+  version: 1.22.2
   manager: conda
   platform: linux-64
   dependencies:
-    keyutils: '>=1.6.1,<2.0a0'
-    libedit: '>=3.1.20191231,<4.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    keyutils: '>=1.6.3,<2.0a0'
+    libedit: '>=3.1.20250104,<4.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
   hash:
-    md5: 3f43953b7d3fb3aaa1d0d0723d91e368
-    sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+    md5: fb53fb07ce46a575c5d004bbc96032c2
+    sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
   category: main
   optional: false
 - name: krb5
-  version: 1.21.3
+  version: 1.22.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=16'
-    libedit: '>=3.1.20191231,<4.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+    libcxx: '>=19'
+    libedit: '>=3.1.20250104,<4.0a0'
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
   hash:
-    md5: d4765c524b1d91567886bde656fb514b
-    sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+    md5: e66e2c52d2fdddcf314ad750fb4ebb4a
+    sha256: df009385e8262c234c0dae9016540b86dad3d299f0d9366d08e327e8e7731634
   category: main
   optional: false
 - name: krb5
-  version: 1.21.3
+  version: 1.22.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-    libedit: '>=3.1.20191231,<4.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+    libcxx: '>=19'
+    libedit: '>=3.1.20250104,<4.0a0'
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
   hash:
-    md5: c6dc8a0fdec13a0565936655c33069a1
-    sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+    md5: e446e1822f4da8e5080a9de93474184d
+    sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
   category: main
   optional: false
 - name: latexcodec
@@ -8189,101 +8764,137 @@ package:
   category: main
   optional: false
 - name: lazy-loader
-  version: '0.4'
+  version: '0.5'
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: ''
     packaging: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
   hash:
-    md5: d10d9393680734a8febc4b362a4c94f2
-    sha256: d7ea986507090fff801604867ef8e79c8fda8ec21314ba27c032ab18df9c3411
+    md5: 75932da6f03a6bef32b70a51e991f6eb
+    sha256: 1a88069ac61d2756ccaf26a6c206ab4d56610fb054bd2fffb5df4cd0744ab78e
   category: main
   optional: false
 - name: lazy-loader
-  version: '0.4'
+  version: '0.5'
   manager: conda
   platform: osx-64
   dependencies:
-    importlib-metadata: ''
     packaging: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
   hash:
-    md5: d10d9393680734a8febc4b362a4c94f2
-    sha256: d7ea986507090fff801604867ef8e79c8fda8ec21314ba27c032ab18df9c3411
+    md5: 75932da6f03a6bef32b70a51e991f6eb
+    sha256: 1a88069ac61d2756ccaf26a6c206ab4d56610fb054bd2fffb5df4cd0744ab78e
   category: main
   optional: false
 - name: lazy-loader
-  version: '0.4'
+  version: '0.5'
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib-metadata: ''
     packaging: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
   hash:
-    md5: d10d9393680734a8febc4b362a4c94f2
-    sha256: d7ea986507090fff801604867ef8e79c8fda8ec21314ba27c032ab18df9c3411
+    md5: 75932da6f03a6bef32b70a51e991f6eb
+    sha256: 1a88069ac61d2756ccaf26a6c206ab4d56610fb054bd2fffb5df4cd0744ab78e
+  category: main
+  optional: false
+- name: lazy_loader
+  version: '0.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    lazy-loader: '0.5'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c8327180586e7b1cd8b6815fc8827f1
+    sha256: 42adb08ded0662114a3146627b24d2cd5eba3bfc3ed424374bac869cdc1745a9
+  category: main
+  optional: false
+- name: lazy_loader
+  version: '0.5'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    lazy-loader: '0.5'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c8327180586e7b1cd8b6815fc8827f1
+    sha256: 42adb08ded0662114a3146627b24d2cd5eba3bfc3ed424374bac869cdc1745a9
+  category: main
+  optional: false
+- name: lazy_loader
+  version: '0.5'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    lazy-loader: '0.5'
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c8327180586e7b1cd8b6815fc8827f1
+    sha256: 42adb08ded0662114a3146627b24d2cd5eba3bfc3ed424374bac869cdc1745a9
   category: main
   optional: false
 - name: lcms2
-  version: '2.18'
+  version: '2.19'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19-h0c24ade_0.conda
   hash:
-    md5: 6f2e2c8f58160147c4d1c6f4c14cbac4
-    sha256: 836ec4b895352110335b9fdcfa83a8dcdbe6c5fb7c06c4929130600caea91c0a
+    md5: f302dbf397ac82eaf9618575d0b5fe33
+    sha256: f1e982b63d505338ff7f9baee80a10360a025b7216deb5ab0fe1494d8ef3bebb
   category: main
   optional: false
 - name: lcms2
-  version: '2.18'
+  version: '2.19'
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    __osx: '>=11.0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.18-h90db99b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.19-h5ea7634_0.conda
   hash:
-    md5: 753acc10c7277f953f168890e5397c80
-    sha256: 3ec16c491425999a8461e1b7c98558060a4645a20cf4c9ac966103c724008cc2
+    md5: f05fc88b6b2480486c006a9bf04db0b7
+    sha256: 278d28a48ae4a679d104a3d557b9354718c7ea4e60391bf52c6e4678bc07c946
   category: main
   optional: false
 - name: lcms2
-  version: '2.18'
+  version: '2.19'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libjpeg-turbo: '>=3.1.2,<4.0a0'
+    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.18-hdfa7624_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.19-hdfa7624_0.conda
   hash:
-    md5: 6631a7bd2335bb9699b1dbc234b19784
-    sha256: d768da024ab74a4b30642401877fa914a68bdc238667f16b1ec2e0e98b2451a6
+    md5: 57baad99764cf6057227e50b11e2ec5b
+    sha256: fc3c54deb7c9b3738796d0db2a1cf673c0f34a13d5e9964633ca50b7d64a5f52
   category: main
   optional: false
 - name: ld_impl_linux-64
-  version: '2.45'
+  version: 2.45.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   hash:
-    md5: 3ec0aa5037d39b06554109a01e6fb0c6
-    sha256: 1027bd8aa0d5144e954e426ab6218fd5c14e54a98f571985675468b339c808ca
+    md5: 18335a698559cdbcd86150a48bf54ba6
+    sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   category: main
   optional: false
 - name: legacy-cgi
@@ -8323,43 +8934,43 @@ package:
   category: main
   optional: false
 - name: lerc
-  version: 4.0.0
+  version: 4.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   hash:
-    md5: 9344155d33912347b37f0ae6c410a835
-    sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
+    md5: a752488c68f2e7c456bcbd8f16eec275
+    sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   category: main
   optional: false
 - name: lerc
-  version: 4.0.0
+  version: 4.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hcca01a6_1.conda
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.1.0-h35c7297_0.conda
   hash:
-    md5: 21f765ced1a0ef4070df53cb425e1967
-    sha256: cc1f1d7c30aa29da4474ec84026ec1032a8df1d7ec93f4af3b98bb793d01184e
+    md5: d2fe7e177d1c97c985140bd54e2a5e33
+    sha256: f918716c71c8bebbc0c40e1050878aa512fea92c1d17c363ca35650bc60f6c35
   category: main
   optional: false
 - name: lerc
-  version: 4.0.0
+  version: 4.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
   hash:
-    md5: a74332d9b60b62905e3d30709df08bf1
-    sha256: 12361697f8ffc9968907d1a7b5830e34c670e4a59b638117a2cdfed8f63a38f8
+    md5: 095e5749868adab9cae42d4b460e5443
+    sha256: 66e5ffd301a44da696f3efc2f25d6d94f42a9adc0db06c44ad753ab844148c51
   category: main
   optional: false
 - name: libabseil
@@ -8443,69 +9054,69 @@ package:
   category: main
   optional: false
 - name: libarchive
-  version: 3.8.5
+  version: 3.8.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     libgcc: '>=14'
-    liblzma: '>=5.8.1,<6.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.5-gpl_hc2c16d8_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_100.conda
   hash:
-    md5: 5fdaa8b856683a5598459dead3976578
-    sha256: ee2cf1499a5a5fd5f03c6203597fe14bf28c6ca2a8fffb761e41f3cf371e768e
+    md5: dbeb5c8321cb2408d406a3da16a0ff0d
+    sha256: 2071a3eb03a868effef273eee8bb7baed6ee9fb2fb94421e9958dcf48ab2c599
   category: main
   optional: false
 - name: libarchive
-  version: 3.8.5
+  version: 3.8.7
   manager: conda
   platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    bzip2: '>=1.0.8,<2.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-    libzlib: '>=1.3.1,<2.0a0'
-    lz4-c: '>=1.10.0,<1.11.0a0'
-    lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.5.4,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.8.5-gpl_h264331f_100.conda
-  hash:
-    md5: bfb9152520db0958801b3c87846c942b
-    sha256: 635b37726c865439b93f7887994eedde33f00ad4b715e286ba3634e39fbca690
-  category: main
-  optional: false
-- name: libarchive
-  version: 3.8.5
-  manager: conda
-  platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     lzo: '>=2.10,<3.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.8.5-gpl_h6fbacd7_100.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.8.7-gpl_h2bf6321_100.conda
   hash:
-    md5: cea06a42883e807bcca32abdd122d1e7
-    sha256: 7f19d9b16ec4383c3e307e5137d394defcc8e2ba1e036ec1c9bd47374f4213aa
+    md5: 0ab331b127ec411f53e5fe2e493e0a93
+    sha256: 4883e891c460e4e005dbc08409613a40a61203041a894ec1adcd107dc5bf961d
+  category: main
+  optional: false
+- name: libarchive
+  version: 3.8.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    lz4-c: '>=1.10.0,<1.11.0a0'
+    lzo: '>=2.10,<3.0a0'
+    openssl: '>=3.5.6,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.8.7-gpl_h6fbacd7_100.conda
+  hash:
+    md5: 014dc9c74fef186581342c4844591ac6
+    sha256: 9bdec2cf61b757f635232d994920fd37439d856844e6701d57d9f3bd9355c7ac
   category: main
   optional: false
 - name: libarrow
@@ -8513,11 +9124,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __cuda: ''
     __glibc: '>=2.17,<3.0.a0'
     aws-crt-cpp: '>=0.35.4,<0.35.5.0a0'
     aws-sdk-cpp: '>=1.11.606,<1.11.607.0a0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
-    azure-identity-cpp: '>=1.13.2,<1.13.3.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
+    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
     azure-storage-blobs-cpp: '>=12.16.0,<12.16.1.0a0'
     azure-storage-files-datalake-cpp: '>=12.14.0,<12.14.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
@@ -8536,10 +9148,10 @@ package:
     orc: '>=2.2.2,<2.2.3.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-23.0.0-h2c50142_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-23.0.0-h258748b_2_cuda.conda
   hash:
-    md5: fba261a7ee565b711b45c5bea554e5a0
-    sha256: 694c0c4fae6a643a9a0bb366371c629d17ec7d5e0cd41bc56439da9d922972df
+    md5: c364f39d8a924797157da59d8cdd6b97
+    sha256: 6443b25aaae157d4bd767de0e73faf40334d2f11bde8732f876216291eb939e6
   category: main
   optional: false
 - name: libarrow
@@ -8550,8 +9162,8 @@ package:
     __osx: '>=11.0'
     aws-crt-cpp: '>=0.35.4,<0.35.5.0a0'
     aws-sdk-cpp: '>=1.11.606,<1.11.607.0a0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
-    azure-identity-cpp: '>=1.13.2,<1.13.3.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
+    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
     azure-storage-blobs-cpp: '>=12.16.0,<12.16.1.0a0'
     azure-storage-files-datalake-cpp: '>=12.14.0,<12.14.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
@@ -8569,10 +9181,10 @@ package:
     orc: '>=2.2.2,<2.2.3.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-23.0.0-h8071b21_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-23.0.0-h72f758e_2_cpu.conda
   hash:
-    md5: 512a46ffda8e0d6a4c34c386f32a1d8e
-    sha256: 8768b493dbf8700b4f77f93e0d792cf2525db701ba211f9cf2278cf063be04f9
+    md5: 0ca5462ee03e2b8e7a506b1b4a0926ce
+    sha256: a771cacb2d047359ce5cd672cd6af974391ed51f8a00601e92eb412ceb9f2845
   category: main
   optional: false
 - name: libarrow
@@ -8583,8 +9195,8 @@ package:
     __osx: '>=11.0'
     aws-crt-cpp: '>=0.35.4,<0.35.5.0a0'
     aws-sdk-cpp: '>=1.11.606,<1.11.607.0a0'
-    azure-core-cpp: '>=1.16.1,<1.16.2.0a0'
-    azure-identity-cpp: '>=1.13.2,<1.13.3.0a0'
+    azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
+    azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
     azure-storage-blobs-cpp: '>=12.16.0,<12.16.1.0a0'
     azure-storage-files-datalake-cpp: '>=12.14.0,<12.14.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
@@ -8602,10 +9214,10 @@ package:
     orc: '>=2.2.2,<2.2.3.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-23.0.0-h4365f54_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-23.0.0-h585ae05_2_cpu.conda
   hash:
-    md5: 4e93106b5de97aafe06b94247b6e963c
-    sha256: f51e188fafef9b00d23986305a8fa5287639205db9ff57df84044d9a95d89d35
+    md5: 8cbb6099377c13f1932c6a04d5da013f
+    sha256: 26854bc0409c487b79abe406f3f5c3a93db8ec6e0adf57d64a24e57542fc1df0
   category: main
   optional: false
 - name: libarrow-acero
@@ -8618,10 +9230,10 @@ package:
     libarrow-compute: 23.0.0
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-23.0.0-h635bf11_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-23.0.0-h635bf11_2_cuda.conda
   hash:
-    md5: 8b1290b259b24a4b29b3a3d6dec0fe53
-    sha256: 44532bfceadae7a575a037011e6262e6f93b2b370074c9ec07c1d30330f344dc
+    md5: b1f327dae633933118765c113fd3ecd0
+    sha256: 2d375ae77653ef0cc9b70ebc9d87e7d3bd6cc4cb2700c5c538521931f3483efd
   category: main
   optional: false
 - name: libarrow-acero
@@ -8636,10 +9248,10 @@ package:
     libcxx: '>=21'
     libopentelemetry-cpp: '>=1.21.0,<1.22.0a0'
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-23.0.0-h9737151_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-23.0.0-h9737151_2_cpu.conda
   hash:
-    md5: 017da997ab188e57a1f78e278e214d29
-    sha256: 0aed6c436e09a04022fb89db6cb46e4455402ec3d152e237099498ccea30d003
+    md5: df07a0e8ed601a2f272ab0f17f0c25b5
+    sha256: 91e650183aeb0294d4e003e67aadfbf70afeb33c201242e305251697a0253dc0
   category: main
   optional: false
 - name: libarrow-acero
@@ -8654,10 +9266,10 @@ package:
     libcxx: '>=21'
     libopentelemetry-cpp: '>=1.21.0,<1.22.0a0'
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-23.0.0-h6de58dd_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-23.0.0-h6de58dd_2_cpu.conda
   hash:
-    md5: f2d2fabd9783477884ea989794ddaf67
-    sha256: 85f9a278c020af2560c8f9f5b17e0c2a1ad0d1e6263e98b6e6b6a3a696682378
+    md5: db14af88015df0dbd660a5eb814a1b23
+    sha256: 58bfc6a3ce5a07e95c333036ca07b548cb1b504bf29a84a5834667130240fb5c
   category: main
   optional: false
 - name: libarrow-compute
@@ -8672,10 +9284,10 @@ package:
     libstdcxx: '>=14'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-23.0.0-h8c2c5c3_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-23.0.0-h8c2c5c3_2_cuda.conda
   hash:
-    md5: 102be5396c7899675268c17993e1a072
-    sha256: 7d49e48aca75f289eeab26220737af1abee7aaf678b5ba35753a6d2b02b2ea94
+    md5: 7846ea1f43ef6beb04749b5dffd6e4da
+    sha256: 0a87b2d585e1f2c37161d3c15881f6d123e383813a5cefc61899447b5c3c2416
   category: main
   optional: false
 - name: libarrow-compute
@@ -8692,10 +9304,10 @@ package:
     libre2-11: '>=2025.8.12'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-compute-23.0.0-hc26cc94_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-compute-23.0.0-hc26cc94_2_cpu.conda
   hash:
-    md5: 13f3890256ec1710409043eb6e81359a
-    sha256: 5a2f2cc1292cc46920474dfe4f96570c3d6da57df7cde627d00ee8cebf183163
+    md5: 278d25b7f2903d53483b0a11dc26dec0
+    sha256: 77d8a716a342f2b64d6e257faa49178ac85e647ff3ca88c1742000163d65211d
   category: main
   optional: false
 - name: libarrow-compute
@@ -8712,10 +9324,10 @@ package:
     libre2-11: '>=2025.8.12'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-23.0.0-h45df96a_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-compute-23.0.0-h45df96a_2_cpu.conda
   hash:
-    md5: 3913b945371055c48978733b8fb5e51b
-    sha256: 759961ad6926a13e47792fddb182c2c99fcc889ea5a28c61ab5b708e77bc01e9
+    md5: 605c1d25d6ea55f0d110a15cb7c95dfe
+    sha256: 300333f8fc6af6859fcaa8012146ddf9120dc9ca86778d81cba807dccc3aa871
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8730,10 +9342,10 @@ package:
     libgcc: '>=14'
     libparquet: 23.0.0
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-23.0.0-h635bf11_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-23.0.0-h635bf11_2_cuda.conda
   hash:
-    md5: 651c34402277a875986db6fa7930d42d
-    sha256: 5e7be5b81662940067db5854220781aed85fa35747d4bd88b533b9c22942859b
+    md5: fa0aa202043167a22dd7638c08004cb2
+    sha256: bc14166ef76974c7bf4587baab2d95acd223ccf2d875f7885cce9b6e621973b8
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8750,10 +9362,10 @@ package:
     libopentelemetry-cpp: '>=1.21.0,<1.22.0a0'
     libparquet: 23.0.0
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-23.0.0-h9737151_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-23.0.0-h9737151_2_cpu.conda
   hash:
-    md5: d94ed1c83b5fad095968ab6f11b0b6e5
-    sha256: 958a9eb275b4ac844d62c0dd32ccb4da0215d44d7a8e5c3812fbdae2ac6c30a3
+    md5: 49a5fb4fbf3e0aa6e234ca9c4ee03594
+    sha256: c6c2eaa42d2c6c085715dd1f002a7544e221113c757ef0a52d842030bebb4a00
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8770,10 +9382,10 @@ package:
     libopentelemetry-cpp: '>=1.21.0,<1.22.0a0'
     libparquet: 23.0.0
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-23.0.0-h6de58dd_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-23.0.0-h6de58dd_2_cpu.conda
   hash:
-    md5: 7b415053e0e3f5863d76b92a69dbf9df
-    sha256: b05c90d40457b710954eae08d624d574fb16f23a1a443ae024171da7803963f1
+    md5: 3da2f4cd4f855e2bcbd668038a5fcd13
+    sha256: 991570eebd1b7bbb050fcc3a1264d57d7e6c1f71d5d1794ce6cd323144bd221b
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8789,10 +9401,10 @@ package:
     libgcc: '>=14'
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-23.0.0-h3f74fd7_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-23.0.0-h3f74fd7_2_cuda.conda
   hash:
-    md5: bcf3ca0f04ed703121db4012e8c8bf5a
-    sha256: 955beae76625c953f211e098e9ac3fa51e3a6f87f0dae6da76cf4eb53e0279eb
+    md5: cf0b0682dadc05c597b11ff24ae6c0b7
+    sha256: f1cdff662d277039e8b70ebbaae0572ce97ddd35a065313da09a234acca48003
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8807,10 +9419,10 @@ package:
     libarrow-dataset: 23.0.0
     libcxx: '>=21'
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-23.0.0-h7f2e36e_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-23.0.0-h7f2e36e_2_cpu.conda
   hash:
-    md5: 4f2b6ff44fceeb46dec7251f207738c6
-    sha256: 2db5ac60983f74070dbfbf95d34ccedffc21232c2b4ec5936de3aedd2c2390e8
+    md5: 8196497a3bc332336078391692ede27b
+    sha256: 716e5f235065c22903a0a1ec1bb2a66e2e71477bece3d78f6f420dc27c4bbba8
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8825,14 +9437,14 @@ package:
     libarrow-dataset: 23.0.0
     libcxx: '>=21'
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-23.0.0-hb5627e6_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-23.0.0-hb5627e6_2_cpu.conda
   hash:
-    md5: a37a44ae8672cf995de6dd04b375c3d8
-    sha256: 378c571505fceba58e0d5521f0054b29e449276fad0564999aa9aaa02a2d6b9b
+    md5: 6b25f000c0719ee305470f62147bfdc6
+    sha256: 1d39899591ab7f1837294a3f894178b47f677e8c69d1e1a9f12979824c6a1c74
   category: main
   optional: false
 - name: libavif16
-  version: 1.3.0
+  version: 1.4.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -8840,44 +9452,44 @@ package:
     aom: '>=3.9.1,<3.10.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
     libgcc: '>=14'
-    rav1e: '>=0.7.1,<0.8.0a0'
-    svt-av1: '>=4.0.0,<4.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.3.0-h316e467_3.conda
+    rav1e: '>=0.8.1,<0.9.0a0'
+    svt-av1: '>=4.0.1,<4.0.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.1-hcfa2d63_0.conda
   hash:
-    md5: 22d5cc5fb45aab8ed3c00cde2938b825
-    sha256: f5ab201b8b4e1f776ced0340c59f87e441fd6763d3face527b5cf3f2280502c9
+    md5: f79415aee8862b3af85ea55dea37e46b
+    sha256: e29d8ed0334305c6bafecb32f9a1967cfc0a081eac916e947a1f2f7c4bb41947
   category: main
   optional: false
 - name: libavif16
-  version: 1.3.0
+  version: 1.4.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     aom: '>=3.9.1,<3.10.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
-    rav1e: '>=0.7.1,<0.8.0a0'
-    svt-av1: '>=4.0.0,<4.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.3.0-hef75fda_3.conda
+    rav1e: '>=0.8.1,<0.9.0a0'
+    svt-av1: '>=4.0.1,<4.0.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.4.1-h9d3eb37_0.conda
   hash:
-    md5: 513ff0778509742a502accc5b7921c81
-    sha256: 25ff9357f1ccdc1979eddf187ecf44f66f2ab6d797865c70c0f0161516743ac5
+    md5: ceedf05905ff9d9bc784ed91a5705f01
+    sha256: b05246b6940fab957585bbc45bca440c0ad4e98ba3ead0ddb28b95ac7583337c
   category: main
   optional: false
 - name: libavif16
-  version: 1.3.0
+  version: 1.4.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aom: '>=3.9.1,<3.10.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
-    rav1e: '>=0.7.1,<0.8.0a0'
-    svt-av1: '>=4.0.0,<4.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.3.0-hde9513d_3.conda
+    rav1e: '>=0.8.1,<0.9.0a0'
+    svt-av1: '>=4.0.1,<4.0.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.4.1-hfce71f6_0.conda
   hash:
-    md5: 6e9bcb90cfd20178a52f355030aba237
-    sha256: 92eb3f8134586972145378b21ac789a65ee232d7c1ef01ce5bfc9e850d0e0e60
+    md5: 2df04ee54a2ce2d34cf375eb02a63725
+    sha256: 09e31e51026a3b74d947ba4b30a68dd99013aeef2860bcb03565bf43cad18da6
   category: main
   optional: false
 - name: libblas
@@ -8885,11 +9497,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.30,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
+    libopenblas: '>=0.3.32,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
   hash:
-    md5: c160954f7418d7b6e87eaf05a8913fa9
-    sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
+    md5: 6d6d225559bfa6e2f3c90ee9c03d4e2e
+    sha256: 7bfe936dbb5db04820cf300a9cc1f5ee8d5302fc896c2d66e30f1ee2f20fbfd6
   category: main
   optional: false
 - name: libblas
@@ -8897,11 +9509,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libopenblas: '>=0.3.30,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-5_he492b99_openblas.conda
+    libopenblas: '>=0.3.32,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-6_he492b99_openblas.conda
   hash:
-    md5: 36d2e68a156692cbae776b75d6ca6eae
-    sha256: 4754de83feafa6c0b41385f8dab1b13f13476232e16f524564a340871a9fc3bc
+    md5: 93e7fc07b395c9e1341d3944dcf2aced
+    sha256: 6865098475f3804208038d0c424edf926f4dc9eacaa568d14e29f59df53731fd
   category: main
   optional: false
 - name: libblas
@@ -8909,11 +9521,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libopenblas: '>=0.3.30,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
+    libopenblas: '>=0.3.32,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-6_h51639a9_openblas.conda
   hash:
-    md5: bcc025e2bbaf8a92982d20863fe1fb69
-    sha256: 620a6278f194dcabc7962277da6835b1e968e46ad0c8e757736255f5ddbfca8d
+    md5: e551103471911260488a02155cef9c94
+    sha256: 979227fc03628925037ab2dfda008eb7b5592644d9c2c21dd285cefe8c42553d
   category: main
   optional: false
 - name: libbrotlicommon
@@ -9039,10 +9651,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
   hash:
-    md5: 6636a2b6f1a87572df2970d3ebc87cc0
-    sha256: 0cbdcc67901e02dc17f1d19e1f9170610bd828100dc207de4d5b6b8ad1ae7ad8
+    md5: 36ae340a916635b97ac8a0655ace2a35
+    sha256: 57edafa7796f6fa3ebbd5367692dd4c7f552be42109c2dd1a7c89b55089bf374
   category: main
   optional: false
 - name: libcblas
@@ -9051,10 +9663,10 @@ package:
   platform: osx-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-5_h9b27e0a_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-6_h9b27e0a_openblas.conda
   hash:
-    md5: b31d771cbccff686e01a687708a7ca41
-    sha256: 8077c29ea720bd152be6e6859a3765228cde51301fe62a3b3f505b377c2cb48c
+    md5: 2a174868cb9e136c4e92b3ffc2815f04
+    sha256: 8422e1ce083e015bdb44addd25c9a8fe99aa9b0edbd9b7f1239b7ac1e3d04f77
   category: main
   optional: false
 - name: libcblas
@@ -9063,10 +9675,10 @@ package:
   platform: osx-arm64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-6_hb0561ab_openblas.conda
   hash:
-    md5: efd8bd15ca56e9d01748a3beab8404eb
-    sha256: 38809c361bbd165ecf83f7f05fae9b791e1baa11e4447367f38ae1327f402fc0
+    md5: 805c6d31c5621fd75e53dfcf21fb243a
+    sha256: 2e6b3e9b1ab672133b70fc6730e42290e952793f132cb5e72eee22835463eba0
   category: main
   optional: false
 - name: libcrc32c
@@ -9112,93 +9724,93 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    krb5: '>=1.21.3,<1.22.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
+    krb5: '>=1.22.2,<1.23.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
   hash:
-    md5: d4a250da4737ee127fb1fa6452a9002e
-    sha256: cb83980c57e311783ee831832eb2c20ecb41e7dee6e86e8b70b8cef0e43eab55
+    md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+    sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
   category: main
   optional: false
 - name: libcurl
-  version: 8.18.0
+  version: 8.20.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    krb5: '>=1.21.3,<1.22.0a0'
+    krb5: '>=1.22.2,<1.23.0a0'
     libgcc: '>=14'
-    libnghttp2: '>=1.67.0,<2.0a0'
+    libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
   hash:
-    md5: 0a5563efed19ca4461cf927419b6eb73
-    sha256: 5454709d9fb6e9c3dd6423bc284fa7835a7823bfa8323f6e8786cdd555101fab
+    md5: c3cc2864f82a944bc90a7beb4d3b0e88
+    sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
   category: main
   optional: false
 - name: libcurl
-  version: 8.18.0
+  version: 8.20.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    krb5: '>=1.21.3,<1.22.0a0'
-    libnghttp2: '>=1.67.0,<2.0a0'
+    __osx: '>=11.0'
+    krb5: '>=1.22.2,<1.23.0a0'
+    libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.18.0-h9348e2b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.20.0-h8f0b9e4_0.conda
   hash:
-    md5: de1910529f64ba4a9ac9005e0be78601
-    sha256: 1a0af3b7929af3c5893ebf50161978f54ae0256abb9532d4efba2735a0688325
+    md5: 4a0085ccf90dc514f0fc0909a874045e
+    sha256: 5d3d8a82ca43347e96f1d79048921f3a7c25e32514bc7feb53ed2a040dcca54d
   category: main
   optional: false
 - name: libcurl
-  version: 8.18.0
+  version: 8.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    krb5: '>=1.21.3,<1.22.0a0'
-    libnghttp2: '>=1.67.0,<2.0a0'
+    krb5: '>=1.22.2,<1.23.0a0'
+    libnghttp2: '>=1.68.1,<2.0a0'
     libssh2: '>=1.11.1,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.18.0-he38603e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.20.0-hd5a2499_0.conda
   hash:
-    md5: 36190179a799f3aee3c2d20a8a2b970d
-    sha256: 11c78b3e89bc332933386f0a11ac60d9200afb7a811b9e3bec98aef8d4a6389b
+    md5: 2f57b7d0c6adda88957586b7afd78438
+    sha256: 38c0bc634b61e542776e97cfd15d5d41edd304d4e47c333004d2d622439b2381
   category: main
   optional: false
 - name: libcxx
-  version: 21.1.8
+  version: 22.1.4
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.8-h3d58e20_1.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.4-h19cb2f5_0.conda
   hash:
-    md5: 7a582e52af3e0e495ba3ba9e1e87c7bb
-    sha256: facdc3861f2d9e8de3cb42cd5b32d56b2a3e0d957bf8e80641cedaf3ab2c7156
+    md5: 4394b1ba4b9604ac4e1c5bdc74451279
+    sha256: 596a0bdd5321c5e41a4734f18b35bcbc5d116079d13bc40d765fd93c32b285d1
   category: main
   optional: false
 - name: libcxx
-  version: 21.1.8
+  version: 22.1.4
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-hf598326_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.4-h55c6f16_0.conda
   hash:
-    md5: cd7367d0c0f49853f8f3560bfb4456ab
-    sha256: 3a924cbce92b0dceb5d392036e692bac1e60ae90d85c7c78264c672a205c007b
+    md5: 448a1af83a9205655ee1cf48d3875ca3
+    sha256: 25a0d02148a39b665d9c2957676faf62a4d2a58494d53b201151199a197db4b0
   category: main
   optional: false
 - name: libdeflate
@@ -9392,88 +10004,40 @@ package:
   category: main
   optional: false
 - name: libexpat
-  version: 2.7.3
+  version: 2.8.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
   hash:
-    md5: 8b09ae86839581147ef2e5c5e229d164
-    sha256: 1e1b08f6211629cbc2efe7a5bca5953f8f6b3cae0eeb04ca4dacee1bd4e2db2f
+    md5: a3b390520c563d78cc58974de95a03e5
+    sha256: ea33c40977ea7a2c3658c522230058395bc2ee0d89d99f0711390b6a1ee80d12
   category: main
   optional: false
 - name: libexpat
-  version: 2.7.3
+  version: 2.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.3-heffb93a_0.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.0-hcc62823_0.conda
   hash:
-    md5: 222e0732a1d0780a622926265bee14ef
-    sha256: d11b3a6ce5b2e832f430fd112084533a01220597221bee16d6c7dc3947dffba6
+    md5: d2e01f78c1daaeb4d2aa870125ebcd7e
+    sha256: 5ebcc413d0a75da926a8b9b681d7d12c9562993991ba49c90a9881c4a59bdc11
   category: main
   optional: false
 - name: libexpat
-  version: 2.7.3
+  version: 2.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.3-haf25636_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.0-hf6b4638_0.conda
   hash:
-    md5: b79875dbb5b1db9a4a22a4520f918e1a
-    sha256: fce22610ecc95e6d149e42a42fbc3cc9d9179bd4eb6232639a60f06e080eec98
-  category: main
-  optional: false
-- name: libfabric
-  version: 2.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libfabric1: 2.4.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfabric-2.4.0-h694c41f_1.conda
-  hash:
-    md5: de06eba92f9e70f8d2bc8bc5b44a4aea
-    sha256: e6b24f2728fa78a877ce2a6a053dac4b7296e1b431561d1f3e3302114d288050
-  category: main
-  optional: false
-- name: libfabric
-  version: 2.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libfabric1: 2.4.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.4.0-hce30654_1.conda
-  hash:
-    md5: b356b8b9cdb1cb1f3cbfb25d00d35515
-    sha256: a2a9779347d26c0d66f18705183e8701aeba420db01edaa5dcde3ae76cbf9c00
-  category: main
-  optional: false
-- name: libfabric1
-  version: 2.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfabric1-2.4.0-hf3981d6_1.conda
-  hash:
-    md5: 27bd5f9b461b65037982bae2082ef241
-    sha256: ba61c8f1d7288fb8e88a315f2220bb2fae8c15d6597f90c3a51dfb109eb88ecb
-  category: main
-  optional: false
-- name: libfabric1
-  version: 2.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.4.0-h84a0fba_1.conda
-  hash:
-    md5: 17b27d39ff83af87065476ab6d8b7e74
-    sha256: c57c240b11a0051f62d9f26560ae2c94df0ba5e30a33c59cd79786bf2d8588c6
+    md5: 65466e82c09e888ca7560c11a97d5450
+    sha256: f4b1cafc59afaede8fa0a2d9cf376840f1c553001acd72f6ead18bbc8ac8c49c
   category: main
   optional: false
 - name: libffi
@@ -9514,82 +10078,82 @@ package:
   category: main
   optional: false
 - name: libfreetype
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: linux-64
   dependencies:
-    libfreetype6: '>=2.14.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+    libfreetype6: '>=2.14.3'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
   hash:
-    md5: f4084e4e6577797150f9b04a4560ceb0
-    sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
+    md5: e289f3d17880e44b633ba911d57a321b
+    sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
   category: main
   optional: false
 - name: libfreetype
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: osx-64
   dependencies:
-    libfreetype6: '>=2.14.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.1-h694c41f_0.conda
+    libfreetype6: '>=2.14.3'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_0.conda
   hash:
-    md5: e0e2edaf5e0c71b843e25a7ecc451cc9
-    sha256: 035e23ef87759a245d51890aedba0b494a26636784910c3730d76f3dc4482b1d
+    md5: 63b822fcf984c891f0afab2eedfcfaf4
+    sha256: b5daa4cee3beb98a0317e81a20aa507b9f897a9e21b11fe0b2e32852e372f746
   category: main
   optional: false
 - name: libfreetype
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libfreetype6: '>=2.14.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.1-hce30654_0.conda
+    libfreetype6: '>=2.14.3'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
   hash:
-    md5: f35fb38e89e2776994131fbf961fa44b
-    sha256: 9de25a86066f078822d8dd95a83048d7dc2897d5d655c0e04a8a54fca13ef1ef
+    md5: f73b109d49568d5d1dda43bb147ae37f
+    sha256: a047a2f238362a37d484f9620e8cba29f513a933cd9eb68571ad4b270d6f8f3e
   category: main
   optional: false
 - name: libfreetype6
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+    libpng: '>=1.6.55,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
   hash:
-    md5: 8e7251989bca326a28f4a5ffbd74557a
-    sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
+    md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
+    sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
   category: main
   optional: false
 - name: libfreetype6
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.1-h6912278_0.conda
+    __osx: '>=11.0'
+    libpng: '>=1.6.55,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_0.conda
   hash:
-    md5: dfbdc8fd781dc3111541e4234c19fdbd
-    sha256: f5f28092e368efc773bcd1c381d123f8b211528385a9353e36f8808d00d11655
+    md5: 27515b8ab8bf4abd8d3d90cf11212411
+    sha256: 9d34b5b2be6ebdd3bcd9e21d6598d493afce4d3fcd2d419f3356022cb4d746fd
   category: main
   optional: false
 - name: libfreetype6
-  version: 2.14.1
+  version: 2.14.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libpng: '>=1.6.50,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.1-h6da58f4_0.conda
+    libpng: '>=1.6.55,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
   hash:
-    md5: 6d4ede03e2a8e20eb51f7f681d2a2550
-    sha256: cc4aec4c490123c0f248c1acd1aeab592afb6a44b1536734e20937cda748f7cd
+    md5: e98ba7b5f09a5f450eca083d5a1c4649
+    sha256: ff764608e1f2839e95e2cf9b243681475f8778c36af7a42b3f78f476fdbb1dd3
   category: main
   optional: false
 - name: libgcc
@@ -9599,10 +10163,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
   hash:
-    md5: 6d0363467e6ed84f11435eb309f2ff06
-    sha256: 6eed58051c2e12b804d53ceff5994a350c61baf117ec83f5f10c953a3f311451
+    md5: 0aa00f03f9e39fb9876085dee11a85d4
+    sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
   category: main
   optional: false
 - name: libgcc
@@ -9611,10 +10175,10 @@ package:
   platform: osx-64
   dependencies:
     _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_15.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_18.conda
   hash:
-    md5: c816665789d1e47cdfd6da8a81e1af64
-    sha256: e04b115ae32f8cbf95905971856ff557b296511735f4e1587b88abf519ff6fb8
+    md5: 9a5cb96e43f5c2296690186e15b3296f
+    sha256: 83366f11615ab234aa1e0797393f9e07b78124b5a24c4a9f8af0113d02df818e
   category: main
   optional: false
 - name: libgcc
@@ -9623,10 +10187,10 @@ package:
   platform: osx-arm64
   dependencies:
     _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_16.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
   hash:
-    md5: 8b216bac0de7a9d60f3ddeba2515545c
-    sha256: 646c91dbc422fe92a5f8a3a5409c9aac66549f4ce8f8d1cab7c2aa5db789bb69
+    md5: 92df6107310b1fff92c4cc84f0de247b
+    sha256: 1d9c4f35586adb71bcd23e31b68b7f3e4c4ab89914c26bed5f2859290be5560e
   category: main
   optional: false
 - name: libgcc-ng
@@ -9635,10 +10199,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
   hash:
-    md5: 5a68259fac2da8f2ee6f7bfe49c9eb8b
-    sha256: 5f07f9317f596a201cc6e095e5fc92621afca64829785e483738d935f8cab361
+    md5: d5e96b1ed75ca01906b3d2469b4ce493
+    sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
   category: main
   optional: false
 - name: libgd
@@ -9714,7 +10278,7 @@ package:
   category: main
   optional: false
 - name: libgdal-core
-  version: 3.12.1
+  version: 3.12.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -9723,81 +10287,81 @@ package:
     geos: '>=3.14.1,<3.14.2.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     json-c: '>=0.18,<0.19.0a0'
-    lerc: '>=4.0.0,<5.0a0'
-    libarchive: '>=3.8.5,<3.9.0a0'
-    libcurl: '>=8.18.0,<9.0a0'
+    lerc: '>=4.1.0,<5.0a0'
+    libarchive: '>=3.8.6,<3.9.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libdeflate: '>=1.25,<1.26.0a0'
-    libexpat: '>=2.7.3,<3.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
     libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
     libjpeg-turbo: '>=3.1.2,<4.0a0'
     libjxl: '>=0.11,<1.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
+    libpng: '>=1.6.57,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.51.2,<4.0a0'
+    libsqlite: '>=3.52.0,<4.0a0'
     libstdcxx: '>=14'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     muparser: '>=2.3.5,<2.4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     pcre2: '>=10.47,<10.48.0a0'
     proj: '>=9.7.1,<9.8.0a0'
     xerces-c: '>=3.3.0,<3.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.1-hf05ffb4_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.3-he63569f_3.conda
   hash:
-    md5: 7a8b949fb98c73b802b5e66a67dac140
-    sha256: 4f3c0dd876e9879c1666aec58dfc72f9824bf66a6fae019b5cdfff10b4bda0cc
+    md5: 83666e2c330f47ee6268396ee4467b63
+    sha256: 298497351f4a7dc94938a1ad8dc3df545a07efdc5f1b91b9256d04e65959a430
   category: main
   optional: false
 - name: libgdal-core
-  version: 3.12.1
+  version: 3.12.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     blosc: '>=1.21.6,<2.0a0'
     geos: '>=3.14.1,<3.14.2.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     json-c: '>=0.18,<0.19.0a0'
-    lerc: '>=4.0.0,<5.0a0'
-    libarchive: '>=3.8.5,<3.9.0a0'
-    libcurl: '>=8.18.0,<9.0a0'
+    lerc: '>=4.1.0,<5.0a0'
+    libarchive: '>=3.8.6,<3.9.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libcxx: '>=19'
     libdeflate: '>=1.25,<1.26.0a0'
-    libexpat: '>=2.7.3,<3.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
     libiconv: '>=1.18,<2.0a0'
     libjpeg-turbo: '>=3.1.2,<4.0a0'
     libjxl: '>=0.11,<1.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
+    libpng: '>=1.6.57,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.51.2,<4.0a0'
+    libsqlite: '>=3.52.0,<4.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     muparser: '>=2.3.5,<2.4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     pcre2: '>=10.47,<10.48.0a0'
     proj: '>=9.7.1,<9.8.0a0'
     xerces-c: '>=3.3.0,<3.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.1-hc010f1d_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.3-hb9a8e9f_3.conda
   hash:
-    md5: 8111ec401a7fe591eddc76f3aa131b62
-    sha256: 55469908a1245d7c14a108ea69cbff9a26232555453f011e3492805cc5c5e0c4
+    md5: 73b52e7bc3049e9e23b157dd5f0bbdd8
+    sha256: b71b221b6514b8ab91ec9647471cbbc92a3727d9f8f730b43ce4e6060353a0b9
   category: main
   optional: false
 - name: libgdal-core
-  version: 3.12.1
+  version: 3.12.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9806,35 +10370,35 @@ package:
     geos: '>=3.14.1,<3.14.2.0a0'
     giflib: '>=5.2.2,<5.3.0a0'
     json-c: '>=0.18,<0.19.0a0'
-    lerc: '>=4.0.0,<5.0a0'
-    libarchive: '>=3.8.5,<3.9.0a0'
-    libcurl: '>=8.18.0,<9.0a0'
+    lerc: '>=4.1.0,<5.0a0'
+    libarchive: '>=3.8.6,<3.9.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libcxx: '>=19'
     libdeflate: '>=1.25,<1.26.0a0'
-    libexpat: '>=2.7.3,<3.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
     libiconv: '>=1.18,<2.0a0'
     libjpeg-turbo: '>=3.1.2,<4.0a0'
     libjxl: '>=0.11,<1.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     liblzma: '>=5.8.2,<6.0a0'
-    libpng: '>=1.6.54,<1.7.0a0'
+    libpng: '>=1.6.57,<1.7.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.51.2,<4.0a0'
+    libsqlite: '>=3.52.0,<4.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     lz4-c: '>=1.10.0,<1.11.0a0'
     muparser: '>=2.3.5,<2.4.0a0'
-    openssl: '>=3.5.5,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     pcre2: '>=10.47,<10.48.0a0'
     proj: '>=9.7.1,<9.8.0a0'
     xerces-c: '>=3.3.0,<3.4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.1-ha937536_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.3-haccf57a_3.conda
   hash:
-    md5: facb2b899416331882211b563f04966a
-    sha256: 162edee3301d712135ea3df8fb36083601f4b6cc8d4d9e77e3547cdd38f687c6
+    md5: 7c7439b43fee531ac02bf45df6caf870
+    sha256: 19376eefc969f055b5823dec7b847011b70a3013c094e53bf0380fffdf436504
   category: main
   optional: false
 - name: libgfortran
@@ -9843,10 +10407,10 @@ package:
   platform: linux-64
   dependencies:
     libgfortran5: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
   hash:
-    md5: 40d9b534410403c821ff64f00d0adc22
-    sha256: 8a7b01e1ee1c462ad243524d76099e7174ebdd94ff045fe3e9b1e58db196463b
+    md5: 9063115da5bc35fdc3e1002e69b9ef6e
+    sha256: d2c9fad338fd85e4487424865da8e74006ab2e2475bd788f624d7a39b2a72aee
   category: main
   optional: false
 - name: libgfortran
@@ -9855,10 +10419,10 @@ package:
   platform: osx-64
   dependencies:
     libgfortran5: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_15.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_18.conda
   hash:
-    md5: a089323fefeeaba2ae60e1ccebf86ddc
-    sha256: 7bb4d51348e8f7c1a565df95f4fc2a2021229d42300aab8366eda0ea1af90587
+    md5: 34a9f67498721abcfef00178bcf4b190
+    sha256: fb06c2a2ef06716a0f2a6550f5d13cdd1d89365993068512b7ae3c34e6e665d9
   category: main
   optional: false
 - name: libgfortran
@@ -9867,10 +10431,10 @@ package:
   platform: osx-arm64
   dependencies:
     libgfortran5: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_16.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
   hash:
-    md5: 11e09edf0dde4c288508501fe621bab4
-    sha256: 68a6c1384d209f8654112c4c57c68c540540dd8e09e17dd1facf6cf3467798b5
+    md5: 26981599908ed2205366e8fc91b37fc6
+    sha256: 63f89087c3f0c8621c5c89ecceec1e56e5e1c84f65fc9c5feca33a07c570a836
   category: main
   optional: false
 - name: libgfortran5
@@ -9880,10 +10444,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=15.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
   hash:
-    md5: 39183d4e0c05609fd65f130633194e37
-    sha256: d0e974ebc937c67ae37f07a28edace978e01dc0f44ee02f29ab8a16004b8148b
+    md5: 646855f357199a12f02a87382d429b75
+    sha256: 539b57cf50ec85509a94ba9949b7e30717839e4d694bc94f30d41c9d34de2d12
   category: main
   optional: false
 - name: libgfortran5
@@ -9892,10 +10456,10 @@ package:
   platform: osx-64
   dependencies:
     libgcc: '>=15.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_15.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_18.conda
   hash:
-    md5: c2a6149bf7f82774a0118b9efef966dd
-    sha256: 456385a7d3357d5fdfc8e11bf18dcdf71753c4016c440f92a2486057524dd59a
+    md5: ca52daf58cea766656266c8771d8be81
+    sha256: ddaf9dcf008c031b10987991aa78643e03c24a534ad420925cbd5851b31faa11
   category: main
   optional: false
 - name: libgfortran5
@@ -9904,10 +10468,10 @@ package:
   platform: osx-arm64
   dependencies:
     libgcc: '>=15.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_16.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
   hash:
-    md5: 265a9d03461da24884ecc8eb58396d57
-    sha256: 9fb7f4ff219e3fb5decbd0ee90a950f4078c90a86f5d8d61ca608c913062f9b0
+    md5: c4a6f7989cffb0544bfd9207b6789971
+    sha256: 91033978ba25e6a60fb86843cf7e1f7dc8ad513f9689f991c9ddabfaf0361e7e
   category: main
   optional: false
 - name: libgl
@@ -9939,7 +10503,7 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.86.3
+  version: 2.88.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -9947,33 +10511,33 @@ package:
     libffi: '>=3.5.2,<3.6.0a0'
     libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h6705ce6_0.conda
   hash:
-    md5: 034bea55a4feef51c98e8449938e9cee
-    sha256: 82d6c2ee9f548c84220fb30fb1b231c64a53561d6e485447394f0a0eeeffe0e6
+    md5: 42c424ab163c576c7fb5981f7fb379cf
+    sha256: d81bb2fd3b339009ddbf642c0569be1459ee0b9e5829d47651c0c0003c0e1ec8
   category: main
   optional: false
 - name: libglib
-  version: 2.86.3
+  version: 2.88.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libffi: '>=3.5.2,<3.6.0a0'
     libiconv: '>=1.18,<2.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.86.3-hf241ffe_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.88.1-h7065de2_0.conda
   hash:
-    md5: 584ce14b08050d3f1a25ab429b9360bc
-    sha256: d205ecdd0873dd92f7b55ac9b266b2eb09236ff5f3b26751579e435bbaed499c
+    md5: 2621b46a987e147c44bfa24f4eb91a12
+    sha256: 877a3ca66acd300f068028eb2ef875015d0e9daf1a7ce5ded362eff7750fe7c4
   category: main
   optional: false
 - name: libglib
-  version: 2.86.3
+  version: 2.88.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9981,12 +10545,12 @@ package:
     libffi: '>=3.5.2,<3.6.0a0'
     libiconv: '>=1.18,<2.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.86.3-hfe11c1f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.1-hc04fd66_0.conda
   hash:
-    md5: 057c7247514048ebdaf89373b263ebee
-    sha256: 801c1835aa35a4f6e45e2192ad668bd7238d95c90ef8f02c52ce859c20117285
+    md5: a34aa67a26e7bd373c7a34ec6550bd23
+    sha256: d03637a2a452c5b4673ec2fd822d9b7e4e9c8f015946eeea9d04e42854841d90
   category: main
   optional: false
 - name: libglu
@@ -10051,10 +10615,10 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
   hash:
-    md5: 26c46f90d0e727e95c6c9498a33a09f3
-    sha256: 5b3e5e4e9270ecfcd48f47e3a68f037f5ab0f529ccb223e8e5d5ac75a58fc687
+    md5: 239c5e9546c38a1e884d69effcf4c882
+    sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -10231,74 +10795,44 @@ package:
     sha256: c2099872b1aa06bf8153e35e5b706d2000c1fc16f4dde2735ccd77a0643a4683
   category: main
   optional: false
-- name: libhwloc
-  version: 2.12.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.12.2-default_h273dbb7_1000.conda
-  hash:
-    md5: 56aaf4b7cc4c24e30cecc185bb08668d
-    sha256: ecc1d327c422ce84fc3ef90effdcb8d54122fe1f80509545c2394e0a0cd762e0
-  category: main
-  optional: false
-- name: libhwloc
-  version: 2.12.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libxml2: ''
-    libxml2-16: '>=2.14.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.12.2-default_ha3cc4f2_1000.conda
-  hash:
-    md5: 38b8aa4ea25d313ad951bcb7d3cd0ad3
-    sha256: 4d03bb9bc0a813cf5e24f07e6adec3c42df2c9c36e226b71cb1dc6c7868c7d90
-  category: main
-  optional: false
 - name: libhwy
-  version: 1.3.0
+  version: 1.4.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
   hash:
-    md5: c2a0c1d0120520e979685034e0b79859
-    sha256: 2bdd1cdd677b119abc5e83069bec2e28fe6bfb21ebaea3cd07acee67f38ea274
+    md5: 3a9428b74c403c71048104d38437b48c
+    sha256: 8b70955d5e9a49d08945d4f8e2eab855b2efa5fce9cb9bc5e75d86764e6f2f38
   category: main
   optional: false
 - name: libhwy
-  version: 1.3.0
+  version: 1.4.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.3.0-hab838a1_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
   hash:
-    md5: bb8ff4fec8150927a54139af07ef8069
-    sha256: 2f49632a3fd9ec5e38a45738f495f8c665298b0b35e6c89cef8e0fbc39b3f791
+    md5: b9e41e8946bb04aca90e181f29c5cf82
+    sha256: fb82a974f5bc029963665a77a0d669cacecfd067e1f3b32fe427d806ec21d52b
   category: main
   optional: false
 - name: libhwy
-  version: 1.3.0
+  version: 1.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.3.0-h48b13b8_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
   hash:
-    md5: 6375717f5fcd756de929a06d0e40fab0
-    sha256: 837fe775ba8ec9f08655bb924e28dba390d917423350333a75fd5eeac0776174
+    md5: 7394850583ca88325244b68b532c7a39
+    sha256: 4fcad3cbec60da940312e883b7866816517acc5f9baecfe9a778de57327a1b1b
   category: main
   optional: false
 - name: libiconv
@@ -10365,44 +10899,44 @@ package:
   category: main
   optional: false
 - name: libjpeg-turbo
-  version: 3.1.2
+  version: 3.1.4.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
   hash:
-    md5: 8397539e3a0bbd1695584fb4f927485a
-    sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
+    md5: 6178c6f2fb254558238ef4e6c56fb782
+    sha256: 10056646c28115b174de81a44e23e3a0a3b95b5347d2e6c45cc6d49d35294256
   category: main
   optional: false
 - name: libjpeg-turbo
-  version: 3.1.2
+  version: 3.1.4.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.1.2-h8616949_0.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.1.4.1-ha1e9b39_0.conda
   hash:
-    md5: 48dda187f169f5a8f1e5e07701d5cdd9
-    sha256: ebe2877abc046688d6ea299e80d8322d10c69763f13a102010f90f7168cc5f54
+    md5: 57cc1464d457d01ac78f5860b9ca1714
+    sha256: 6b809d8acb6b97bbb1a858eb4ba7b7163c67257b6c3f199dd9d1e0751f4c5b18
   category: main
   optional: false
 - name: libjpeg-turbo
-  version: 3.1.2
+  version: 3.1.4.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.2-hc919400_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.4.1-h84a0fba_0.conda
   hash:
-    md5: f0695fbecf1006f27f4395d64bd0c4b8
-    sha256: 6c061c56058bb10374daaef50e81b39cf43e8aee21f0037022c0c39c4f31872f
+    md5: b8a7544c83a67258b0e8592ec6a5d322
+    sha256: 17e035ae6a520ff6a6bb5dd93a4a7c3895891f4f9743bcb8c6ef607445a31cd0
   category: main
   optional: false
 - name: libjxl
-  version: 0.11.1
+  version: 0.11.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -10410,32 +10944,32 @@ package:
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libgcc: '>=14'
-    libhwy: '>=1.3.0,<1.4.0a0'
+    libhwy: '>=1.4.0,<1.5.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-ha09017c_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-h174a0a3_1.conda
   hash:
-    md5: 6e9bf4ce797d0216bd2a58298b6290b5
-    sha256: 1b9eda9cf595313cf093d40dfbe5aa1ff55c97a04cc024cf80a35dad527f7a54
+    md5: 850f48943d6b4589800a303f0de6a816
+    sha256: 0c8a78c6a42a6e4c6de3a5e82d692f60400d43f4cc80591745f28b37daad9c70
   category: main
   optional: false
 - name: libjxl
-  version: 0.11.1
+  version: 0.11.2
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcxx: '>=19'
-    libhwy: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libjxl-0.11.1-hde0fb83_8.conda
+    libhwy: '>=1.4.0,<1.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libjxl-0.11.2-h473410d_1.conda
   hash:
-    md5: 5e478d37b1027d73872f7c8d579dc314
-    sha256: fa5ee8b83d7d87e7bd3bfd4623c5e50a7135ccbcbbebf247b992df284c85d679
+    md5: 596810d804d0b2f2c54bfdd635025e92
+    sha256: 5c59a02fcb345c49ef8bdd5e1889de8aa918bedd95917f9805d20659cec65da1
   category: main
   optional: false
 - name: libjxl
-  version: 0.11.1
+  version: 0.11.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10443,11 +10977,11 @@ package:
     libbrotlidec: '>=1.2.0,<1.3.0a0'
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcxx: '>=19'
-    libhwy: '>=1.3.0,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjxl-0.11.1-h913acd8_8.conda
+    libhwy: '>=1.4.0,<1.5.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjxl-0.11.2-h934fa54_1.conda
   hash:
-    md5: c41ad4bd5cb936fd7662426753ff1784
-    sha256: cb3713aa91c9271e1992d2a7234447f6da84ec0d59a5cf2f92ba850f808becb9
+    md5: 05bead8980f5ae6a070117dacec38b5b
+    sha256: 948cf1370abb58e06a7c9554838c68672ef1d78e01c3fc4e62ccfc3072579645
   category: main
   optional: false
 - name: libkml
@@ -10456,15 +10990,15 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libexpat: '>=2.7.1,<3.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     uriparser: '>=0.9.8,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1022.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1023.conda
   hash:
-    md5: 00f0f4a9d2eb174015931b1a234d61ca
-    sha256: aa55f5779d6bc7bf24dc8257f053d5a0708b5910b6bc6ea1396f15febf812c98
+    md5: 953b7cca897e21215302dbfe2af5cd0c
+    sha256: f6348ac9cebbc03f765ea6d2da88d57d19531585c8f3a963b98635b208e8bef1
   category: main
   optional: false
 - name: libkml
@@ -10472,15 +11006,15 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-    libexpat: '>=2.7.1,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     uriparser: '>=0.9.8,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-h450b6c2_1022.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-h72464b1_1023.conda
   hash:
-    md5: ec47f97e9a3cdfb729e1b1173d80ed0f
-    sha256: 9d0fa449acb13bd0e7a7cb280aac3578f5956ace0602fa3cf997969432c18786
+    md5: 83103d49cefa1d365c4a67bcf6ab1831
+    sha256: d6ca748bf779008f25cc68d314e71999119ba1598d68d47909016ee4f903ad68
   category: main
   optional: false
 - name: libkml
@@ -10490,13 +11024,13 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    libexpat: '>=2.7.1,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     uriparser: '>=0.9.8,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-hc33e383_1022.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-hb833057_1023.conda
   hash:
-    md5: a91a7afac6eec20a07d9435bf1372bc1
-    sha256: ef32d85c00aefa510e9f36f19609dddc93359c1abbe58c2a695a927d2537721f
+    md5: 3d8eeedb8e541d1cb593e8204fcc397d
+    sha256: bfc6c0b1f30de524e3270eed2171d87e6b96552ff90cf2a5eb34c00d6bcb3dfa
   category: main
   optional: false
 - name: liblapack
@@ -10505,10 +11039,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
   hash:
-    md5: b38076eb5c8e40d0106beda6f95d7609
-    sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
+    md5: 881d801569b201c2e753f03c84b85e15
+    sha256: 371f517eb7010b21c6cc882c7606daccebb943307cb9a3bf2c70456a5c024f7d
   category: main
   optional: false
 - name: liblapack
@@ -10517,10 +11051,10 @@ package:
   platform: osx-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-5_h859234e_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-6_h859234e_openblas.conda
   hash:
-    md5: eb5b1c25d4ac30813a6ca950a58710d6
-    sha256: 2c915fe2b3d806d4b82776c882ba66ba3e095e9e2c41cc5c3375bffec6bddfdc
+    md5: 0808639f35afc076d89375aac666e8cb
+    sha256: 27aa20356e85f5fda5651866fed28e145dc98587f0bdd358a07d87bf1a68e427
   category: main
   optional: false
 - name: liblapack
@@ -10529,47 +11063,47 @@ package:
   platform: osx-arm64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-5_hd9741b5_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-6_hd9741b5_openblas.conda
   hash:
-    md5: ca9d752201b7fa1225bca036ee300f2b
-    sha256: 735a6e6f7d7da6f718b6690b7c0a8ae4815afb89138aa5793abe78128e951dbb
+    md5: ee33d2d05a7c5ea1f67653b37eb74db1
+    sha256: 21606b7346810559e259807497b86f438950cf19e71838e44ebaf4bd2b35b549
   category: main
   optional: false
 - name: liblzma
-  version: 5.8.2
+  version: 5.8.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
   hash:
-    md5: c7c83eecbb72d88b940c249af56c8b17
-    sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
+    md5: b88d90cad08e6bc8ad540cb310a761fb
+    sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
   category: main
   optional: false
 - name: liblzma
-  version: 5.8.2
+  version: 5.8.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.2-h11316ed_0.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
   hash:
-    md5: 688a0c3d57fa118b9c97bf7e471ab46c
-    sha256: 7ab3c98abd3b5d5ec72faa8d9f5d4b50dcee4970ed05339bc381861199dabb41
+    md5: becdfbfe7049fa248e52aa37a9df09e2
+    sha256: d9e2006051529aec5578c6efeb13bb6a7200a014b2d5a77a579e83a8049d5f3c
   category: main
   optional: false
 - name: liblzma
-  version: 5.8.2
+  version: 5.8.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
   hash:
-    md5: 009f0d956d7bfb00de86901d16e486c7
-    sha256: 7bfc7ffb2d6a9629357a70d4eadeadb6f88fa26ebc28f606b1c1e5e5ed99dc7e
+    md5: b1fd823b5ae54fbec272cea0811bd8a9
+    sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
   category: main
   optional: false
 - name: libmpdec
@@ -10610,63 +11144,58 @@ package:
   category: main
   optional: false
 - name: libnetcdf
-  version: 4.9.3
+  version: 4.10.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    attr: '>=2.5.2,<2.6.0a0'
     blosc: '>=1.21.6,<2.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     hdf4: '>=4.2.15,<4.2.16.0a0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libaec: '>=1.1.4,<2.0a0'
-    libcurl: '>=8.14.1,<9.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.2,<4.0a0'
-    zlib: ''
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.3-nompi_h11f7409_103.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_hb6f1874_104.conda
   hash:
-    md5: 3ccff1066c05a1e6c221356eecc40581
-    sha256: e9a8668212719a91a6b0348db05188dfc59de5a21888db13ff8510918a67b258
+    md5: e9e60f617e5545e1a7de60c2d01f8029
+    sha256: 7deab19f51934a5bfdf8eec10721d91a02c6a27632471527b07ece8f0d2c7a8e
   category: main
   optional: false
 - name: libnetcdf
-  version: 4.9.3
+  version: 4.10.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     blosc: '>=1.21.6,<2.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     hdf4: '>=4.2.15,<4.2.16.0a0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libaec: '>=1.1.4,<2.0a0'
-    libcurl: '>=8.14.1,<9.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libcxx: '>=19'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    mpich: '>=4.3.1,<5.0a0'
-    openssl: '>=3.5.2,<4.0a0'
-    zlib: ''
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.3-mpi_mpich_h0fdbe1b_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.10.0-nompi_h2d2ed95_104.conda
   hash:
-    md5: e4359a409365056520a6ab3d9a905821
-    sha256: 6c70f97b228e1debb7af2c5dc7e221c8e1fc9314167e67bf68a508eb6486983a
+    md5: a58584c0f0e1caa07c02cf5ff065b03a
+    sha256: 8cecfe0abadb79ad1292213755962be0fc709da44ad0df59b9b052d2b82ace89
   category: main
   optional: false
 - name: libnetcdf
-  version: 4.9.3
+  version: 4.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10675,74 +11204,71 @@ package:
     bzip2: '>=1.0.8,<2.0a0'
     hdf4: '>=4.2.15,<4.2.16.0a0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libaec: '>=1.1.4,<2.0a0'
-    libcurl: '>=8.14.1,<9.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libcurl: '>=8.19.0,<9.0a0'
     libcxx: '>=19'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzip: '>=1.11.2,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    mpich: '>=4.3.1,<5.0a0'
-    openssl: '>=3.5.2,<4.0a0'
-    zlib: ''
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.3-mpi_mpich_hf007bf3_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.10.0-nompi_h7a8d41e_104.conda
   hash:
-    md5: 5e5d36351ce67e40781d3dc205edffa2
-    sha256: b31ad71b7a60a923570ae75ae76d89adb1b66c152153c3a7ef9b4178a1d90a72
+    md5: a78ca7f5fd6a7431bc0c128c2ce759be
+    sha256: db5bd198e5b22277beab224f2e89527fa260d97081bc32dfad797c8530b5eca6
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.67.0
+  version: 1.68.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.5,<2.0a0'
+    c-ares: '>=1.34.6,<2.0a0'
     libev: '>=4.33,<5.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
   hash:
-    md5: b499ce4b026493a13774bcf0f4c33849
-    sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
+    md5: 2a45e7f8af083626f009645a6481f12d
+    sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.67.0
+  version: 1.68.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    c-ares: '>=1.34.5,<2.0a0'
+    __osx: '>=11.0'
+    c-ares: '>=1.34.6,<2.0a0'
     libcxx: '>=19'
     libev: '>=4.33,<5.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.67.0-h3338091_0.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
   hash:
-    md5: e7630cef881b1174d40f3e69a883e55f
-    sha256: c48d7e1cc927aef83ff9c48ae34dd1d7495c6ccc1edc4a3a6ba6aff1624be9ac
+    md5: dba4c95e2fe24adcae4b77ebf33559ae
+    sha256: 899551e16aac9dfb85bfc2fd98b655f4d1b7fea45720ec04ccb93d95b4d24798
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.67.0
+  version: 1.68.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    c-ares: '>=1.34.5,<2.0a0'
+    c-ares: '>=1.34.6,<2.0a0'
     libcxx: '>=19'
     libev: '>=4.33,<5.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.2,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.67.0-hc438710_0.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
   hash:
-    md5: a4b4dd73c67df470d091312ab87bf6ae
-    sha256: a07cb53b5ffa2d5a18afc6fd5a526a5a53dd9523fbc022148bd2f9395697c46d
+    md5: 6ea18834adbc3b33df9bd9fb45eaf95b
+    sha256: 2bc7bc3978066f2c274ebcbf711850cc9ab92e023e433b9631958a098d11e10a
   category: main
   optional: false
 - name: libnsl
@@ -10759,7 +11285,7 @@ package:
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.30
+  version: 0.3.32
   manager: conda
   platform: linux-64
   dependencies:
@@ -10767,29 +11293,29 @@ package:
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
   hash:
-    md5: be43915efc66345cccb3c310b6ed0374
-    sha256: 199d79c237afb0d4780ccd2fbf829cea80743df60df4705202558675e07dd2c5
+    md5: 89d61bc91d3f39fda0ca10fcd3c68594
+    sha256: 6dc30b28f32737a1c52dada10c8f3a41bc9e021854215efca04a7f00487d09d9
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.30
+  version: 0.3.32
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     llvm-openmp: '>=19.1.7'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.30-openmp_h6006d49_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.32-openmp_h9e49c7b_0.conda
   hash:
-    md5: 9241a65e6e9605e4581a2a8005d7f789
-    sha256: ba642353f7f41ab2d2eb6410fbe522238f0f4483bcd07df30b3222b4454ee7cd
+    md5: 4058c5f8dbef6d28cb069f96b95ae6df
+    sha256: 6764229359cd927c9efc036930ba28f83436b8d6759c5ac4ea9242fc29a7184e
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.30
+  version: 0.3.32
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10797,10 +11323,10 @@ package:
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     llvm-openmp: '>=19.1.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
   hash:
-    md5: a6f6d3a31bb29e48d37ce65de54e2df0
-    sha256: ebbbc089b70bcde87c4121a083c724330f02a690fb9d7c6cd18c30f1b12504fa
+    md5: 3a1111a4b6626abebe8b978bb5a323bf
+    sha256: 713e453bde3531c22a660577e59bf91ef578dcdfd5edb1253a399fa23514949a
   category: main
   optional: false
 - name: libopengl
@@ -10916,11 +11442,11 @@ package:
     libgcc: '>=14'
     libstdcxx: '>=14'
     libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-23.0.0-h7376487_1_cpu.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-23.0.0-h7376487_2_cuda.conda
   hash:
-    md5: e7562d15926b3cea66a6e3546b133c5d
-    sha256: 2498642c6366d1f141ee4c22e8504e0704bd961a46b091a28674b1b2d63c778d
+    md5: 1e2a463be2b1248c214b246fa14b72f6
+    sha256: b97e076c60f017810d38a411547f4fd7ae014e1b8c6a0ec189ffcb531319a41a
   category: main
   optional: false
 - name: libparquet
@@ -10935,11 +11461,11 @@ package:
     libopentelemetry-cpp: '>=1.21.0,<1.22.0a0'
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
     libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-23.0.0-ha0d2768_1_cpu.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-23.0.0-ha0d2768_2_cpu.conda
   hash:
-    md5: b5d2acb91e5f4fe5fa73ef33794bcd7a
-    sha256: f97c0941c91d4739171e084a51ff1ccd56d1ba941ae30fc4d7abd1a2b62bc12c
+    md5: 174b6059fc1102dbe2a784d732e919b4
+    sha256: 7bcdca6f68c17e1b154c39bcc5ea8be65a555e8c7c562b291df0bd290523fd2a
   category: main
   optional: false
 - name: libparquet
@@ -10954,11 +11480,11 @@ package:
     libopentelemetry-cpp: '>=1.21.0,<1.22.0a0'
     libprotobuf: '>=6.31.1,<6.31.2.0a0'
     libthrift: '>=0.22.0,<0.22.1.0a0'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-23.0.0-hcc2992d_1_cpu.conda
+    openssl: '>=3.5.5,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-23.0.0-hcc2992d_2_cpu.conda
   hash:
-    md5: 4c1f3011d9a4ef9da705c27873ef7315
-    sha256: 1cec55158a0346323362c27e9f8115f9e65fb2364053fb20d9e80bca4516b734
+    md5: 7b877b0e610ca5a58a8947eadb1f6191
+    sha256: 8a73ec8dd63d993ba4d0daa366470d0b68f3fcda7386362ec10a0e1abae5a9b8
   category: main
   optional: false
 - name: libpciaccess
@@ -10974,76 +11500,44 @@ package:
     sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
   category: main
   optional: false
-- name: libpnetcdf
-  version: 1.14.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=19'
-    libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    mpich: '>=4.3.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpnetcdf-1.14.1-mpi_mpich_h981b6f0_100.conda
-  hash:
-    md5: e95bd6b51695b03da2fff6765a1e0389
-    sha256: 285d97a0628af7b7f4a57f06fae209bf64d2e89738187228c648c7b233436b0f
-  category: main
-  optional: false
-- name: libpnetcdf
-  version: 1.14.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-    libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    mpich: '>=4.3.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpnetcdf-1.14.1-mpi_mpich_h23c1e46_100.conda
-  hash:
-    md5: d2a90b80dda0358e86f7fa1720705b77
-    sha256: 07d82fb438b4cc360b29228ace038bb439bc8ed4cb8780afb67a53489f348be3
-  category: main
-  optional: false
 - name: libpng
-  version: 1.6.54
+  version: 1.6.58
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.54-h421ea60_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
   hash:
-    md5: d361fa2a59e53b61c2675bfa073e5b7e
-    sha256: 5de60d34aac848a9991a09fcdea7c0e783d00024aefec279d55e87c0c44742cd
+    md5: eba48a68a1a2b9d3c0d9511548db85db
+    sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
   category: main
   optional: false
 - name: libpng
-  version: 1.6.54
+  version: 1.6.58
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.54-h07817ec_0.conda
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
   hash:
-    md5: 3d43dcdfcc3971939c80f855cf2df235
-    sha256: c0efdf9b34132e7d4e0051bf65a97f1b9e1125c7f8a9067a35ec119af367eb38
+    md5: 9744d43d5200f284260637304a069ddd
+    sha256: a669b22978e546484d18d99a210801b1823360a266d7035c713d8d1facd035f7
   category: main
   optional: false
 - name: libpng
-  version: 1.6.54
+  version: 1.6.58
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.54-h132b30e_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
   hash:
-    md5: 1b80fd1eecb98f1cb7de4239f5d7dc15
-    sha256: 1c271c0ec73b69f7570c5da67d0e47ddf7ff079bc1ca2dfaccd267ea39314b06
+    md5: 2259ae0949dbe20c0665850365109b27
+    sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   category: main
   optional: false
 - name: libprotobuf
@@ -11136,55 +11630,64 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.60.0
+  version: 2.62.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.4,<2.0a0'
-    gdk-pixbuf: '>=2.44.3,<3.0a0'
+    fontconfig: '>=2.17.1,<3.0a0'
+    fonts-conda-ecosystem: ''
+    gdk-pixbuf: '>=2.44.5,<3.0a0'
+    harfbuzz: '>=13.1.1'
     libgcc: '>=14'
-    libglib: '>=2.86.0,<3.0a0'
+    libglib: '>=2.86.4,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
   hash:
-    md5: 91e6d4d684e237fba31b9815c4b40edf
-    sha256: 960b137673b2b8293e2a12d194add72967b3bf12fcdf691e7ad8bd5c8318cec3
+    md5: a4b87f1fbcdbb8ad32e99c2611120f2e
+    sha256: dc4698b32b2ca3fc0715d7d307476a71622bee0f2f708f9dadec8af21e1047c8
   category: main
   optional: false
 - name: librsvg
-  version: 2.60.0
+  version: 2.62.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
-    gdk-pixbuf: '>=2.44.3,<3.0a0'
-    libglib: '>=2.86.0,<3.0a0'
+    fontconfig: '>=2.17.1,<3.0a0'
+    fonts-conda-ecosystem: ''
+    gdk-pixbuf: '>=2.44.5,<3.0a0'
+    harfbuzz: '>=13.1.1'
+    libglib: '>=2.86.4,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.60.0-h2da6fc3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.62.1-h7321050_0.conda
   hash:
-    md5: 0e5609c0f8e5421e43301bcc3c5e1985
-    sha256: 9ac53c255af84a3913015796797785f6a94e12ea991e1c36735c5aefaf70ebca
+    md5: 471e8234c120e51c76dada4f86fc8ed5
+    sha256: ef63983208a0037d5eef331ea157bf892c73e0a73e41692fd02471fb48a7f920
   category: main
   optional: false
 - name: librsvg
-  version: 2.60.0
+  version: 2.62.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
-    gdk-pixbuf: '>=2.44.3,<3.0a0'
-    libglib: '>=2.86.0,<3.0a0'
+    fontconfig: '>=2.17.1,<3.0a0'
+    fonts-conda-ecosystem: ''
+    gdk-pixbuf: '>=2.44.5,<3.0a0'
+    harfbuzz: '>=13.1.1'
+    libglib: '>=2.86.4,<3.0a0'
     libxml2-16: '>=2.14.6'
     pango: '>=1.56.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.60.0-h5c55ec3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.1-he8aa2a2_0.conda
   hash:
-    md5: 05ad1d6b6fb3b384f7a07128025725cb
-    sha256: ca5a2de5d3f68e8d6443ea1bf193c1596a278e6f86018017c0ccd4928eaf8971
+    md5: 4766fd69e64e477b500eb901dbe7bb6b
+    sha256: 4d28ad0213fca6f93624c27f13493b986ce63e05386d2ff7a2ad723c4e7c7cec
   category: main
   optional: false
 - name: librttopo
@@ -11306,45 +11809,45 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.51.2
+  version: 3.53.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.2,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
   hash:
-    md5: da5be73701eecd0e8454423fd6ffcf30
-    sha256: 04596fcee262a870e4b7c9807224680ff48d4d0cc0dac076a602503d3dc6d217
+    md5: 810d83373448da85c3f673fbcb7ad3a3
+    sha256: ec37c79f737933bbac965f5dc0f08ef2790247129a84bb3114fad4900adce401
   category: main
   optional: false
 - name: libsqlite
-  version: 3.51.2
+  version: 3.53.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.51.2-hb99441e_0.conda
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.0-h8f8c405_0.conda
   hash:
-    md5: d910105ce2b14dfb2b32e92ec7653420
-    sha256: 710a7ea27744199023c92e66ad005de7f8db9cf83f10d5a943d786f0dac53b7c
+    md5: f2bb6692dfb33a1bbce746aa812a9a5b
+    sha256: ae9d83cab8988a7d4ccec411fef23c141b5b3d301db3e926ab7cd4befe3764e6
   category: main
   optional: false
 - name: libsqlite
-  version: 3.51.2
+  version: 3.53.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.2,<79.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
   hash:
-    md5: 4b0bf313c53c3e89692f020fb55d5f2c
-    sha256: 6e9b9f269732cbc4698c7984aa5b9682c168e2a8d1e0406e1ff10091ca046167
+    md5: 8423c008105df35485e184066cad4566
+    sha256: 1a9d1e3e18dbb0b87cff3b40c3e42703730d7ac7ee9b9322c2682196a81ba0c3
   category: main
   optional: false
 - name: libssh2
@@ -11396,10 +11899,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
   hash:
-    md5: 68f68355000ec3f1d6f26ea13e8f525f
-    sha256: 813427918316a00c904723f1dfc3da1bbc1974c5cfe1ed1e704c6f4e0798cbc6
+    md5: 1b08cd684f34175e4514474793d44bcb
+    sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
   category: main
   optional: false
 - name: libstdcxx-ng
@@ -11408,10 +11911,10 @@ package:
   platform: linux-64
   dependencies:
     libstdcxx: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
   hash:
-    md5: 1b3152694d236cf233b76b8c56bf0eae
-    sha256: 81f2f246c7533b41c5e0c274172d607829019621c4a0823b5c0b4a8c7028ee84
+    md5: 6235adb93d064ecdf3d44faee6f468de
+    sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
   category: main
   optional: false
 - name: libthrift
@@ -11423,12 +11926,12 @@ package:
     libevent: '>=2.1.12,<2.1.13.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h454ac66_1.conda
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
   hash:
-    md5: 8ed82d90e6b1686f5e98f8b7825a15ef
-    sha256: 4888b9ea2593c36ca587a5ebe38d0a56a0e6d6a9e4bb7da7d9a326aaaca7c336
+    md5: b6e326fbe1e3948da50ec29cee0380db
+    sha256: af6025aa4a4fc3f4e71334000d2739d927e2f678607b109ec630cc17d716918a
   category: main
   optional: false
 - name: libthrift
@@ -11436,15 +11939,15 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.22.0-h687e942_1.conda
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.22.0-hebea4ca_2.conda
   hash:
-    md5: 69251ed374b31a5664bf5ba58626f3b7
-    sha256: a0f9fdc663db089fde4136a0bd6c819d7f8daf869fc3ca8582201412e47f298c
+    md5: 36d5479e1b5967c2eb9824b953317e41
+    sha256: 89a20cb35e0f32d59a7080c934a56120591cb962d4fab1cba3a795a094bc8256
   category: main
   optional: false
 - name: libthrift
@@ -11455,12 +11958,12 @@ package:
     __osx: '>=11.0'
     libcxx: '>=19'
     libevent: '>=2.1.12,<2.1.13.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h14a376c_1.conda
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h1fb9c8a_2.conda
   hash:
-    md5: 3161023bb2f8c152e4c9aa59bdd40975
-    sha256: 8b703f2c6e47ed5886d7298601b9416b59e823fc8d1a8fa867192c94c5911aac
+    md5: d006875f9a58a44f92aec9a7ebeb7150
+    sha256: 568bb23db02b050c3903bec05edbcab84960c8c7e5a1710dac3109df997ac7f1
   category: main
   optional: false
 - name: libtiff
@@ -11599,40 +12102,40 @@ package:
   category: main
   optional: false
 - name: libuuid
-  version: 2.41.3
+  version: '2.42'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
   hash:
-    md5: db409b7c1720428638e7c0d509d3e1b5
-    sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
+    md5: 38ffe67b78c9d4de527be8315e5ada2c
+    sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
   category: main
   optional: false
 - name: libuuid
-  version: 2.41.3
+  version: '2.42'
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuuid-2.41.3-h3fe7000_0.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuuid-2.42-h58504dd_0.conda
   hash:
-    md5: 781317c18cbc0d1a08e37ccbd674b8e2
-    sha256: 2f464c8c24fe8e6a96c7856c5fcc2a9e43689d24e98ddbeb2f9ef6b55d4289fa
+    md5: af1da8ab8575dc8da4d99b2995d6fc66
+    sha256: f44603e224cb06d21fbd2842670ac8444856ce7496e06d85d7dfd76ec5ea67c1
   category: main
   optional: false
 - name: libuuid
-  version: 2.41.3
+  version: '2.42'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuuid-2.41.3-h0053d0f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuuid-2.42-h7b1c3a4_0.conda
   hash:
-    md5: 5e4c76ba638d70a2e1ba9ed34dc4dced
-    sha256: 28b4a4ef050413e7793dfb935e675a9f57423e20ea98f4c0b165d1386b05f93b
+    md5: e158f0764308852789ecadf336406dec
+    sha256: 002863cf314c567a57f3fd7e388740071be02ced631d79b39a997b1255283ad2
   category: main
   optional: false
 - name: libwebp-base
@@ -11719,7 +12222,7 @@ package:
   category: main
   optional: false
 - name: libxgboost
-  version: 3.1.3
+  version: 3.2.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -11727,38 +12230,38 @@ package:
     _openmp_mutex: '>=4.5'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxgboost-3.1.3-cpu_h2ebb00f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxgboost-3.2.0-cpu_h2ebb00f_1.conda
   hash:
-    md5: fb035e541b59f46b1cbcf7979c395bec
-    sha256: bfd245300c41d0961abe749b0b8ad83b03a7b63528aba1fea76836534a0de8c5
+    md5: a78c513baa6b68aec0ba19f53f8f476a
+    sha256: 7acbfd2fc01fc4cab13540b361fb1d4aa467d32f35fbc87d262e641e8d15ddda
   category: main
   optional: false
 - name: libxgboost
-  version: 3.1.3
+  version: 3.2.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=19'
     llvm-openmp: '>=19.1.7'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxgboost-3.1.3-cpu_h819c4c3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxgboost-3.2.0-cpu_h819c4c3_1.conda
   hash:
-    md5: 0d60004b8c6a8af56f843eeaf956e111
-    sha256: f5722edbe44fee3f6dd5eebe7cb6c61ff0553b3ba2e71c40f41148459fe03dd8
+    md5: baacf8b97bd968147f70d28e91a3e174
+    sha256: 2c8ecd77201b40f23cfae7ad8aaec4459f2a0918f6f3da950fda09a701b6696d
   category: main
   optional: false
 - name: libxgboost
-  version: 3.1.3
+  version: 3.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
     llvm-openmp: '>=19.1.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxgboost-3.1.3-cpu_h77aee5e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxgboost-3.2.0-cpu_h77aee5e_1.conda
   hash:
-    md5: 01eabfa67fa1b051147f05b58aa58d4f
-    sha256: 0ff94e8090ba89c7a53475133e38c5708c972284bc9836b5b0f74a57e8c1af91
+    md5: d9a704339570ed7ad6ef2e778af89f31
+    sha256: 1e6c4a6970deef10cf173091eccef7921252fd93833aa98d1468554062e926aa
   category: main
   optional: false
 - name: libxkbcommon
@@ -11781,159 +12284,159 @@ package:
   category: main
   optional: false
 - name: libxml2
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.1,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxml2-16: 2.15.1
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
   hash:
-    md5: 417955234eccd8f252b86a265ccdab7f
-    sha256: 047be059033c394bd32ae5de66ce389824352120b3a7c0eff980195f7ed80357
+    md5: 995d8c8bad2a3cc8db14675a153dec2b
+    sha256: 3bc5551720c58591f6ea1146f7d1539c734ed1c40e7b9f5cb8cb7e900c509aba
   category: main
   optional: false
 - name: libxml2
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    icu: '>=78.1,<79.0a0'
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxml2-16: 2.15.1
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.1-h24ca049_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
   hash:
-    md5: c58fc83257ad06634b9c935099ef2680
-    sha256: 24ecb3a3eed2b17cec150714210067cafc522dec111750cbc44f5921df1ffec3
+    md5: 33f30d4878d1f047da82a669c33b307d
+    sha256: 24248928e63b5de45012c8ad3fd6b350ae1fe2fc355613bb89ee5f0a35835bea
   category: main
   optional: false
 - name: libxml2
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.1,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxml2-16: 2.15.1
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.1-h8d039ee_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
   hash:
-    md5: fd804ee851e20faca4fecc7df0901d07
-    sha256: 59f96fa27cce6a9a27414c5bb301eedda1a1b85cd0d8f5d68f77e46b86e7c95f
+    md5: 8e037d73747d6fe34e12d7bcac10cf21
+    sha256: 2fe1d8de0854342ae9cabe408b476935f82f5636e153b3b497456264dc8ff3a1
   category: main
   optional: false
 - name: libxml2-16
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.1,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
   hash:
-    md5: 3fdd8d99683da9fe279c2f4cecd1e048
-    sha256: 8331284bf9ae641b70cdc0e5866502dd80055fc3b9350979c74bb1d192e8e09e
+    md5: e79d2c2f24b027aa8d5ab1b1ba3061e7
+    sha256: 3d44f737c5ae52d5af32682cc1530df433f401f8e58a7533926536244127572a
   category: main
   optional: false
 - name: libxml2-16
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    icu: '>=78.1,<79.0a0'
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.1-he456531_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
   hash:
-    md5: 6cd21078a491bdf3fdb7482e1680ef63
-    sha256: eff0894cd82f2e055ea761773eb80bfaacdd13fbdd427a80fe0c5b00bf777762
+    md5: c74ae93cd7876e3a9c4b5569d5e29e34
+    sha256: 437f003e299d77403db42d17e532d686236f357ac5c3d6bf466558c697902597
   category: main
   optional: false
 - name: libxml2-16
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.1,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.1-h5ef1a60_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
   hash:
-    md5: 7eed1026708e26ee512f43a04d9d0027
-    sha256: 2d5ab15113b0ba21f4656d387d26ab59e4fbaf3027f5e58a2a4fe370821eb106
+    md5: 19edaa53885fc8205614b03da2482282
+    sha256: ff75b84cdb9e8d123db2fa694a8ac2c2059516b6cbc98ac21fb68e235d0fd354
   category: main
   optional: false
 - name: libxml2-devel
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.1,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxml2: 2.15.1
-    libxml2-16: 2.15.1
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.1-he237659_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2: 2.15.3
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.3-h49c6c72_0.conda
   hash:
-    md5: 644b2a3a92ba0bb8e2aa671dd831e793
-    sha256: 6621eb70375ff867c7c6606c216139e47eade8dfad78bcf7bdd0a62dc87d629f
+    md5: be70cb50dd0ecc1531c58034d38f72e0
+    sha256: adada9c781ea51faea3e3adcd6883dc294ff2fa044c7f4e199430a11862dfa40
   category: main
   optional: false
 - name: libxml2-devel
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    icu: '>=78.1,<79.0a0'
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxml2: 2.15.1
-    libxml2-16: 2.15.1
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-devel-2.15.1-h24ca049_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2: 2.15.3
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-devel-2.15.3-h953d39d_0.conda
   hash:
-    md5: cc1c67f0676478f972e26c5649ea68ac
-    sha256: 5db52eae7357f89c16d08ab21ec89b35a7361e1d7be277716505e9764fe37eb8
+    md5: 875a51e12cc99a98d70aa48055f40ba4
+    sha256: 05ed86d6395a8c7aeabc5d5505e2189ebca33e14073895a3f3d1b4db37c67333
   category: main
   optional: false
 - name: libxml2-devel
-  version: 2.15.1
+  version: 2.15.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.1,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libxml2: 2.15.1
-    libxml2-16: 2.15.1
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-devel-2.15.1-h8d039ee_1.conda
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2: 2.15.3
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-devel-2.15.3-h5654f7c_0.conda
   hash:
-    md5: 8975a4d0277920627000f0126c3c2b48
-    sha256: a51ac5f66270b5f21b6669d705531208ab599a8744c7e60c1638229e22c8267d
+    md5: 469f4af737803bf7deda25d41c557593
+    sha256: 541980a15bf0acb7794754f1cde9cfeb74ca27c139d065c1c6541c73b4e07105
   category: main
   optional: false
 - name: libxslt
@@ -12026,40 +12529,39 @@ package:
   category: main
   optional: false
 - name: libzlib
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
   hash:
-    md5: edb0dca6bc32e4f4789199455a1dbeb8
-    sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+    md5: d87ff7921124eccd67248aa483c23fec
+    sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
   category: main
   optional: false
 - name: libzlib
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
   hash:
-    md5: 003a54a4e32b02f7355b50a837e699da
-    sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+    md5: 30439ff30578e504ee5e0b390afc8c65
+    sha256: 4c6da089952b2d70150c74234679d6f7ac04f4a98f9432dec724968f912691e7
   category: main
   optional: false
 - name: libzlib
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
   hash:
-    md5: 369964e85dc26bfe78f41399b366c435
-    sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+    md5: bc5a5721b6439f2f62a84f2548136082
+    sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
   category: main
   optional: false
 - name: libzopfli
@@ -12154,79 +12656,79 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 21.1.8
+  version: 22.1.4
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.8-h472b3d1_0.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.4-h0d3cbff_0.conda
   hash:
-    md5: e2d811e9f464dd67398b4ce1f9c7c872
-    sha256: 2a41885f44cbc1546ff26369924b981efa37a29d20dc5445b64539ba240739e6
+    md5: fac1a640081b85688ead36a88c4d20ff
+    sha256: c933580850e35ec0b8c53439aa63041e979fc6fe845fe0630bc6476acae8293c
   category: main
   optional: false
 - name: llvm-openmp
-  version: 21.1.8
+  version: 22.1.4
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.8-h4a912ad_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.4-hc7d1edf_0.conda
   hash:
-    md5: 206ad2df1b5550526e386087bef543c7
-    sha256: 56bcd20a0a44ddd143b6ce605700fdf876bcf5c509adc50bf27e76673407a070
+    md5: 46d04a647df7a4525e487d88068d19ef
+    sha256: a269273ccf48be6ac582bb958713ba8373262b9157a0fc76b7e5475e8a1d2a78
   category: main
   optional: false
 - name: llvmlite
-  version: 0.46.0
+  version: 0.47.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.46.0-py313hdd307be_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.47.0-py313hdd307be_1.conda
   hash:
-    md5: d99ac09b331711fd12e16323ca8d96e4
-    sha256: 0e1bc6ee1c7885cc26c37fcd1a2095169a4e4e148860c600d3f685b6a4f32322
+    md5: 916eb82289f0d2209176fd2d05c5d1f5
+    sha256: 3e9bf7bdbae5c3bc8f3831351016e880c931816c27f076fbd5d400914727e539
   category: main
   optional: false
 - name: llvmlite
-  version: 0.46.0
+  version: 0.47.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.46.0-py313h590e1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.47.0-py313he3abfad_1.conda
   hash:
-    md5: ab9fe8b3937e90b22a18554c3d961e97
-    sha256: f1549261f0f2f24c2dd2c7a613b465c0c3e4e1158c43a72224c228aa0b5cb76f
+    md5: 8f3ee1831de575259c46f0ca2a526e7a
+    sha256: 2349c94059290b700dca814046ba4fb2dbecc109e644e6890c3a60b794101b7a
   category: main
   optional: false
 - name: llvmlite
-  version: 0.46.0
+  version: 0.47.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.46.0-py313he297ed2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.47.0-py313h691f2cf_1.conda
   hash:
-    md5: 81f05ab2abc842253505133ffa652bf5
-    sha256: d59fdc5a5682e3f6c17f1c8dc73019afaf6724f4ecd10878515438ca35683269
+    md5: 83997263c510455908d0987b6e14afd6
+    sha256: a092b6d86ee2ec3af1fdecf4835438eadefe3e4e59e77019848a669f8a60de94
   category: main
   optional: false
 - name: locket
@@ -12266,7 +12768,7 @@ package:
   category: main
   optional: false
 - name: lxml
-  version: 6.0.2
+  version: 6.1.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -12275,35 +12777,35 @@ package:
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libxslt: '>=1.1.43,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py313h4a16004_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.0-py313h4a16004_0.conda
   hash:
-    md5: eb93cf5d79939716bc82434eb7e1af30
-    sha256: f2b2ffa585d1bf74faea4c04e7e39b4230c1390c0b889e2ac725fc2a343d9de0
+    md5: e5ba7f288d2389e3801952efa1be111f
+    sha256: 96dc58adadf29655c0a010c5268ef7cf3c7fb676015b7c96bc9dc01c800b659e
   category: main
   optional: false
 - name: lxml
-  version: 6.0.2
+  version: 6.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libxslt: '>=1.1.43,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/lxml-6.0.2-py313h00bd3da_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/lxml-6.1.0-py313hdc5d0a5_0.conda
   hash:
-    md5: 4158c697b90cba2db2ca8d58bd4461fb
-    sha256: ad3ad781171593306f754442c8ccd4853bc90a57b30b49f48de723a8d6065d3e
+    md5: 25a36c8381c419eb1bd90c38a35ff375
+    sha256: 01fe4c1673a0f99e53a28ddef1ee4fac4c5e7ab0c3691287edd2d7013cecfc01
   category: main
   optional: false
 - name: lxml
-  version: 6.0.2
+  version: 6.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12311,13 +12813,13 @@ package:
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libxslt: '>=1.1.43,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.2-py313he6cafaa_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.1.0-py313h28ec6f0_0.conda
   hash:
-    md5: fbeb15565dc7202f9dce40783d0b270d
-    sha256: 1be65e16e4e89d333de95b356a75df9f050a0f505e6b82633ba8157c76239835
+    md5: 15ee46eb46f3a43538ecc9236ac399ee
+    sha256: caabfe28000b4242a33c46e0625e3c72fa94e5246926d41386f896a26cc91ad8
   category: main
   optional: false
 - name: lz4
@@ -12452,22 +12954,25 @@ package:
     cairo: '>=1.18.4,<2.0a0'
     eccodes: '>=2.21.0'
     expat: ''
-    libexpat: '>=2.7.1,<3.0a0'
+    freetype: ''
+    libexpat: '>=2.7.5,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.0,<3.0a0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
+    libglib: '>=2.86.4,<3.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     magics-python: ''
     pango: '>=1.56.4,<2.0a0'
-    proj: '>=9.7.0,<9.8.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
     simplejson: ''
     xorg-xorgproto: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/magics-4.16.0-h637ef6b_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/magics-4.16.0-h1a1f456_4.conda
   hash:
-    md5: de519f1c69a8e0963fb52ab9deff9999
-    sha256: cd1227d176d6f8437b31fc82e64b78d743a55473927764d2c1e4aa9400b3e88f
+    md5: 71975455784f2903a277e920813a5299
+    sha256: d90c1f2b6a7f6da1052b4f28c18c5811bd5e5b51bff7416b7e8f1587d9804de0
   category: main
   optional: false
 - name: magics
@@ -12475,25 +12980,28 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.15'
+    __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
     eccodes: '>=2.21.0'
     expat: ''
+    freetype: ''
     libcxx: '>=19'
-    libexpat: '>=2.7.1,<3.0a0'
-    libglib: '>=2.86.0,<3.0a0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.86.4,<3.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     magics-python: ''
     pango: '>=1.56.4,<2.0a0'
-    proj: '>=9.7.0,<9.8.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
     simplejson: ''
     xorg-xorgproto: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/magics-4.16.0-h3e217e6_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/magics-4.16.0-h6824280_4.conda
   hash:
-    md5: cd37b9304622f5b0bdc85ecf5d31ce34
-    sha256: 319f4df2423e187bc61db3f83d290237116e818fa5982fe867c9f7a7a1148141
+    md5: 87b0820b96c5c698a5977e02acd16d84
+    sha256: db85598324802e7eebe1d5327b9d808e9297c60f35719b31b0496a0c341c1d71
   category: main
   optional: false
 - name: magics
@@ -12505,21 +13013,24 @@ package:
     cairo: '>=1.18.4,<2.0a0'
     eccodes: '>=2.21.0'
     expat: ''
+    freetype: ''
     libcxx: '>=19'
-    libexpat: '>=2.7.1,<3.0a0'
-    libglib: '>=2.86.0,<3.0a0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.86.4,<3.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     magics-python: ''
     pango: '>=1.56.4,<2.0a0'
-    proj: '>=9.7.0,<9.8.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
     simplejson: ''
     xorg-xorgproto: ''
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/magics-4.16.0-hae7c3dd_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/magics-4.16.0-hbbcb6f6_4.conda
   hash:
-    md5: 4bd05c3a17f87d35c6d5b6965228acd8
-    sha256: b406de450a047da18db3205614d7e53d81cc0148bba0db7ebcba25b8aefec30a
+    md5: 9b0760c3f60cf0785222160d9734b0af
+    sha256: 6fa5880ab061af38c9a9509658b04532d50ce6ef3d4ef5abeabb40ad30a37f81
   category: main
   optional: false
 - name: magics-python
@@ -12678,10 +13189,10 @@ package:
     libgcc: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py313h3dea7bd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py313h3dea7bd_1.conda
   hash:
-    md5: c14389156310b8ed3520d84f854be1ee
-    sha256: a530a411bdaaf0b1e4de8869dfaca46cb07407bc7dc0702a9e231b0e5ce7ca85
+    md5: aeb9b9da79fd0258b3db091d1fefcd71
+    sha256: 72ed7c0216541d65a17b171bf2eec4a3b81e9158d8ed48e59e1ecd3ae302d263
   category: main
   optional: false
 - name: markupsafe
@@ -12689,13 +13200,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py313h0f4d31d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py313h035b7d0_1.conda
   hash:
-    md5: 884a82dc80ecd251e38d647808c424b3
-    sha256: 9c698da56e3bdae80be2a7bc0d19565971b36060155374d16fce14271c8b695c
+    md5: 3d88718cbd26857fb68fa899e80177ea
+    sha256: e589b345402e352fb47394f7bc311c241f37627a34a9becc9299b395809a5853
   category: main
   optional: false
 - name: markupsafe
@@ -12706,14 +13217,14 @@ package:
     __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py313h7d74516_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py313h65a2061_1.conda
   hash:
-    md5: 3df5979cc0b761dda0053ffdb0bca3ea
-    sha256: e06902a1bf370fdd4ada0a8c81c504868fdb7e9971b72c6bd395aa4e5a497bd2
+    md5: 0195d558b0c0ab8f4af3089af83067c5
+    sha256: f62892a42948c61aa0a13d9a36ff811651f0a1102331223594aecf3cc042bece
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.8
+  version: 3.10.9
   manager: conda
   platform: linux-64
   dependencies:
@@ -12723,8 +13234,8 @@ package:
     fonttools: '>=4.22.0'
     freetype: ''
     kiwisolver: '>=1.3.1'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libgcc: '>=14'
     libstdcxx: '>=14'
     numpy: '>=1.23,<3'
@@ -12736,26 +13247,26 @@ package:
     python_abi: 3.13.*
     qhull: '>=2020.2,<2020.3.0a0'
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py313h683a580_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py313h683a580_0.conda
   hash:
-    md5: ffe67570e1a9192d2f4c189b27f75f89
-    sha256: b1117aa2c1d11ca70d1704054cdc8801cbcf2dfb846c565531edd417ddd82559
+    md5: 4265d85b1d706caba7ac1d73b5f43dee
+    sha256: ae0233aa03da84e0964a4c214faaa9d0735575714529a7f2ebe96bc712c276bf
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.8
+  version: 3.10.9
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: ''
     kiwisolver: '>=1.3.1'
     libcxx: '>=19'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     numpy: '>=1.23,<3'
     packaging: '>=20.0'
     pillow: '>=8'
@@ -12764,14 +13275,14 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.13.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.8-py313h4ad75b8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.10.9-py313h864100f_0.conda
   hash:
-    md5: 5a0ed440de10c49cfed0178d3e59d994
-    sha256: d25d81b6022b6d012ea13f3feb41792e3b7de058e73bce05066a72acd0ce77ef
+    md5: 3cab76cf6ccb46b9cab00bc8d0c4f69d
+    sha256: 273224b440675b10074fdf5d81afd963461aedd92a505393002f3fe123d842ba
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.10.8
+  version: 3.10.9
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12782,8 +13293,8 @@ package:
     freetype: ''
     kiwisolver: '>=1.3.1'
     libcxx: '>=19'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     numpy: '>=1.23,<3'
     packaging: '>=20.0'
     pillow: '>=8'
@@ -12792,10 +13303,10 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.13.*
     qhull: '>=2020.2,<2020.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.8-py313h58042b9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.9-py313h36cb854_0.conda
   hash:
-    md5: 745c18472bc6d3dc9146c3dec18bb740
-    sha256: 24767ca32ea9db74a4a5965d2df8c69c83c82583e8ba32b683123d406092e205
+    md5: 31b565206ed2d71a0a6cca1e54e3f2c5
+    sha256: c58141d2971d2c16cc10e0870635ecd4a64ca89aa0b107d3c1afa3d382f99490
   category: main
   optional: false
 - name: matplotlib-inline
@@ -12931,64 +13442,86 @@ package:
     sha256: b3503bd3da5d48d57b44835f423951f487574e08a999f13288c81464ac293840
   category: main
   optional: false
-- name: mpi
-  version: 1.0.1
+- name: mmh3
+  version: 5.2.1
   manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/mmh3-5.2.1-py313h7033f15_0.conda
   hash:
-    md5: 1052de900d672ec8b3713b8e300a8f06
-    sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
+    md5: e975c0be37ebdfc76a84987031cfbb65
+    sha256: 578909286f17317959384e22214b605b7b86e001d4be19d2fc16e0b76c712ce0
   category: main
   optional: false
-- name: mpi
-  version: 1.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
-  hash:
-    md5: 1052de900d672ec8b3713b8e300a8f06
-    sha256: eacc189267202669a1c5c849dcca2298f41acb3918f05cf912d7d61ee7176fac
-  category: main
-  optional: false
-- name: mpich
-  version: 4.3.2
+- name: mmh3
+  version: 5.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-    libfabric: ''
-    libfabric1: '>=1.14.0'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libhwloc: '>=2.12.2,<2.12.3.0a0'
-    mpi: 1.0.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/mpich-4.3.2-h8aa633b_104.conda
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/mmh3-5.2.1-py313hbc4457e_0.conda
   hash:
-    md5: 176a79a47e3e114f607076d2fec76e27
-    sha256: 4d56e109af037e0a30890a0d1692bb642f21b127cde2813461ea008396a96569
+    md5: 3bca4e5a689e7cd678f5924753d52697
+    sha256: ffec8720043bdef49ca1fb9ef27216a1111cfb46d16c8e8c94c3377e65a66377
   category: main
   optional: false
-- name: mpich
-  version: 4.3.2
+- name: mmh3
+  version: 5.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    libfabric: ''
-    libfabric1: '>=1.14.0'
-    libgfortran: ''
-    libgfortran5: '>=14.3.0'
-    libhwloc: '>=2.12.2,<2.12.3.0a0'
-    mpi: 1.0.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpich-4.3.2-hb31c3fa_105.conda
+    python: '>=3.13,<3.14.0a0'
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mmh3-5.2.1-py313h6deaedc_0.conda
   hash:
-    md5: 6bf716ccac6b5839fb3e1d31c6915d69
-    sha256: 3074fbf7a79c49bf0e8bf1063cb509dc7f3585b8c32f9677a3a58492867d2f82
+    md5: dd1664e2a82c512b23186dd58b6e3102
+    sha256: 1ae0adedf16553c40df1c1f28f2f5ec390f3130da7bd959d08050478f11cf661
+  category: main
+  optional: false
+- name: morphys
+  version: '1.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/morphys-1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5ca01eb0a1927c236ee37dba81d05bbc
+    sha256: 2eb9d9c55b940d657eef2ec6a05fb9547a62f1b25d24aa6a7a74b5ac43d10f21
+  category: main
+  optional: false
+- name: morphys
+  version: '1.0'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/morphys-1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5ca01eb0a1927c236ee37dba81d05bbc
+    sha256: 2eb9d9c55b940d657eef2ec6a05fb9547a62f1b25d24aa6a7a74b5ac43d10f21
+  category: main
+  optional: false
+- name: morphys
+  version: '1.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/morphys-1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5ca01eb0a1927c236ee37dba81d05bbc
+    sha256: 2eb9d9c55b940d657eef2ec6a05fb9547a62f1b25d24aa6a7a74b5ac43d10f21
   category: main
   optional: false
 - name: msgpack-python
@@ -13038,7 +13571,7 @@ package:
   category: main
   optional: false
 - name: multidict
-  version: 6.7.0
+  version: 6.7.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -13046,38 +13579,38 @@ package:
     libgcc: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.0-py313h3dea7bd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
   hash:
-    md5: d182804a222acc8f2c7e215f344d229f
-    sha256: b967371e773b36c772976e2e22b526eb5322ba478be94727cff279d146c78181
+    md5: 4f3e7bf5a9fc60a7d39047ba9e84c84c
+    sha256: 3d277c0a9e237dc4c64f0b6414f3cf3e95806b2f5d03dec9c50f0ad0db5b7df1
   category: main
   optional: false
 - name: multidict
-  version: 6.7.0
+  version: 6.7.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.7.0-py313h5d7b66b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.7.1-py313h84cef87_0.conda
   hash:
-    md5: fe4dfc1a4c6bc916cd723c7efe8d3138
-    sha256: f2a73bc88f34c34ebd040933dee1c9879e520f8dfc9c49eae5dc4b76ae9ca3df
+    md5: ba0bbe19fb2f82ca7da2c2d0b8b6ce55
+    sha256: 8ec2cdedd59bccf6ed97ca4da0b0f3b2a25892006c66b660b29f8258b2d3386a
   category: main
   optional: false
 - name: multidict
-  version: 6.7.0
+  version: 6.7.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.0-py313h92dd972_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
   hash:
-    md5: 1e544f6a27a177c52e8d76b351433a3a
-    sha256: edca3b5b539e2455d96dadbf7515ebf65a40859d2d1c21898b747dcb04ab8809
+    md5: f958fcfdcf64155e1e33fb2d3bdb44e0
+    sha256: 7766b348101dcb2cb0ff59c6e5245a295bfdc8355e62990d48c574e7d7474585
   category: main
   optional: false
 - name: multiurl
@@ -13258,39 +13791,39 @@ package:
   category: main
   optional: false
 - name: narwhals
-  version: 2.15.0
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 37926bb0db8b04b8b99945076e1442d0
-    sha256: 2e64699401c6170ce9a0916461ff4686f8d10b076f6abe1d887cbcb7061c0e85
+    md5: 6cac1a50359219d786453c6fef819f98
+    sha256: 676cbfbf709ce984a14e3af5aef70f1ec94a29ea3fdec477115ae302b34a1a2d
   category: main
   optional: false
 - name: narwhals
-  version: 2.15.0
+  version: 2.20.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 37926bb0db8b04b8b99945076e1442d0
-    sha256: 2e64699401c6170ce9a0916461ff4686f8d10b076f6abe1d887cbcb7061c0e85
+    md5: 6cac1a50359219d786453c6fef819f98
+    sha256: 676cbfbf709ce984a14e3af5aef70f1ec94a29ea3fdec477115ae302b34a1a2d
   category: main
   optional: false
 - name: narwhals
-  version: 2.15.0
+  version: 2.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.15.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
   hash:
-    md5: 37926bb0db8b04b8b99945076e1442d0
-    sha256: 2e64699401c6170ce9a0916461ff4686f8d10b076f6abe1d887cbcb7061c0e85
+    md5: 6cac1a50359219d786453c6fef819f98
+    sha256: 676cbfbf709ce984a14e3af5aef70f1ec94a29ea3fdec477115ae302b34a1a2d
   category: main
   optional: false
 - name: natsort
@@ -13299,10 +13832,10 @@ package:
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
   hash:
-    md5: 0aa03903d33997f3886be58abc890aef
-    sha256: 594ae12c32f163f6d312e38de41311a89e476544613df0c1d048f699721621d7
+    md5: e941e85e273121222580723010bd4fa2
+    sha256: aeb1548eb72e4f198e72f19d242fb695b35add2ac7b2c00e0d83687052867680
   category: main
   optional: false
 - name: natsort
@@ -13311,10 +13844,10 @@ package:
   platform: osx-64
   dependencies:
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
   hash:
-    md5: 0aa03903d33997f3886be58abc890aef
-    sha256: 594ae12c32f163f6d312e38de41311a89e476544613df0c1d048f699721621d7
+    md5: e941e85e273121222580723010bd4fa2
+    sha256: aeb1548eb72e4f198e72f19d242fb695b35add2ac7b2c00e0d83687052867680
   category: main
   optional: false
 - name: natsort
@@ -13323,10 +13856,10 @@ package:
   platform: osx-arm64
   dependencies:
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyh29332c3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
   hash:
-    md5: 0aa03903d33997f3886be58abc890aef
-    sha256: 594ae12c32f163f6d312e38de41311a89e476544613df0c1d048f699721621d7
+    md5: e941e85e273121222580723010bd4fa2
+    sha256: aeb1548eb72e4f198e72f19d242fb695b35add2ac7b2c00e0d83687052867680
   category: main
   optional: false
 - name: nc-time-axis
@@ -13420,40 +13953,40 @@ package:
   category: main
   optional: false
 - name: ncurses
-  version: '6.5'
+  version: '6.6'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
   hash:
-    md5: 47e340acb35de30501a76c7c799c41d7
-    sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+    md5: fc21868a1a5aacc937e7a18747acb8a5
+    sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
   category: main
   optional: false
 - name: ncurses
-  version: '6.5'
+  version: '6.6'
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
   hash:
-    md5: ced34dd9929f491ca6dab6a2927aff25
-    sha256: ea4a5d27ded18443749aefa49dc79f6356da8506d508b5296f60b8d51e0c4bd9
+    md5: 31b8740cf1b2588d4e61c81191004061
+    sha256: f5f7e006ff4271305ab4cc08eedd855c67a571793c3d18aff73f645f088a8cae
   category: main
   optional: false
 - name: ncurses
-  version: '6.5'
+  version: '6.6'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
   hash:
-    md5: 068d497125e4bf8a66bf707254fff5ae
-    sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
+    md5: 343d10ed5b44030a2f67193905aea159
+    sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
   category: main
   optional: false
 - name: nested-lookup
@@ -13505,11 +14038,12 @@ package:
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_h90de81b_102.conda
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf-fortran-4.6.2-nompi_he05732c_105.conda
   hash:
-    md5: f4c67a50ac3008a578530e7fc32f3d98
-    sha256: 9deea65513100a377e36991ac1263439dc7e88e823d75dd45183278426bebd25
+    md5: 914e1aad73ecde97c8daee18d8c94525
+    sha256: c190b107c096e8d41b790b4af3ca71395fac6d42162b62c1a64bb0632a6498ec
   category: main
   optional: false
 - name: netcdf-fortran
@@ -13517,16 +14051,16 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
     libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    mpich: '>=4.3.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/netcdf-fortran-4.6.2-mpi_mpich_h5e56383_2.conda
+    libgfortran5: '>=14.3.0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/netcdf-fortran-4.6.2-nompi_hb028221_105.conda
   hash:
-    md5: 69cffc650ee4414cebecc5c3cbb0c651
-    sha256: 05df442df0f51b81fed0118b8a2379862252ba094f8876874b376350dd32b68f
+    md5: 82212e357e8233baeff428bf1fa28470
+    sha256: efcbcb8bf3f05b8fa3c00810dc997b3c709c1cd81b24cc6f33dd5ff283030782
   category: main
   optional: false
 - name: netcdf-fortran
@@ -13537,13 +14071,13 @@ package:
     __osx: '>=11.0'
     hdf5: '>=1.14.6,<1.14.7.0a0'
     libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    mpich: '>=4.3.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf-fortran-4.6.2-mpi_mpich_h87b36d0_2.conda
+    libgfortran5: '>=14.3.0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf-fortran-4.6.2-nompi_h7f4e30d_105.conda
   hash:
-    md5: 18238e1924ec156d690f601893bb6098
-    sha256: d77c65c17507ae1319501735f886bde164bd5018e81383f8955407c49143b783
+    md5: ad257fe2c932c9349e154f75de2dcd68
+    sha256: 1f4b7134bcf71d04e837cf6c344855d888547f5c5413f44ed7a734557e9f8c93
   category: main
   optional: false
 - name: netcdf4
@@ -13552,19 +14086,21 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    _python_abi3_support: 1.*
     certifi: ''
     cftime: ''
+    cpython: '>=3.11'
     hdf5: '>=1.14.6,<1.14.7.0a0'
     libgcc: '>=14'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     numpy: '>=1.23,<3'
+    packaging: ''
     python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py313h16051e2_102.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311ha0596eb_107.conda
   hash:
-    md5: 20ae46c5e9c7106bdb2cac6b44b7d845
-    sha256: 4e1941cc41091c5b598d41d30931864ce3df414ed01e1370a1751bdae294bc8d
+    md5: ef14eaaa377836b3b18ab8a6b07bf9fa
+    sha256: e78690e717e0d7a7ea73ff378f28b6eeaf6341e2ee7123e54b6a64bcf738d80c
   category: main
   optional: false
 - name: netcdf4
@@ -13572,19 +14108,21 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
+    _python_abi3_support: 1.*
     certifi: ''
     cftime: ''
+    cpython: '>=3.11'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     numpy: '>=1.23,<3'
+    packaging: ''
     python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.4-nompi_py313hed393bf_102.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/netcdf4-1.7.4-nompi_py311hd72b3df_107.conda
   hash:
-    md5: 9bcb3b5a24013b0fbf64e71d1e65017c
-    sha256: 5de199c5233b8de24b0f7857d730c81f402db6142e89c4ee9dbef203fea5f95a
+    md5: bb2c556744e59d25123152980ee365a7
+    sha256: 563f4caa5cefccbe686e7c954a152fb607acda3116528950aa4a6274e1a675cb
   category: main
   optional: false
 - name: netcdf4
@@ -13593,18 +14131,20 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
+    _python_abi3_support: 1.*
     certifi: ''
     cftime: ''
+    cpython: '>=3.11'
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     numpy: '>=1.23,<3'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.4-nompi_py313hdfdf71f_102.conda
+    packaging: ''
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.4-nompi_py311h8d5b1ca_107.conda
   hash:
-    md5: 68e72ea5a0e6465088cb1958db97a657
-    sha256: ebbd3f1cf9e53ae605bde38ae7267db8268e03d79554b49911a009b155b95e26
+    md5: d8b44220d12594fcfb4461fde6c4e803
+    sha256: 7a970ec23c8bbc28ca4b9e87f9f433e88652be4a486b985b734a24aa99a390e3
   category: main
   optional: false
 - name: networkx
@@ -13677,7 +14217,7 @@ package:
   category: main
   optional: false
 - name: numba
-  version: 0.63.1
+  version: 0.65.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -13685,50 +14225,50 @@ package:
     _openmp_mutex: '>=4.5'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    llvmlite: '>=0.46.0,<0.47.0a0'
+    llvmlite: '>=0.47.0,<0.48.0a0'
     numpy: '>=1.23,<3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.63.1-py313h5dce7c4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py313h5dce7c4_0.conda
   hash:
-    md5: dbdae1a85bb346d57fae63269def955a
-    sha256: 3ceba93570814df69969edff3156097dc0e86ccefa2ea2bdfe08f84b2023cf04
+    md5: 9bf6fdae64fce80e917e23d7cfec771a
+    sha256: 3e721a1b7555f09dc30d466a867c677a3d86e2e4b4837b811659a91495c892c4
   category: main
   optional: false
 - name: numba
-  version: 0.63.1
+  version: 0.65.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-    llvm-openmp: '>=21.1.7'
-    llvmlite: '>=0.46.0,<0.47.0a0'
+    llvm-openmp: '>=22.1.4'
+    llvmlite: '>=0.47.0,<0.48.0a0'
     numpy: '>=1.23,<3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/numba-0.63.1-py313hd3f9b42_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/numba-0.65.1-py313h4fc6aae_0.conda
   hash:
-    md5: 6f4b1341edb126722ece084e2c382c6a
-    sha256: 5d883cbc0147fc460219750f248221839f31ae66f5eeaacac9903753dc018c60
+    md5: 21e23453549c0c5570442d4155a02b78
+    sha256: 41c871b6151e32f2dc2d290a7530d0ec29aa5c640951cf63942aef8d8be478d0
   category: main
   optional: false
 - name: numba
-  version: 0.63.1
+  version: 0.65.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    llvm-openmp: '>=21.1.7'
-    llvmlite: '>=0.46.0,<0.47.0a0'
+    llvm-openmp: '>=22.1.4'
+    llvmlite: '>=0.47.0,<0.48.0a0'
     numpy: '>=1.23,<3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.63.1-py313ha873477_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.65.1-py313h3ca053b_0.conda
   hash:
-    md5: 2d0abc39aee6824aa5cb982ee6eb82ae
-    sha256: 6f5d51434275240db065c9a57599b0fde3d117115b79466422dc5e01f355e2f1
+    md5: 8cf811454470245db98b6bbf2a45a7c2
+    sha256: 0fe139adbad11027773484e547393640111c800294693175771d524d65db4527
   category: main
   optional: false
 - name: numcodecs
@@ -13790,7 +14330,7 @@ package:
   category: main
   optional: false
 - name: numpy
-  version: 2.3.5
+  version: 2.4.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -13802,32 +14342,32 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.5-py313hf6604e3_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
   hash:
-    md5: dce261869f78ba9b81b9091b084d328d
-    sha256: 2f8aff2a17e4d43012e9863ef4392e6d5de3ae9da0c3e322831f8c5c3d86df71
+    md5: c4a9d2e77eb9fee983a70cf5f047c202
+    sha256: bcf75998ea3ae133df3580fb427d1054b006b093799430f499fd7ce8207d34c7
   category: main
   optional: false
 - name: numpy
-  version: 2.3.5
+  version: 2.4.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=19'
     liblapack: '>=3.9.0,<4.0a0'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.3.5-py313hf1665ba_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.3-py313hb870fc3_0.conda
   hash:
-    md5: 90fa3a86c16cfb708e35733b731ad5fd
-    sha256: 7878ba3143d53638a39b702f0d55af1d4dcbb123eda09d98ca4e3637ef6d151b
+    md5: a8edd94da68a8ea91e35889708959578
+    sha256: 2ef07192b3e53dd783438fcc4c18cb9fcbb40ee39c5db024e9e78c0adb047e33
   category: main
   optional: false
 - name: numpy
-  version: 2.3.5
+  version: 2.4.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13838,10 +14378,55 @@ package:
     liblapack: '>=3.9.0,<4.0a0'
     python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.3.5-py313h16eae64_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
   hash:
-    md5: c72599556b49dc853839f4439c1eea32
-    sha256: d759e7fee853d8e18709a15b8fc8a6db90c96986cb9d316c4d5ccdf5a1d3f61f
+    md5: 03b99caf1270c27febfcceb4f1090af7
+    sha256: d55c3f4b13486bf8e3cadaf731a5d9b67aa9deb51f7c30e381b948a9ada20ef0
+  category: main
+  optional: false
+- name: oauthlib
+  version: 3.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    blinker: ''
+    cryptography: ''
+    pyjwt: '>=1.0.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: d4f3f31ee39db3efecb96c0728d4bdbf
+    sha256: dfa8222df90736fa13f8896f5a573a50273af8347542d412c3bd1230058e56a5
+  category: main
+  optional: false
+- name: oauthlib
+  version: 3.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    blinker: ''
+    cryptography: ''
+    pyjwt: '>=1.0.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: d4f3f31ee39db3efecb96c0728d4bdbf
+    sha256: dfa8222df90736fa13f8896f5a573a50273af8347542d412c3bd1230058e56a5
+  category: main
+  optional: false
+- name: oauthlib
+  version: 3.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    blinker: ''
+    cryptography: ''
+    pyjwt: '>=1.0.0'
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: d4f3f31ee39db3efecb96c0728d4bdbf
+    sha256: dfa8222df90736fa13f8896f5a573a50273af8347542d412c3bd1230058e56a5
   category: main
   optional: false
 - name: openjpeg
@@ -13866,15 +14451,15 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
-    libpng: '>=1.6.50,<1.7.0a0'
+    libpng: '>=1.6.55,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h87e8dc5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h52bb76a_0.conda
   hash:
-    md5: a67d3517ebbf615b91ef9fdc99934e0c
-    sha256: fdf4708a4e45b5fd9868646dd0c0a78429f4c0b8be490196c975e06403a841d0
+    md5: 46e628da6e796c948fa8ec9d6d10bda3
+    sha256: 9a37ecf9c086f3a50d0132e6087dcbe7ea978d80e2da267fa3199c486529b311
   category: main
   optional: false
 - name: openjpeg
@@ -13884,17 +14469,17 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    libpng: '>=1.6.50,<1.7.0a0'
+    libpng: '>=1.6.55,<1.7.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hbfb3c88_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
   hash:
-    md5: 6bf3d24692c157a41c01ce0bd17daeea
-    sha256: dd73e8f1da7dd6a5494c5586b835cbe2ec68bace55610b1c4bf927400fe9c0d7
+    md5: 4b5d3a91320976eec71678fad1e3569b
+    sha256: 60aca8b9f94d06b852b296c276b3cf0efba5a6eb9f25feb8708570d3a74f00e4
   category: main
   optional: false
 - name: openjph
-  version: 0.26.0
+  version: 0.27.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -13902,38 +14487,38 @@ package:
     libgcc: '>=14'
     libstdcxx: '>=14'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.0-h8d634f6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.27.0-h8d634f6_0.conda
   hash:
-    md5: 65900b71509b2fd6c0a34a5dc1bd893a
-    sha256: 5f8e3ad6e707c3ffee81c3c2cbc1ac8f66eb10bbe0fe2edbe1cdad0972e006c8
+    md5: 8397bb8cf4b370f5df7d7ee3d80ea977
+    sha256: 7feff0a0cf14ee008ae03fc83fa556d5d0acfac870a6ce4371d6a75e5edc8d0a
   category: main
   optional: false
 - name: openjph
-  version: 0.26.0
+  version: 0.27.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjph-0.26.0-h51ff197_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjph-0.27.0-h2c0e27e_0.conda
   hash:
-    md5: c8779b20b262ea8a2f51e2f396bf0b69
-    sha256: 743ca7fb922447e09e82aad8765389c3870427864ea8ec8c460519fc79ab09ef
+    md5: adae8d1381843e6d8da2fdc057346d73
+    sha256: 044ec189d61848268f13a83ed9cf54e0b074b605859935166b7c52b2ac1b4f7d
   category: main
   optional: false
 - name: openjph
-  version: 0.26.0
+  version: 0.27.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjph-0.26.0-h2a4d681_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjph-0.27.0-h2a4d681_0.conda
   hash:
-    md5: 165b7d49b821d421d057dbb35897df32
-    sha256: 151443d08ec9149c3547eb1b066bfee8d15af6e8cf1724f100a1efe96ffba8be
+    md5: 3ade21592a8a1ddd526eaba5bc6babcc
+    sha256: 446ac3241c7643b2f918979f7eeca2333ff291d82df07da7a77fd09ed50d1abc
   category: main
   optional: false
 - name: openpyxl
@@ -13980,43 +14565,43 @@ package:
   category: main
   optional: false
 - name: openssl
-  version: 3.6.1
+  version: 3.6.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     ca-certificates: ''
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
   hash:
-    md5: f61eb8cd60ff9057122a3d338b99c00f
-    sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
+    md5: da1b85b6a87e141f5140bb9924cecab0
+    sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
   category: main
   optional: false
 - name: openssl
-  version: 3.6.1
+  version: 3.6.2
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
   hash:
-    md5: 30bb8d08b99b9a7600d39efb3559fff0
-    sha256: e02e5639b0e4d6d4fcf0f3b082642844fb5a37316f5b0a1126c6271347462e90
+    md5: 5cf0ece4375c73d7a5765e83565a69c7
+    sha256: 334fd49ea31b99114f5afb1ec44555dc8c90640648302a4f8f838ee345d1ec50
   category: main
   optional: false
 - name: openssl
-  version: 3.6.1
+  version: 3.6.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
   hash:
-    md5: f4f6ad63f98f64191c3e77c5f5f29d76
-    sha256: 361f5c5e60052abc12bdd1b50d7a1a43e6a6653aab99a2263bf2288d709dcf67
+    md5: 25dcccd4f80f1638428613e0d7c9b4e1
+    sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
   category: main
   optional: false
 - name: orc
@@ -14078,43 +14663,43 @@ package:
   category: main
   optional: false
 - name: packaging
-  version: '26.0'
+  version: '26.2'
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
-    md5: b76541e68fea4d511b1ac46a28dcd2c6
-    sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
+    md5: 4c06a92e74452cfa53623a81592e8934
+    sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
   category: main
   optional: false
 - name: packaging
-  version: '26.0'
+  version: '26.2'
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
-    md5: b76541e68fea4d511b1ac46a28dcd2c6
-    sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
+    md5: 4c06a92e74452cfa53623a81592e8934
+    sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
   category: main
   optional: false
 - name: packaging
-  version: '26.0'
+  version: '26.2'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   hash:
-    md5: b76541e68fea4d511b1ac46a28dcd2c6
-    sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
+    md5: 4c06a92e74452cfa53623a81592e8934
+    sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
   category: main
   optional: false
 - name: pandas
-  version: 3.0.0
+  version: 3.0.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -14125,31 +14710,31 @@ package:
     python: ''
     python-dateutil: '>=2.8.2'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.0-py313hbfd7664_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py313hbfd7664_0.conda
   hash:
-    md5: ab6d05e915ab2ae4c41d275b14592151
-    sha256: 05719fdfacdf97206a901621d79ab103c34905973ec8a18627825d5adab7a1b0
+    md5: 6a036e42f4e47720804f35d1897336a1
+    sha256: 6aa7b7b234805c673fd63ef60432362e6cc130a3ae09b5ed2b40d74a2bd6c7bb
   category: main
   optional: false
 - name: pandas
-  version: 3.0.0
+  version: 3.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     numpy: '>=1.23,<3'
     python: ''
     python-dateutil: '>=2.8.2'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.0-py313h4810d26_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.2-py313hfd25234_0.conda
   hash:
-    md5: c23196474aa5d19c20d37d03ef8a5973
-    sha256: 87694301760b22b76cac17253bd579c65962d553be05a98718614f296b16d605
+    md5: ff03b34fdf68e3769de61638edfa19a2
+    sha256: 596f1a17b6c8268b3ea616163f58246ea0aa5c4a403c9a6738a243b4243252f6
   category: main
   optional: false
 - name: pandas
-  version: 3.0.0
+  version: 3.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -14159,10 +14744,10 @@ package:
     python: 3.13.*
     python-dateutil: '>=2.8.2'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.0-py313h6974306_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.2-py313h1188861_0.conda
   hash:
-    md5: ae2e72c47ce95ec8c489cffa0592f492
-    sha256: 9a43b0b6a6be447c180a69704e16dcdab1afffe8f37bc501ed1bf1fd99e67e14
+    md5: 13410787da0135eec56a4bb8d674fc42
+    sha256: 02d3995ae9a95506d1bb5bfe6f68f5abdc13439eb85be53df5a631abc7b28246
   category: main
   optional: false
 - name: pango
@@ -14172,21 +14757,21 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
+    fontconfig: '>=2.17.1,<3.0a0'
     fonts-conda-ecosystem: ''
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=11.0.1'
-    libexpat: '>=2.7.0,<3.0a0'
-    libfreetype: '>=2.13.3'
-    libfreetype6: '>=2.13.3'
-    libgcc: '>=13'
-    libglib: '>=2.84.2,<3.0a0'
-    libpng: '>=1.6.49,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+    fribidi: '>=1.0.16,<2.0a0'
+    harfbuzz: '>=13.2.1'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.2'
+    libfreetype6: '>=2.14.2'
+    libgcc: '>=14'
+    libglib: '>=2.86.4,<3.0a0'
+    libpng: '>=1.6.55,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
   hash:
-    md5: 79f71230c069a287efe3a8614069ddf1
-    sha256: 3613774ad27e48503a3a6a9d72017087ea70f1426f6e5541dbdb59a3b626eaaf
+    md5: d53ffc0edc8eabf4253508008493c5bc
+    sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
   category: main
   optional: false
 - name: pango
@@ -14194,22 +14779,22 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
+    fontconfig: '>=2.17.1,<3.0a0'
     fonts-conda-ecosystem: ''
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=11.0.1'
-    libexpat: '>=2.7.0,<3.0a0'
-    libfreetype: '>=2.13.3'
-    libfreetype6: '>=2.13.3'
-    libglib: '>=2.84.2,<3.0a0'
-    libpng: '>=1.6.49,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.4-h6ef8af8_0.conda
+    fribidi: '>=1.0.16,<2.0a0'
+    harfbuzz: '>=13.2.1'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.2'
+    libfreetype6: '>=2.14.2'
+    libglib: '>=2.86.4,<3.0a0'
+    libpng: '>=1.6.55,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.4-hf280016_1.conda
   hash:
-    md5: 8c6316c058884ffda0af1f1272910f94
-    sha256: baab8ebf970fb6006ad26884f75f151316e545c47fb308a1de2dd47ddd0381c5
+    md5: 591f9fcbb36fbd50caef590d9b1de614
+    sha256: c1150e6a405985b25830c18f896d5e89b9777ef7e420bc0b1d88634f9a614769
   category: main
   optional: false
 - name: pango
@@ -14219,90 +14804,56 @@ package:
   dependencies:
     __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.15.0,<3.0a0'
+    fontconfig: '>=2.17.1,<3.0a0'
     fonts-conda-ecosystem: ''
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=11.0.1'
-    libexpat: '>=2.7.0,<3.0a0'
-    libfreetype: '>=2.13.3'
-    libfreetype6: '>=2.13.3'
-    libglib: '>=2.84.2,<3.0a0'
-    libpng: '>=1.6.49,<1.7.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-h875632e_0.conda
+    fribidi: '>=1.0.16,<2.0a0'
+    harfbuzz: '>=13.2.1'
+    libexpat: '>=2.7.4,<3.0a0'
+    libfreetype: '>=2.14.2'
+    libfreetype6: '>=2.14.2'
+    libglib: '>=2.86.4,<3.0a0'
+    libpng: '>=1.6.55,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-hf80efc4_1.conda
   hash:
-    md5: 7d57f8b4b7acfc75c777bc231f0d31be
-    sha256: 705484ad60adee86cab1aad3d2d8def03a699ece438c864e8ac995f6f66401a6
-  category: main
-  optional: false
-- name: parallelio
-  version: '2_6_7'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
-    mpich: '>=4.3.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/parallelio-2_6_7-mpi_mpich_he3bd8b5_100.conda
-  hash:
-    md5: d0966e902cc49988459e61a488b61d22
-    sha256: 0476c5368e9a1527db86be11083b98f85d09108ae560580117c7e2af6839a88b
-  category: main
-  optional: false
-- name: parallelio
-  version: '2_6_7'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libgfortran: ''
-    libgfortran5: '>=15.1.0'
-    libnetcdf: '>=4.9.3,<4.9.4.0a0'
-    libpnetcdf: '>=1.14.1,<1.14.2.0a0'
-    mpich: '>=4.3.1,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/parallelio-2_6_7-mpi_mpich_he327d1a_100.conda
-  hash:
-    md5: e5a9525642c521a73695eec2bff0797f
-    sha256: 418096becb9af1e221f83fc9666dabdf728b2b2107d33860479ba137e0cbf05d
+    md5: 4b433508ebb295c05dd3d03daf27f7bb
+    sha256: b57c59cf5abb06d407b3a79017b990ca5bfb10c15a10c62fc29e113f2b12d9a9
   category: main
   optional: false
 - name: parso
-  version: 0.8.5
+  version: 0.8.7
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
-    md5: a110716cdb11cf51482ff4000dc253d7
-    sha256: 30de7b4d15fbe53ffe052feccde31223a236dae0495bab54ab2479de30b2990f
+    md5: 39894c952938276405a1bd30e4ce2caf
+    sha256: 611882f7944b467281c46644ffde6c5145d1a7730388bcde26e7e86819b0998e
   category: main
   optional: false
 - name: parso
-  version: 0.8.5
+  version: 0.8.7
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
-    md5: a110716cdb11cf51482ff4000dc253d7
-    sha256: 30de7b4d15fbe53ffe052feccde31223a236dae0495bab54ab2479de30b2990f
+    md5: 39894c952938276405a1bd30e4ce2caf
+    sha256: 611882f7944b467281c46644ffde6c5145d1a7730388bcde26e7e86819b0998e
   category: main
   optional: false
 - name: parso
-  version: 0.8.5
+  version: 0.8.7
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.5-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   hash:
-    md5: a110716cdb11cf51482ff4000dc253d7
-    sha256: 30de7b4d15fbe53ffe052feccde31223a236dae0495bab54ab2479de30b2990f
+    md5: 39894c952938276405a1bd30e4ce2caf
+    sha256: 611882f7944b467281c46644ffde6c5145d1a7730388bcde26e7e86819b0998e
   category: main
   optional: false
 - name: partd
@@ -14469,14 +15020,14 @@ package:
   category: main
   optional: false
 - name: pillow
-  version: 12.1.0
+  version: 12.2.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    lcms2: '>=2.17,<3.0a0'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
+    lcms2: '>=2.18,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libgcc: '>=14'
     libjpeg-turbo: '>=3.1.2,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
@@ -14486,22 +15037,22 @@ package:
     python: ''
     python_abi: 3.13.*
     tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.2,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.0-py313h80991f8_0.conda
+    zlib-ng: '>=2.3.3,<2.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py313h80991f8_0.conda
   hash:
-    md5: 183fe6b9e99e5c2b464c1573ec78eac8
-    sha256: bdad1e21cadd64154c45fa554247dd672288ad51982ca7d54b3fab63e40938df
+    md5: 7245f1bbf52ed5e3818d742f51b44a7d
+    sha256: 55a76548bb003ff6deac9bf209b279d428030f230632fb70f15ae153aed05158
   category: main
   optional: false
 - name: pillow
-  version: 12.1.0
+  version: 12.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    lcms2: '>=2.17,<3.0a0'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
+    __osx: '>=11.0'
+    lcms2: '>=2.18,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libjpeg-turbo: '>=3.1.2,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
@@ -14510,22 +15061,22 @@ package:
     python: ''
     python_abi: 3.13.*
     tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.2,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.1.0-py313h16bb925_0.conda
+    zlib-ng: '>=2.3.3,<2.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.2.0-py313h23d381d_0.conda
   hash:
-    md5: bc8c5b5215ba393b44040e5cdb4b4a58
-    sha256: 2e428848bde27506936329303144a889a9e168e797053e25943973d25560e9c7
+    md5: 69e4cefea9c222ea64b219df6ba5787d
+    sha256: 60f721fb766c585c370e1a936754163652cd9f4fd33bda5202ebcf38d502abd2
   category: main
   optional: false
 - name: pillow
-  version: 12.1.0
+  version: 12.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    lcms2: '>=2.17,<3.0a0'
-    libfreetype: '>=2.14.1'
-    libfreetype6: '>=2.14.1'
+    lcms2: '>=2.18,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libjpeg-turbo: '>=3.1.2,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
@@ -14534,47 +15085,47 @@ package:
     python: 3.13.*
     python_abi: 3.13.*
     tk: '>=8.6.13,<8.7.0a0'
-    zlib-ng: '>=2.3.2,<2.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.0-py313h45e5a15_0.conda
+    zlib-ng: '>=2.3.3,<2.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.2.0-py313h45e5a15_0.conda
   hash:
-    md5: 78a39731fd50dbd511de305934fe7e62
-    sha256: e5eaa7f00fca189848a0454303c56cc4edefd3e58a70bfd490d2cfe0d0aa525d
+    md5: 6186601fd72a394a6f7c7b7096f6a063
+    sha256: 90333643a7868b10724999633bb393d005bc5f539d05666f80c41fb67e5f0f3f
   category: main
   optional: false
 - name: pip
-  version: '25.3'
+  version: 26.0.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
   hash:
-    md5: bf47878473e5ab9fdb4115735230e191
-    sha256: 4d5e2faca810459724f11f78d19a0feee27a7be2b3fc5f7abbbec4c9fdcae93d
+    md5: 09a970fbf75e8ed1aa633827ded6aa4f
+    sha256: 5f66ea31d62188c266c5a8752119b0cc90a5bf05963f665cf48a33e0ec58d39c
   category: main
   optional: false
 - name: pip
-  version: '25.3'
+  version: 26.0.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
   hash:
-    md5: bf47878473e5ab9fdb4115735230e191
-    sha256: 4d5e2faca810459724f11f78d19a0feee27a7be2b3fc5f7abbbec4c9fdcae93d
+    md5: 09a970fbf75e8ed1aa633827ded6aa4f
+    sha256: 5f66ea31d62188c266c5a8752119b0cc90a5bf05963f665cf48a33e0ec58d39c
   category: main
   optional: false
 - name: pip
-  version: '25.3'
+  version: 26.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
   hash:
-    md5: bf47878473e5ab9fdb4115735230e191
-    sha256: 4d5e2faca810459724f11f78d19a0feee27a7be2b3fc5f7abbbec4c9fdcae93d
+    md5: 09a970fbf75e8ed1aa633827ded6aa4f
+    sha256: 5f66ea31d62188c266c5a8752119b0cc90a5bf05963f665cf48a33e0ec58d39c
   category: main
   optional: false
 - name: pixman
@@ -14618,81 +15169,81 @@ package:
   category: main
   optional: false
 - name: platformdirs
-  version: 4.5.1
+  version: 4.9.6
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   hash:
-    md5: 1bd2e65c8c7ef24f4639ae6e850dacc2
-    sha256: 04c64fb78c520e5c396b6e07bc9082735a5cc28175dbe23138201d0a9441800b
+    md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
+    sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   category: main
   optional: false
 - name: platformdirs
-  version: 4.5.1
+  version: 4.9.6
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   hash:
-    md5: 1bd2e65c8c7ef24f4639ae6e850dacc2
-    sha256: 04c64fb78c520e5c396b6e07bc9082735a5cc28175dbe23138201d0a9441800b
+    md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
+    sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   category: main
   optional: false
 - name: platformdirs
-  version: 4.5.1
+  version: 4.9.6
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   hash:
-    md5: 1bd2e65c8c7ef24f4639ae6e850dacc2
-    sha256: 04c64fb78c520e5c396b6e07bc9082735a5cc28175dbe23138201d0a9441800b
+    md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
+    sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   category: main
   optional: false
 - name: plotly
-  version: 6.5.2
+  version: 6.6.0
   manager: conda
   platform: linux-64
   dependencies:
     narwhals: '>=1.15.1'
     packaging: ''
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-6.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7702bcd70891dd0154d765a69e1afa94
-    sha256: 48d2caf66b8209bfb3fa160f5bc7cbd625deaa4826e8aa1bad706b2dd22bbb86
+    md5: 3e9427ee186846052e81fadde8ebe96a
+    sha256: c418d325359fc7a0074cea7f081ef1bce26e114d2da8a0154c5d27ecc87a08e7
   category: main
   optional: false
 - name: plotly
-  version: 6.5.2
+  version: 6.6.0
   manager: conda
   platform: osx-64
   dependencies:
     narwhals: '>=1.15.1'
     packaging: ''
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-6.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7702bcd70891dd0154d765a69e1afa94
-    sha256: 48d2caf66b8209bfb3fa160f5bc7cbd625deaa4826e8aa1bad706b2dd22bbb86
+    md5: 3e9427ee186846052e81fadde8ebe96a
+    sha256: c418d325359fc7a0074cea7f081ef1bce26e114d2da8a0154c5d27ecc87a08e7
   category: main
   optional: false
 - name: plotly
-  version: 6.5.2
+  version: 6.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
     narwhals: '>=1.15.1'
     packaging: ''
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-6.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7702bcd70891dd0154d765a69e1afa94
-    sha256: 48d2caf66b8209bfb3fa160f5bc7cbd625deaa4826e8aa1bad706b2dd22bbb86
+    md5: 3e9427ee186846052e81fadde8ebe96a
+    sha256: c418d325359fc7a0074cea7f081ef1bce26e114d2da8a0154c5d27ecc87a08e7
   category: main
   optional: false
 - name: pluggy
@@ -14817,48 +15368,48 @@ package:
   category: main
   optional: false
 - name: pooch
-  version: 1.8.2
+  version: 1.9.0
   manager: conda
   platform: linux-64
   dependencies:
     packaging: '>=20.0'
     platformdirs: '>=2.5.0'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.19.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d2bbbd293097e664ffb01fc4cdaf5729
-    sha256: 032405adb899ba7c7cc24d3b4cd4e7f40cf24ac4f253a8e385a4f44ccb5e0fc6
+    md5: dd4b6337bf8886855db6905b336db3c8
+    sha256: 081e52c4612830bf1fd4a9c78eebaf335d1385d74ddfd328b1b2f26b983848eb
   category: main
   optional: false
 - name: pooch
-  version: 1.8.2
+  version: 1.9.0
   manager: conda
   platform: osx-64
   dependencies:
     packaging: '>=20.0'
     platformdirs: '>=2.5.0'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.19.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d2bbbd293097e664ffb01fc4cdaf5729
-    sha256: 032405adb899ba7c7cc24d3b4cd4e7f40cf24ac4f253a8e385a4f44ccb5e0fc6
+    md5: dd4b6337bf8886855db6905b336db3c8
+    sha256: 081e52c4612830bf1fd4a9c78eebaf335d1385d74ddfd328b1b2f26b983848eb
   category: main
   optional: false
 - name: pooch
-  version: 1.8.2
+  version: 1.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
     packaging: '>=20.0'
     platformdirs: '>=2.5.0'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.19.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_3.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d2bbbd293097e664ffb01fc4cdaf5729
-    sha256: 032405adb899ba7c7cc24d3b4cd4e7f40cf24ac4f253a8e385a4f44ccb5e0fc6
+    md5: dd4b6337bf8886855db6905b336db3c8
+    sha256: 081e52c4612830bf1fd4a9c78eebaf335d1385d74ddfd328b1b2f26b983848eb
   category: main
   optional: false
 - name: progressbar2
@@ -14912,10 +15463,10 @@ package:
     libstdcxx: '>=14'
     libtiff: '>=4.7.1,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_3.conda
   hash:
-    md5: beb1885cfdb793193bba83c9720d53b1
-    sha256: 1e93bf13f56b68cd16414353c97e92db4d38e17fc90146a6e9f1cd73251c775e
+    md5: 031e33ae075b336c0ce92b14efa886c5
+    sha256: c94d3d8ef40d1ea018860d66c416003bc03adede7d212efc9218bb64041fe2f7
   category: main
   optional: false
 - name: proj
@@ -14929,10 +15480,10 @@ package:
     libsqlite: '>=3.51.2,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.7.1-h4aacef1_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.7.1-h4aacef1_3.conda
   hash:
-    md5: 2deeb48139ea69c6000e5f26296195fc
-    sha256: 76efc2d9d359662246aa09b03ac52c25a6df1871a988a27fb13585af413aa4fd
+    md5: 86a72148f2ace31569279a41c903f1be
+    sha256: 848b0393f363ab49169d9a7d4dccef15cb4b34cbdbc6365240dd7e70bd602173
   category: main
   optional: false
 - name: proj
@@ -14946,10 +15497,10 @@ package:
     libsqlite: '>=3.51.2,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
     sqlite: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.7.1-hfb14a63_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.7.1-hfb14a63_3.conda
   hash:
-    md5: 7515b2df0846e534a2096dff3ae6f11e
-    sha256: dd8d0a63500963d7413b5406bfd12bc9370fe6206dccc2b2d6fec99a04745f83
+    md5: 8f33a4a2b856de0e8f006c489beca62a
+    sha256: 14484430a32a13cb9c03ebf3084a4ffb1feb417aa4c23907844fba219924058f
   category: main
   optional: false
 - name: prometheus-cpp
@@ -15290,7 +15841,7 @@ package:
   category: main
   optional: false
 - name: py-cordex
-  version: 0.10.2
+  version: 0.10.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -15301,14 +15852,14 @@ package:
     python: '>=3.10'
     setuptools: '>=40.4'
     xarray: '>=0.15,!=2023.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/py-cordex-0.10.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/py-cordex-0.10.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 16c4e373655de5f0a1b1c55cbb7e2c52
-    sha256: 9050c05646fd06e75bdd5df877ef738009cb51eda7ef84c41b66597e37ba140f
+    md5: 030313608287d25555bde79634f36d67
+    sha256: 87feb4ca48bc9fd40b3124941d0a70be6dff4f28872fd0e885933457f548fa6e
   category: main
   optional: false
 - name: py-cordex
-  version: 0.10.2
+  version: 0.10.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -15319,14 +15870,14 @@ package:
     python: '>=3.10'
     setuptools: '>=40.4'
     xarray: '>=0.15,!=2023.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/py-cordex-0.10.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/py-cordex-0.10.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 16c4e373655de5f0a1b1c55cbb7e2c52
-    sha256: 9050c05646fd06e75bdd5df877ef738009cb51eda7ef84c41b66597e37ba140f
+    md5: 030313608287d25555bde79634f36d67
+    sha256: 87feb4ca48bc9fd40b3124941d0a70be6dff4f28872fd0e885933457f548fa6e
   category: main
   optional: false
 - name: py-cordex
-  version: 0.10.2
+  version: 0.10.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -15337,58 +15888,112 @@ package:
     python: '>=3.10'
     setuptools: '>=40.4'
     xarray: '>=0.15,!=2023.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/py-cordex-0.10.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/py-cordex-0.10.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 16c4e373655de5f0a1b1c55cbb7e2c52
-    sha256: 9050c05646fd06e75bdd5df877ef738009cb51eda7ef84c41b66597e37ba140f
+    md5: 030313608287d25555bde79634f36d67
+    sha256: 87feb4ca48bc9fd40b3124941d0a70be6dff4f28872fd0e885933457f548fa6e
   category: main
   optional: false
-- name: py-xgboost
-  version: 3.1.3
+- name: py-multihash
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    libxgboost: '>=3.1.3,<3.1.4.0a0'
-    numpy: ''
+    base58: '>=1.0.2,<3.0'
+    blake3: '>=0.3.0,<2.0'
+    mmh3: '>=3.0.0,<6.0'
+    morphys: '>=1.0,<2.0'
     python: '>=3.10'
-    scikit-learn: ''
-    scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/py-xgboost-3.1.3-cpu_pyh718b53a_0.conda
+    six: '>=1.10.0,<2.0'
+    varint: '>=1.0.2,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/py-multihash-3.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9d22e09aa7a0f42272f684291246287d
-    sha256: e66bc85e5d0f6bc72e1628e498c2318576f846591b6051fb71ef73afef632c71
+    md5: 2611525c9e718b8514bfa41dd81d9c77
+    sha256: 245637f026cea64aeef4cc348410ffa50081d11b9ca16c8350be90faa4d0c518
   category: main
   optional: false
-- name: py-xgboost
-  version: 3.1.3
+- name: py-multihash
+  version: 3.0.0
   manager: conda
   platform: osx-64
   dependencies:
-    libxgboost: '>=3.1.3,<3.1.4.0a0'
-    numpy: ''
+    base58: '>=1.0.2,<3.0'
+    blake3: '>=0.3.0,<2.0'
+    mmh3: '>=3.0.0,<6.0'
+    morphys: '>=1.0,<2.0'
     python: '>=3.10'
-    scikit-learn: ''
-    scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/py-xgboost-3.1.3-cpu_pyh718b53a_0.conda
+    six: '>=1.10.0,<2.0'
+    varint: '>=1.0.2,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/py-multihash-3.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9d22e09aa7a0f42272f684291246287d
-    sha256: e66bc85e5d0f6bc72e1628e498c2318576f846591b6051fb71ef73afef632c71
+    md5: 2611525c9e718b8514bfa41dd81d9c77
+    sha256: 245637f026cea64aeef4cc348410ffa50081d11b9ca16c8350be90faa4d0c518
   category: main
   optional: false
-- name: py-xgboost
-  version: 3.1.3
+- name: py-multihash
+  version: 3.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libxgboost: '>=3.1.3,<3.1.4.0a0'
+    base58: '>=1.0.2,<3.0'
+    blake3: '>=0.3.0,<2.0'
+    mmh3: '>=3.0.0,<6.0'
+    morphys: '>=1.0,<2.0'
+    python: '>=3.10'
+    six: '>=1.10.0,<2.0'
+    varint: '>=1.0.2,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/py-multihash-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2611525c9e718b8514bfa41dd81d9c77
+    sha256: 245637f026cea64aeef4cc348410ffa50081d11b9ca16c8350be90faa4d0c518
+  category: main
+  optional: false
+- name: py-xgboost
+  version: 3.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libxgboost: '>=3.2.0,<3.2.1.0a0'
     numpy: ''
     python: '>=3.10'
     scikit-learn: ''
     scipy: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/py-xgboost-3.1.3-cpu_pyh718b53a_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/py-xgboost-3.2.0-cpu_pyh718b53a_1.conda
   hash:
-    md5: 9d22e09aa7a0f42272f684291246287d
-    sha256: e66bc85e5d0f6bc72e1628e498c2318576f846591b6051fb71ef73afef632c71
+    md5: 0bf931ab19063eeea5372c5e47fcd072
+    sha256: 5b54bfecae9dffa94aaaa131a3b46029482af1cc74e078490d07c0e349a60393
+  category: main
+  optional: false
+- name: py-xgboost
+  version: 3.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libxgboost: '>=3.2.0,<3.2.1.0a0'
+    numpy: ''
+    python: '>=3.10'
+    scikit-learn: ''
+    scipy: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/py-xgboost-3.2.0-cpu_pyh718b53a_1.conda
+  hash:
+    md5: 0bf931ab19063eeea5372c5e47fcd072
+    sha256: 5b54bfecae9dffa94aaaa131a3b46029482af1cc74e078490d07c0e349a60393
+  category: main
+  optional: false
+- name: py-xgboost
+  version: 3.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libxgboost: '>=3.2.0,<3.2.1.0a0'
+    numpy: ''
+    python: '>=3.10'
+    scikit-learn: ''
+    scipy: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/py-xgboost-3.2.0-cpu_pyh718b53a_1.conda
+  hash:
+    md5: 0bf931ab19063eeea5372c5e47fcd072
+    sha256: 5b54bfecae9dffa94aaaa131a3b46029482af1cc74e078490d07c0e349a60393
   category: main
   optional: false
 - name: pyarrow
@@ -15458,10 +16063,10 @@ package:
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-23.0.0-py313he109ebe_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-23.0.0-py313hfe0801a_0_cuda.conda
   hash:
-    md5: 9120bf253ebbdb0015069b9a25cf4d36
-    sha256: 1914b79fe640a60b7ab240d90548f601c43513ef39bc6bc8517d73f259acfce1
+    md5: c9ab081186dd0163e75bebaa77fde5ae
+    sha256: c81a348c58cdda73b0aefd02b150517f3ad06f9de1d3c2e0b2cce74222d8b973
   category: main
   optional: false
 - name: pyarrow-core
@@ -15476,10 +16081,10 @@ package:
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-23.0.0-py313h7c712a9_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-23.0.0-py313h83f9c1b_0_cpu.conda
   hash:
-    md5: 8c51b7be069b1faa48981caa133f440b
-    sha256: f6ec4f8de08c0212501675555954a8f5f203d63cdd4eca2f034541619bb7fbb5
+    md5: 79cb6380e69848540ca3f42460900880
+    sha256: 2a3f8241a63f3a542fe977a122898d551a18c49be3c8fdae9f3e95ea2c55a149
   category: main
   optional: false
 - name: pyarrow-core
@@ -15494,58 +16099,55 @@ package:
     libzlib: '>=1.3.1,<2.0a0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-23.0.0-py313hfb690af_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-23.0.0-py313h23b330d_0_cpu.conda
   hash:
-    md5: 17395366e9516f9663f0c1a9342feb2a
-    sha256: 59f1452c5274f5bef0872ddacaf1c4891c0a7a0d1f51de4342b0fc637a456eca
+    md5: d12ac9817b6da9d02fdece0f0170f1fd
+    sha256: 97287878797287756344e39204c2081d396ce785c25eac7965deb0d3501d1b26
   category: main
   optional: false
 - name: pybtex
-  version: 0.25.1
+  version: 0.26.1
   manager: conda
   platform: linux-64
   dependencies:
     importlib-metadata: ''
     latexcodec: '>=1.0.4'
-    python: '>=3.9'
-    pyyaml: '>=3.01'
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.25.1-pyhd8ed1ab_0.conda
+    python: ''
+    pyyaml: '>=3.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.26.1-pyhcf101f3_0.conda
   hash:
-    md5: 9c25a850410220d31085173fbfdfa191
-    sha256: 3053895e08ce56923e48eea7d1c07a6d8bf09948d1e69a21ae7ab9e459b0a227
+    md5: b0969b1326b5b9d6094dd1831eb48919
+    sha256: fd9b0a389b21dc2ccb11925db83a5e9e32652e87971f93c23358d51c3632d96d
   category: main
   optional: false
 - name: pybtex
-  version: 0.25.1
+  version: 0.26.1
   manager: conda
   platform: osx-64
   dependencies:
     importlib-metadata: ''
     latexcodec: '>=1.0.4'
-    python: '>=3.9'
-    pyyaml: '>=3.01'
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.25.1-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+    pyyaml: '>=3.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.26.1-pyhcf101f3_0.conda
   hash:
-    md5: 9c25a850410220d31085173fbfdfa191
-    sha256: 3053895e08ce56923e48eea7d1c07a6d8bf09948d1e69a21ae7ab9e459b0a227
+    md5: b0969b1326b5b9d6094dd1831eb48919
+    sha256: fd9b0a389b21dc2ccb11925db83a5e9e32652e87971f93c23358d51c3632d96d
   category: main
   optional: false
 - name: pybtex
-  version: 0.25.1
+  version: 0.26.1
   manager: conda
   platform: osx-arm64
   dependencies:
     importlib-metadata: ''
     latexcodec: '>=1.0.4'
-    python: '>=3.9'
-    pyyaml: '>=3.01'
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.25.1-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+    pyyaml: '>=3.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pybtex-0.26.1-pyhcf101f3_0.conda
   hash:
-    md5: 9c25a850410220d31085173fbfdfa191
-    sha256: 3053895e08ce56923e48eea7d1c07a6d8bf09948d1e69a21ae7ab9e459b0a227
+    md5: b0969b1326b5b9d6094dd1831eb48919
+    sha256: fd9b0a389b21dc2ccb11925db83a5e9e32652e87971f93c23358d51c3632d96d
   category: main
   optional: false
 - name: pycparser
@@ -15585,58 +16187,55 @@ package:
   category: main
   optional: false
 - name: pydantic
-  version: 2.12.5
+  version: 2.13.3
   manager: conda
   platform: linux-64
   dependencies:
     annotated-types: '>=0.6.0'
-    pydantic-core: 2.41.5
+    pydantic-core: 2.46.3
     python: ''
-    typing-extensions: '>=4.6.1'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.3-pyhcf101f3_0.conda
   hash:
-    md5: c3946ed24acdb28db1b5d63321dbca7d
-    sha256: 868569d9505b7fe246c880c11e2c44924d7613a8cdcc1f6ef85d5375e892f13d
+    md5: f690e6f204efd2e5c06b57518a383d98
+    sha256: 12909d5c2bfb31492667dd4132ac900dd47f8162bd8b1dd9e5973ce8ea28ca1a
   category: main
   optional: false
 - name: pydantic
-  version: 2.12.5
+  version: 2.13.3
   manager: conda
   platform: osx-64
   dependencies:
     annotated-types: '>=0.6.0'
-    pydantic-core: 2.41.5
+    pydantic-core: 2.46.3
     python: '>=3.10'
-    typing-extensions: '>=4.6.1'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.3-pyhcf101f3_0.conda
   hash:
-    md5: c3946ed24acdb28db1b5d63321dbca7d
-    sha256: 868569d9505b7fe246c880c11e2c44924d7613a8cdcc1f6ef85d5375e892f13d
+    md5: f690e6f204efd2e5c06b57518a383d98
+    sha256: 12909d5c2bfb31492667dd4132ac900dd47f8162bd8b1dd9e5973ce8ea28ca1a
   category: main
   optional: false
 - name: pydantic
-  version: 2.12.5
+  version: 2.13.3
   manager: conda
   platform: osx-arm64
   dependencies:
     annotated-types: '>=0.6.0'
-    pydantic-core: 2.41.5
+    pydantic-core: 2.46.3
     python: '>=3.10'
-    typing-extensions: '>=4.6.1'
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.3-pyhcf101f3_0.conda
   hash:
-    md5: c3946ed24acdb28db1b5d63321dbca7d
-    sha256: 868569d9505b7fe246c880c11e2c44924d7613a8cdcc1f6ef85d5375e892f13d
+    md5: f690e6f204efd2e5c06b57518a383d98
+    sha256: 12909d5c2bfb31492667dd4132ac900dd47f8162bd8b1dd9e5973ce8ea28ca1a
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.41.5
+  version: 2.46.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -15645,29 +16244,29 @@ package:
     python: ''
     python_abi: 3.13.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py313h843e2db_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.3-py313h843e2db_0.conda
   hash:
-    md5: f27c39a1906771bbe56cd26a76bf0b8b
-    sha256: b15568ddc03bd33ea41610e5df951be4e245cd61957cbf8c2cfd12557f3d53b5
+    md5: 81752daa2838eec5df529e5c60044dc5
+    sha256: 885d7809b6f9e011f8cd7294ab030535a65637a229fb5e49453f7be4f05c3083
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.41.5
+  version: 2.46.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     python: ''
     python_abi: 3.13.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.41.5-py313hcc225dc_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.46.3-py313h23ec8f2_0.conda
   hash:
-    md5: e12491c39d2ea259771ce4d80a91817f
-    sha256: 73de35081774d9b445dd807ac4d4e043846159b2de348b8e6a81f1b810210fe4
+    md5: a5aefd2880a59680270677265aaa7cc6
+    sha256: 7357f1f4c9b722dbf3331f9d4793505ff5aa03e5e425f48d18074daffdc7c2b8
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.41.5
+  version: 2.46.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -15675,14 +16274,14 @@ package:
     python: 3.13.*
     python_abi: 3.13.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py313h2c089d5_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.46.3-py313h212e517_0.conda
   hash:
-    md5: eaeed566f6d88c0a08d73700b34be4a2
-    sha256: 08398c0599084837ba89d69db00b3d0973dc86d6519957dc6c1b480e2571451a
+    md5: 2f753ff1d3b847e16cf2692fe7df0655
+    sha256: c09c7ce40f6e3496a4bb61ef5057b40c1ae834653e6ea7cdf4ddd6534b929922
   category: main
   optional: false
 - name: pydap
-  version: 3.5.8
+  version: 3.5.9
   manager: conda
   platform: linux-64
   dependencies:
@@ -15696,14 +16295,14 @@ package:
     requests-cache: ''
     scipy: ''
     webob: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5.8-pyhc455866_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5.9-pyhc455866_0.conda
   hash:
-    md5: 8556185cf5e54ea7971afaf465d69fd5
-    sha256: 52f460d3278cf43ba4fe1415d396bb40f59b6628eb5551cdcd40ebd0ab53ec12
+    md5: 625e8ddc3aa6435500209e981583b55b
+    sha256: 99300df4fc6bee8b12f43f1f7fd1de8c91764d810b47ca065681c17955b1a8f3
   category: main
   optional: false
 - name: pydap
-  version: 3.5.8
+  version: 3.5.9
   manager: conda
   platform: osx-64
   dependencies:
@@ -15717,14 +16316,14 @@ package:
     requests-cache: ''
     scipy: ''
     webob: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5.8-pyhc455866_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5.9-pyhc455866_0.conda
   hash:
-    md5: 8556185cf5e54ea7971afaf465d69fd5
-    sha256: 52f460d3278cf43ba4fe1415d396bb40f59b6628eb5551cdcd40ebd0ab53ec12
+    md5: 625e8ddc3aa6435500209e981583b55b
+    sha256: 99300df4fc6bee8b12f43f1f7fd1de8c91764d810b47ca065681c17955b1a8f3
   category: main
   optional: false
 - name: pydap
-  version: 3.5.8
+  version: 3.5.9
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -15738,10 +16337,10 @@ package:
     requests-cache: ''
     scipy: ''
     webob: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5.8-pyhc455866_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydap-3.5.9-pyhc455866_0.conda
   hash:
-    md5: 8556185cf5e54ea7971afaf465d69fd5
-    sha256: 52f460d3278cf43ba4fe1415d396bb40f59b6628eb5551cdcd40ebd0ab53ec12
+    md5: 625e8ddc3aa6435500209e981583b55b
+    sha256: 99300df4fc6bee8b12f43f1f7fd1de8c91764d810b47ca065681c17955b1a8f3
   category: main
   optional: false
 - name: pydot
@@ -15787,84 +16386,120 @@ package:
   category: main
   optional: false
 - name: pygments
-  version: 2.19.2
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6b6ece66ebcae2d5f326c77ef2c5a066
-    sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+    md5: 16c18772b340887160c79a6acc022db0
+    sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
   category: main
   optional: false
 - name: pygments
-  version: 2.19.2
+  version: 2.20.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6b6ece66ebcae2d5f326c77ef2c5a066
-    sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+    md5: 16c18772b340887160c79a6acc022db0
+    sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
   category: main
   optional: false
 - name: pygments
-  version: 2.19.2
+  version: 2.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6b6ece66ebcae2d5f326c77ef2c5a066
-    sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+    md5: 16c18772b340887160c79a6acc022db0
+    sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
   category: main
   optional: false
-- name: pyopenssl
-  version: 25.3.0
+- name: pyjwt
+  version: 2.12.1
   manager: conda
   platform: linux-64
   dependencies:
-    cryptography: '>=45.0.7,<47'
-    python: '>=3.10'
-    typing-extensions: '>=4.9'
-    typing_extensions: '>=4.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-25.3.0-pyhd8ed1ab_0.conda
+    python: ''
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
   hash:
-    md5: ddf01a1d87103a152f725c7aeabffa29
-    sha256: e3a1216bbc4622ac4dfd36c3f8fd3a90d800eebc9147fa3af7eab07d863516b3
+    md5: b27a9f4eca2925036e43542488d3a804
+    sha256: 4279ee4cf2533fd17910ae7373159d9bee2492d8c50932ddc74dd27a70b15de4
   category: main
   optional: false
-- name: pyopenssl
-  version: 25.3.0
+- name: pyjwt
+  version: 2.12.1
   manager: conda
   platform: osx-64
   dependencies:
-    cryptography: '>=45.0.7,<47'
     python: '>=3.10'
-    typing-extensions: '>=4.9'
-    typing_extensions: '>=4.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-25.3.0-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
   hash:
-    md5: ddf01a1d87103a152f725c7aeabffa29
-    sha256: e3a1216bbc4622ac4dfd36c3f8fd3a90d800eebc9147fa3af7eab07d863516b3
+    md5: b27a9f4eca2925036e43542488d3a804
+    sha256: 4279ee4cf2533fd17910ae7373159d9bee2492d8c50932ddc74dd27a70b15de4
   category: main
   optional: false
-- name: pyopenssl
-  version: 25.3.0
+- name: pyjwt
+  version: 2.12.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    cryptography: '>=45.0.7,<47'
+    python: '>=3.10'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+  hash:
+    md5: b27a9f4eca2925036e43542488d3a804
+    sha256: 4279ee4cf2533fd17910ae7373159d9bee2492d8c50932ddc74dd27a70b15de4
+  category: main
+  optional: false
+- name: pyopenssl
+  version: 26.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: '>=46.0.0,<47'
+    python: ''
+    typing-extensions: '>=4.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-26.0.0-pyhcf101f3_0.conda
+  hash:
+    md5: 5291776e59082b5244ab973a8fd66e8b
+    sha256: db1475010a893f3592132fbf03d99cfbf10822fb03f185898f3d014af485fdbd
+  category: main
+  optional: false
+- name: pyopenssl
+  version: 26.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cryptography: '>=46.0.0,<47'
     python: '>=3.10'
     typing-extensions: '>=4.9'
-    typing_extensions: '>=4.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-25.3.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-26.0.0-pyhcf101f3_0.conda
   hash:
-    md5: ddf01a1d87103a152f725c7aeabffa29
-    sha256: e3a1216bbc4622ac4dfd36c3f8fd3a90d800eebc9147fa3af7eab07d863516b3
+    md5: 5291776e59082b5244ab973a8fd66e8b
+    sha256: db1475010a893f3592132fbf03d99cfbf10822fb03f185898f3d014af485fdbd
+  category: main
+  optional: false
+- name: pyopenssl
+  version: 26.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cryptography: '>=46.0.0,<47'
+    python: '>=3.10'
+    typing-extensions: '>=4.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-26.0.0-pyhcf101f3_0.conda
+  hash:
+    md5: 5291776e59082b5244ab973a8fd66e8b
+    sha256: db1475010a893f3592132fbf03d99cfbf10822fb03f185898f3d014af485fdbd
   category: main
   optional: false
 - name: pyparsing
@@ -15911,13 +16546,13 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     certifi: ''
     libgcc: '>=14'
-    proj: '>=9.7.0,<9.8.0a0'
-    python: '>=3.13,<3.14.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
+    python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py313h77f6078_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py313h446daf0_3.conda
   hash:
-    md5: 42d11c7d1ac21ae2085f58353641e71c
-    sha256: a37cabb43cf5d73bacd0c20856374561dde9f0025c4a189593d961057ba4a17d
+    md5: f02459696406eb29211e929036e04548
+    sha256: 96ea68d4e4954beca1b4aa62695b1c1e525a0e11d32d7823afb7a9a6495acb66
   category: main
   optional: false
 - name: pyproj
@@ -15925,15 +16560,15 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     certifi: ''
-    proj: '>=9.7.0,<9.8.0a0'
-    python: '>=3.13,<3.14.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
+    python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.2-py313hc0f1baa_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.7.2-py313hb57fe85_3.conda
   hash:
-    md5: c575fef0091ba29a58fc600e52fa675d
-    sha256: 6927858d40ac2acf5b75da70c69f9a65ca3e012af469bb680ef67a68fe7fbd0d
+    md5: 1182dbafb963ed41bf46baa835bc8c76
+    sha256: a825e90fe0f292cf2596f8001487ec6215dd45550857ec62db30b6d4fcc688bc
   category: main
   optional: false
 - name: pyproj
@@ -15943,13 +16578,13 @@ package:
   dependencies:
     __osx: '>=11.0'
     certifi: ''
-    proj: '>=9.7.0,<9.8.0a0'
-    python: '>=3.13,<3.14.0a0'
+    proj: '>=9.7.1,<9.8.0a0'
+    python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py313h698103d_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py313h6de5794_3.conda
   hash:
-    md5: 65f22ed9bf92ab532ee61b14779f3c9f
-    sha256: e6c433f5364e9897b260e0b3038bd13be251b14d33eda575706b95fbb0826ccc
+    md5: 1f2ae983e8f36a664dbe220b8d1f7e97
+    sha256: 7a65aa08a4dd6060289a73d461a379ee8e6c183f1b6dd78e0c01332acec8f651
   category: main
   optional: false
 - name: pys2index
@@ -16081,8 +16716,92 @@ package:
     sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   category: main
   optional: false
+- name: pystac
+  version: 1.14.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.10'
+    python-dateutil: '>=2.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 77ae41598d63b453bb3c9052f4a14c4b
+    sha256: 2d39f4eb1c926792229131897fbddde112d7595727c1db824d48574ab10a5a01
+  category: main
+  optional: false
+- name: pystac
+  version: 1.14.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+    python-dateutil: '>=2.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 77ae41598d63b453bb3c9052f4a14c4b
+    sha256: 2d39f4eb1c926792229131897fbddde112d7595727c1db824d48574ab10a5a01
+  category: main
+  optional: false
+- name: pystac
+  version: 1.14.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+    python-dateutil: '>=2.7.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 77ae41598d63b453bb3c9052f4a14c4b
+    sha256: 2d39f4eb1c926792229131897fbddde112d7595727c1db824d48574ab10a5a01
+  category: main
+  optional: false
+- name: pystac-client
+  version: 0.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pystac: '>=1.10.0'
+    python: '>=3.10'
+    python-dateutil: '>=2.8.2'
+    requests: '>=2.28.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d10aaa4bf5c9fc88730007bf64cda768
+    sha256: 0dbfe9e842ece00ab14736021f959db84663306ab2ffe44263991d30aa595106
+  category: main
+  optional: false
+- name: pystac-client
+  version: 0.9.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    pystac: '>=1.10.0'
+    python: '>=3.10'
+    python-dateutil: '>=2.8.2'
+    requests: '>=2.28.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d10aaa4bf5c9fc88730007bf64cda768
+    sha256: 0dbfe9e842ece00ab14736021f959db84663306ab2ffe44263991d30aa595106
+  category: main
+  optional: false
+- name: pystac-client
+  version: 0.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pystac: '>=1.10.0'
+    python: '>=3.10'
+    python-dateutil: '>=2.8.2'
+    requests: '>=2.28.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d10aaa4bf5c9fc88730007bf64cda768
+    sha256: 0dbfe9e842ece00ab14736021f959db84663306ab2ffe44263991d30aa595106
+  category: main
+  optional: false
 - name: pytest
-  version: 9.0.2
+  version: 9.0.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -16094,14 +16813,14 @@ package:
     pygments: '>=2.7.2'
     python: ''
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
   hash:
-    md5: 2b694bad8a50dc2f712f5368de866480
-    sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
+    md5: 6a991452eadf2771952f39d43615bb3e
+    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
   category: main
   optional: false
 - name: pytest
-  version: 9.0.2
+  version: 9.0.3
   manager: conda
   platform: osx-64
   dependencies:
@@ -16113,14 +16832,14 @@ package:
     pygments: '>=2.7.2'
     python: '>=3.10'
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
   hash:
-    md5: 2b694bad8a50dc2f712f5368de866480
-    sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
+    md5: 6a991452eadf2771952f39d43615bb3e
+    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
   category: main
   optional: false
 - name: pytest
-  version: 9.0.2
+  version: 9.0.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -16132,91 +16851,91 @@ package:
     pygments: '>=2.7.2'
     python: '>=3.10'
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
   hash:
-    md5: 2b694bad8a50dc2f712f5368de866480
-    sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
+    md5: 6a991452eadf2771952f39d43615bb3e
+    sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
   category: main
   optional: false
 - name: python
-  version: 3.13.11
+  version: 3.13.13
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
     ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.7.3,<3.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
     libgcc: '>=14'
     liblzma: '>=5.8.2,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.51.2,<4.0a0'
-    libuuid: '>=2.41.3,<3.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libsqlite: '>=3.52.0,<4.0a0'
+    libuuid: '>=2.42,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     pip: ''
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.11-hc97d973_101_cp313.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
   hash:
-    md5: aa23b675b860f2566af2dfb3ffdf3b8c
-    sha256: c9625638f32f4ee27a506e8cefc56a78110c4c54867663f56d91dc721df9dc7f
+    md5: 05051be49267378d2fcd12931e319ac3
+    sha256: 7f77eb57648f545c1f58e10035d0d9d66b0a0efb7c4b58d3ed89ec7269afdde1
   category: main
   optional: false
 - name: python
-  version: 3.13.11
+  version: 3.13.13
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.7.3,<3.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
     liblzma: '>=5.8.2,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.51.2,<4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libsqlite: '>=3.52.0,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     pip: ''
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.11-h17c18a5_101_cp313.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.13-h3d5d122_100_cp313.conda
   hash:
-    md5: aa0e1db83fc31e7c5281337b4207a5cb
-    sha256: e4b1ce43f1bbe9bbda604fe465f07131e568ba1877ac2562c3148bb13c4bfe79
+    md5: 8948c8c7c653ad668d55bbbd6836178b
+    sha256: 6f71b48fe93ebc0dd42c80358b75020f6ad12ed4772fb3555da36000139c0dc7
   category: main
   optional: false
 - name: python
-  version: 3.13.11
+  version: 3.13.13
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.7.3,<3.0a0'
+    libexpat: '>=2.7.5,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
     liblzma: '>=5.8.2,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.51.2,<4.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
+    libsqlite: '>=3.52.0,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
-    openssl: '>=3.5.4,<4.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     pip: ''
     python_abi: 3.13.*
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.11-hfc2f54d_101_cp313.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
   hash:
-    md5: 8f2ac152fe98c22af0f4b479cf11c845
-    sha256: 8565d451dff3cda5e55fabdbae2751033c2b08b3fd3833526f8dbf3c08bcb3cf
+    md5: 9991a930e81d3873eba7a299ba783ec4
+    sha256: d0fffc5fde21d1ae350da545dfb9e115a8c53bed8a9c5761f9efd4a5581853c1
   category: main
   optional: false
 - name: python-cdo
@@ -16304,100 +17023,202 @@ package:
   category: main
   optional: false
 - name: python-eccodes
-  version: 2.45.0
+  version: 2.47.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     attrs: ''
     cffi: ''
-    eccodes: '>=2.45.0'
+    eccodes: '>=2.47.0'
     findlibs: ''
     libgcc: '>=14'
     numpy: '>=1.23,<3'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-eccodes-2.45.0-np2py313hc18bace_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-eccodes-2.47.0-np2py313hc18bace_0.conda
   hash:
-    md5: 17ae2a605a45add6050a04962f847b21
-    sha256: 231716d4b0e8d0e67eaddd9dea2d7bd6afd8901afd66e8f5ab7f0e257d15bdf9
+    md5: 5ac58ad77ebc56ba99f965562315a69c
+    sha256: 4a4c9d44467464064caafc15d066fb8e37def1ce01a55a3fea0ddabec11f8006
   category: main
   optional: false
 - name: python-eccodes
-  version: 2.45.0
+  version: 2.47.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     attrs: ''
     cffi: ''
-    eccodes: '>=2.45.0'
+    eccodes: '>=2.47.0'
     findlibs: ''
     numpy: '>=1.23,<3'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-eccodes-2.45.0-np2py313h7488b0a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-eccodes-2.47.0-np2py313h4ef92c9_0.conda
   hash:
-    md5: c1ad796bc2195d11df1627a51d08e32d
-    sha256: abe6487f78d7a208e38387ef1bbea562932883b0594eca3d0eb1d0f08fa1e9a6
+    md5: fd7ded1f20d0dc396e655526352418fd
+    sha256: 150bcf991fe772053d26f3c538ad2b3d6b309fa672c95af65b451324568033b2
   category: main
   optional: false
 - name: python-eccodes
-  version: 2.45.0
+  version: 2.47.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     attrs: ''
     cffi: ''
-    eccodes: '>=2.45.0'
+    eccodes: '>=2.47.0'
     findlibs: ''
     numpy: '>=1.23,<3'
     python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-eccodes-2.45.0-np2py313h2962dae_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-eccodes-2.47.0-np2py313h2962dae_0.conda
   hash:
-    md5: 043a00e5b0a49bb00f3431ec1a0941d0
-    sha256: ea3bd82bc615926c35123f2bcb3a00ee2494aaa25f707fb8e6a772304b1c0819
+    md5: 1d46eb27507a38bd8bd18681f4c3ed97
+    sha256: 9da164f56a2eac305e8e256e9ff06f200c4eeee1a4e0703d0bf2991535120092
   category: main
   optional: false
-- name: python-gil
-  version: 3.13.11
+- name: python-fasthtml
+  version: 0.13.4
   manager: conda
   platform: linux-64
   dependencies:
-    cpython: 3.13.11.*
-    python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.11-h4df99d1_101.conda
+    beautifulsoup4: ''
+    fastcore: '>=1.12.41'
+    fastlite: '>=0.1.1'
+    httpx: ''
+    itsdangerous: ''
+    oauthlib: ''
+    python: ''
+    python-dateutil: ''
+    python-multipart: ''
+    starlette: '>=1.0,<2.dev0'
+    uvicorn: '>=0.30'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fasthtml-0.13.4-pyhc364b38_0.conda
   hash:
-    md5: 4af7a72062bddcb57dea6b236e1b245e
-    sha256: c17676be5479d9032b54fea09024fc2cdeb689639070b25fa9bd85b32c531a7a
+    md5: d9df005a0b037d550cd7d3316f13d660
+    sha256: 5b7bc6c34d3f157f6c4c029d45c4d88a0fbc8181543556751c6d7a05fd826d87
   category: main
   optional: false
-- name: python-gil
-  version: 3.13.11
+- name: python-fasthtml
+  version: 0.13.4
   manager: conda
   platform: osx-64
   dependencies:
-    cpython: 3.13.11.*
-    python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.11-h4df99d1_101.conda
+    beautifulsoup4: ''
+    fastcore: '>=1.12.41'
+    fastlite: '>=0.1.1'
+    httpx: ''
+    itsdangerous: ''
+    oauthlib: ''
+    python: '>=3.10'
+    python-dateutil: ''
+    python-multipart: ''
+    starlette: '>=1.0,<2.dev0'
+    uvicorn: '>=0.30'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fasthtml-0.13.4-pyhc364b38_0.conda
   hash:
-    md5: 4af7a72062bddcb57dea6b236e1b245e
-    sha256: c17676be5479d9032b54fea09024fc2cdeb689639070b25fa9bd85b32c531a7a
+    md5: d9df005a0b037d550cd7d3316f13d660
+    sha256: 5b7bc6c34d3f157f6c4c029d45c4d88a0fbc8181543556751c6d7a05fd826d87
   category: main
   optional: false
-- name: python-gil
-  version: 3.13.11
+- name: python-fasthtml
+  version: 0.13.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    cpython: 3.13.11.*
-    python_abi: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.11-h4df99d1_101.conda
+    beautifulsoup4: ''
+    fastcore: '>=1.12.41'
+    fastlite: '>=0.1.1'
+    httpx: ''
+    itsdangerous: ''
+    oauthlib: ''
+    python: '>=3.10'
+    python-dateutil: ''
+    python-multipart: ''
+    starlette: '>=1.0,<2.dev0'
+    uvicorn: '>=0.30'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fasthtml-0.13.4-pyhc364b38_0.conda
   hash:
-    md5: 4af7a72062bddcb57dea6b236e1b245e
-    sha256: c17676be5479d9032b54fea09024fc2cdeb689639070b25fa9bd85b32c531a7a
+    md5: d9df005a0b037d550cd7d3316f13d660
+    sha256: 5b7bc6c34d3f157f6c4c029d45c4d88a0fbc8181543556751c6d7a05fd826d87
+  category: main
+  optional: false
+- name: python-gil
+  version: 3.13.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cpython: 3.13.13.*
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+  hash:
+    md5: fd00e4b24ea88093c93f5c9bad27b52f
+    sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
+  category: main
+  optional: false
+- name: python-gil
+  version: 3.13.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cpython: 3.13.13.*
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+  hash:
+    md5: fd00e4b24ea88093c93f5c9bad27b52f
+    sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
+  category: main
+  optional: false
+- name: python-gil
+  version: 3.13.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cpython: 3.13.13.*
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+  hash:
+    md5: fd00e4b24ea88093c93f5c9bad27b52f
+    sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
+  category: main
+  optional: false
+- name: python-multipart
+  version: 0.0.27
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.27-pyhcf101f3_0.conda
+  hash:
+    md5: 8093fa1c299e4bc6b015d4d01f0925dc
+    sha256: 27a8fe0284b8d9b2d3748b13d6d7b111c663ab8b2397a0c144d4859c0bdd8557
+  category: main
+  optional: false
+- name: python-multipart
+  version: 0.0.27
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.27-pyhcf101f3_0.conda
+  hash:
+    md5: 8093fa1c299e4bc6b015d4d01f0925dc
+    sha256: 27a8fe0284b8d9b2d3748b13d6d7b111c663ab8b2397a0c144d4859c0bdd8557
+  category: main
+  optional: false
+- name: python-multipart
+  version: 0.0.27
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.27-pyhcf101f3_0.conda
+  hash:
+    md5: 8093fa1c299e4bc6b015d4d01f0925dc
+    sha256: 27a8fe0284b8d9b2d3748b13d6d7b111c663ab8b2397a0c144d4859c0bdd8557
   category: main
   optional: false
 - name: python-stratify
@@ -16571,39 +17392,39 @@ package:
   category: main
   optional: false
 - name: pytz
-  version: '2025.2'
+  version: 2026.1.post1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
   hash:
-    md5: bc8e3267d44011051f2eb14d22fb0960
-    sha256: 8d2a8bf110cc1fc3df6904091dead158ba3e614d8402a83e51ed3a8aa93cdeb0
+    md5: f8a489f43a1342219a3a4d69cecc6b25
+    sha256: d35c15c861d5635db1ba847a2e0e7de4c01994999602db1f82e41b5935a9578a
   category: main
   optional: false
 - name: pytz
-  version: '2025.2'
+  version: 2026.1.post1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
   hash:
-    md5: bc8e3267d44011051f2eb14d22fb0960
-    sha256: 8d2a8bf110cc1fc3df6904091dead158ba3e614d8402a83e51ed3a8aa93cdeb0
+    md5: f8a489f43a1342219a3a4d69cecc6b25
+    sha256: d35c15c861d5635db1ba847a2e0e7de4c01994999602db1f82e41b5935a9578a
   category: main
   optional: false
 - name: pytz
-  version: '2025.2'
+  version: 2026.1.post1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
   hash:
-    md5: bc8e3267d44011051f2eb14d22fb0960
-    sha256: 8d2a8bf110cc1fc3df6904091dead158ba3e614d8402a83e51ed3a8aa93cdeb0
+    md5: f8a489f43a1342219a3a4d69cecc6b25
+    sha256: d35c15c861d5635db1ba847a2e0e7de4c01994999602db1f82e41b5935a9578a
   category: main
   optional: false
 - name: pywavelets
@@ -16662,10 +17483,10 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
   hash:
-    md5: 4794ea0adaebd9f844414e594b142cb2
-    sha256: 40dcd6718dce5fbee8aabdd0519f23d456d8feb2e15ac352eaa88bbfd3a881af
+    md5: f256753e840c3cd3766488c9437a8f8b
+    sha256: ef7df29b38ef04ec67a8888a4aa039973eaa377e8c4b59a7be0a1c50cd7e4ac6
   category: main
   optional: false
 - name: pyyaml
@@ -16677,10 +17498,10 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py313h0f4d31d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.3-py313h7c6a591_1.conda
   hash:
-    md5: e0c9e257970870212c449106964a5ace
-    sha256: 8420815e10d455b012db39cb7dc0d86f0ac3a287d5a227892fa611fe3d467df9
+    md5: 0eaf6cf9939bb465ee62b17d04254f9e
+    sha256: ab5f6c27d24facd1832481ccd8f432c676472d57596a3feaa77880a1462cdb2a
   category: main
   optional: false
 - name: pyyaml
@@ -16692,10 +17513,10 @@ package:
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py313h7d74516_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py313h65a2061_1.conda
   hash:
-    md5: 0e8e3235217b4483a7461b63dca5826b
-    sha256: f5be0d84f72a567b7333b9efa74a65bfa44a25658cf107ffa3fc65d3ae6660d7
+    md5: 5d0c8b92128c93027632ca8f8dc1190f
+    sha256: 950725516f67c9691d81bb8dde8419581c5332c5da3da10c9ba8cbb1698b825d
   category: main
   optional: false
 - name: qhull
@@ -16818,82 +17639,82 @@ package:
   category: main
   optional: false
 - name: rav1e
-  version: 0.7.1
+  version: 0.8.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
   hash:
-    md5: 2c42649888aac645608191ffdc80d13a
-    sha256: 6e5e704c1c21f820d760e56082b276deaf2b53cf9b751772761c3088a365f6f4
+    md5: d83958768626b3c8471ce032e28afcd3
+    sha256: cf550bbc8e5ebedb6dba9ccaead3e07bd1cb86b183644a4c853e06e4b3ad5ac7
   category: main
   optional: false
 - name: rav1e
-  version: 0.7.1
+  version: 0.8.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.7.1-h371c88c_3.conda
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.8.1-h618d828_0.conda
   hash:
-    md5: 30e2344bbe29f60bb535ec0bfff31008
-    sha256: d86b9631d6237f5a62957f9461d321d9bd2fef0807fb60de823b8dea2028501b
+    md5: 19c2d0ae0255c175faec576d43fe9763
+    sha256: 4286abee88102b8889d2d20e79a51424fcee2aa24aba3d0ea3c5c7ee251d48ca
   category: main
   optional: false
 - name: rav1e
-  version: 0.7.1
+  version: 0.8.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.7.1-h0716509_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.8.1-h8246384_0.conda
   hash:
-    md5: 7b37f30516100b86ea522350c8cab44c
-    sha256: 65f862b2b31ef2b557990a82015cbd41e5a66041c2f79b4451dd14b4595d4c04
+    md5: 4706a8a71474c692482c3f86c2175454
+    sha256: 925e35b71fe513e0380ecd2fe137e3f4f248bf7ce4bad96946c7c704b7a50d26
   category: main
   optional: false
 - name: rdflib
-  version: 7.5.0
+  version: 7.6.0
   manager: conda
   platform: linux-64
   dependencies:
     isodate: '>=0.7.2,<1.0.0'
     pyparsing: '>=2.1.0,<4'
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rdflib-7.5.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rdflib-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 4773a3dc77af2f5b82c7713681d3cfd8
-    sha256: fc991727e14276b0030b09f058c9f2a4ff4c55921053234131dd744e62d7367d
+    md5: 1ba0ceffa17c51959fa5c0996449266d
+    sha256: b1ebe0cf1803d9b5e2584af6e7c414b8baa9ba2f41bb0e61d991cbfa5cfcf130
   category: main
   optional: false
 - name: rdflib
-  version: 7.5.0
+  version: 7.6.0
   manager: conda
   platform: osx-64
   dependencies:
     isodate: '>=0.7.2,<1.0.0'
     pyparsing: '>=2.1.0,<4'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/rdflib-7.5.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rdflib-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 4773a3dc77af2f5b82c7713681d3cfd8
-    sha256: fc991727e14276b0030b09f058c9f2a4ff4c55921053234131dd744e62d7367d
+    md5: 1ba0ceffa17c51959fa5c0996449266d
+    sha256: b1ebe0cf1803d9b5e2584af6e7c414b8baa9ba2f41bb0e61d991cbfa5cfcf130
   category: main
   optional: false
 - name: rdflib
-  version: 7.5.0
+  version: 7.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
     isodate: '>=0.7.2,<1.0.0'
     pyparsing: '>=2.1.0,<4'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/rdflib-7.5.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rdflib-7.6.0-pyhcf101f3_0.conda
   hash:
-    md5: 4773a3dc77af2f5b82c7713681d3cfd8
-    sha256: fc991727e14276b0030b09f058c9f2a4ff4c55921053234131dd744e62d7367d
+    md5: 1ba0ceffa17c51959fa5c0996449266d
+    sha256: b1ebe0cf1803d9b5e2584af6e7c414b8baa9ba2f41bb0e61d991cbfa5cfcf130
   category: main
   optional: false
 - name: re2
@@ -16973,55 +17794,55 @@ package:
   category: main
   optional: false
 - name: requests
-  version: 2.32.5
+  version: 2.33.1
   manager: conda
   platform: linux-64
   dependencies:
-    certifi: '>=2017.4.17'
+    certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
     python: ''
-    urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+    urllib3: '>=1.26,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_1.conda
   hash:
-    md5: c65df89a0b2e321045a9e01d1337b182
-    sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
+    md5: 9659f587a8ceacc21864260acd02fc67
+    sha256: 7f2c24dd3bd3c104a1d2c9a10ead5ed6758b0976b74f972cfe9c19884ccc4241
   category: main
   optional: false
 - name: requests
-  version: 2.32.5
+  version: 2.33.1
   manager: conda
   platform: osx-64
   dependencies:
-    certifi: '>=2017.4.17'
+    certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
     python: '>=3.10'
-    urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+    urllib3: '>=1.26,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_1.conda
   hash:
-    md5: c65df89a0b2e321045a9e01d1337b182
-    sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
+    md5: 9659f587a8ceacc21864260acd02fc67
+    sha256: 7f2c24dd3bd3c104a1d2c9a10ead5ed6758b0976b74f972cfe9c19884ccc4241
   category: main
   optional: false
 - name: requests
-  version: 2.32.5
+  version: 2.33.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    certifi: '>=2017.4.17'
+    certifi: '>=2023.5.7'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
     python: '>=3.10'
-    urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+    urllib3: '>=1.26,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_1.conda
   hash:
-    md5: c65df89a0b2e321045a9e01d1337b182
-    sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
+    md5: 9659f587a8ceacc21864260acd02fc67
+    sha256: 7f2c24dd3bd3c104a1d2c9a10ead5ed6758b0976b74f972cfe9c19884ccc4241
   category: main
   optional: false
 - name: requests-cache
-  version: 1.2.1
+  version: 1.3.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -17029,20 +17850,20 @@ package:
     cattrs: '>=22.2'
     itsdangerous: '>=2.0'
     platformdirs: '>=2.5'
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: '>=6.0.1'
     requests: '>=2.22'
     ujson: '>=5.4'
     url-normalize: '>=1.4'
     urllib3: '>=1.25.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.2.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 584e6aab3a5cffde537c575ad6a673ff
-    sha256: 97195fe57ef9ab18e368a8d1f021be4e041f97638bed90a339e068989159e877
+    md5: cb9d061ef6ddabbe09b2dddffb96c476
+    sha256: 046b72d49c5856c3e7711ba5b790c55905b78e25baf4531c1f52c655da84e505
   category: main
   optional: false
 - name: requests-cache
-  version: 1.2.1
+  version: 1.3.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -17050,20 +17871,20 @@ package:
     cattrs: '>=22.2'
     itsdangerous: '>=2.0'
     platformdirs: '>=2.5'
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: '>=6.0.1'
     requests: '>=2.22'
     ujson: '>=5.4'
     url-normalize: '>=1.4'
     urllib3: '>=1.25.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.2.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 584e6aab3a5cffde537c575ad6a673ff
-    sha256: 97195fe57ef9ab18e368a8d1f021be4e041f97638bed90a339e068989159e877
+    md5: cb9d061ef6ddabbe09b2dddffb96c476
+    sha256: 046b72d49c5856c3e7711ba5b790c55905b78e25baf4531c1f52c655da84e505
   category: main
   optional: false
 - name: requests-cache
-  version: 1.2.1
+  version: 1.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -17071,16 +17892,16 @@ package:
     cattrs: '>=22.2'
     itsdangerous: '>=2.0'
     platformdirs: '>=2.5'
-    python: '>=3.9'
+    python: '>=3.10'
     pyyaml: '>=6.0.1'
     requests: '>=2.22'
     ujson: '>=5.4'
     url-normalize: '>=1.4'
     urllib3: '>=1.25.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.2.1-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 584e6aab3a5cffde537c575ad6a673ff
-    sha256: 97195fe57ef9ab18e368a8d1f021be4e041f97638bed90a339e068989159e877
+    md5: cb9d061ef6ddabbe09b2dddffb96c476
+    sha256: 046b72d49c5856c3e7711ba5b790c55905b78e25baf4531c1f52c655da84e505
   category: main
   optional: false
 - name: retrying
@@ -17120,7 +17941,7 @@ package:
   category: main
   optional: false
 - name: rich
-  version: 14.3.1
+  version: 15.0.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -17128,14 +17949,14 @@ package:
     pygments: '>=2.13.0,<3.0.0'
     python: ''
     typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
   hash:
-    md5: 83d94f410444da5e2f96e5742b7a4973
-    sha256: 8d9c9c52bb4d3684d467a6e31814d8c9fccdacc8c50eb1e3e5025e88d6d57cb4
+    md5: 0242025a3c804966bf71aa04eee82f66
+    sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
   category: main
   optional: false
 - name: rich
-  version: 14.3.1
+  version: 15.0.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -17143,14 +17964,14 @@ package:
     pygments: '>=2.13.0,<3.0.0'
     python: '>=3.10'
     typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
   hash:
-    md5: 83d94f410444da5e2f96e5742b7a4973
-    sha256: 8d9c9c52bb4d3684d467a6e31814d8c9fccdacc8c50eb1e3e5025e88d6d57cb4
+    md5: 0242025a3c804966bf71aa04eee82f66
+    sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
   category: main
   optional: false
 - name: rich
-  version: 14.3.1
+  version: 15.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -17158,92 +17979,10 @@ package:
     pygments: '>=2.13.0,<3.0.0'
     python: '>=3.10'
     typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
   hash:
-    md5: 83d94f410444da5e2f96e5742b7a4973
-    sha256: 8d9c9c52bb4d3684d467a6e31814d8c9fccdacc8c50eb1e3e5025e88d6d57cb4
-  category: main
-  optional: false
-- name: ruamel.yaml
-  version: 0.19.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-    ruamel.yaml.clib: '>=0.2.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
-  hash:
-    md5: 06ad944772941d5dae1e0d09848d8e49
-    sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
-  category: main
-  optional: false
-- name: ruamel.yaml
-  version: 0.19.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.10'
-    ruamel.yaml.clib: '>=0.2.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
-  hash:
-    md5: 06ad944772941d5dae1e0d09848d8e49
-    sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
-  category: main
-  optional: false
-- name: ruamel.yaml
-  version: 0.19.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.10'
-    ruamel.yaml.clib: '>=0.2.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
-  hash:
-    md5: 06ad944772941d5dae1e0d09848d8e49
-    sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
-  category: main
-  optional: false
-- name: ruamel.yaml.clib
-  version: 0.2.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
-  hash:
-    md5: ef8c7c9f4ea478806d9056bbc9c9c093
-    sha256: e7655f12e29add10ef6842ca7e06167fc326903f32b0a9e62f464afda4e0d3d1
-  category: main
-  optional: false
-- name: ruamel.yaml.clib
-  version: 0.2.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py313h16366db_1.conda
-  hash:
-    md5: 846c1dd713142a49a08e917a92343f51
-    sha256: 0bcb752de3e034b43529fc41aec9bca95cf1d1b9ae741b9db7bccd980ef603ac
-  category: main
-  optional: false
-- name: ruamel.yaml.clib
-  version: 0.2.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: 3.13.*
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
-  hash:
-    md5: ccc49acbc9df82571383070bc4591c45
-    sha256: d2050d1d9fb396bd8fb42758bcc6e5bf301c94856086be5411dfe21a0bb2da22
+    md5: 0242025a3c804966bf71aa04eee82f66
+    sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
   category: main
   optional: false
 - name: s2geometry
@@ -17438,7 +18177,7 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.17.0
+  version: 1.17.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -17453,18 +18192,18 @@ package:
     numpy: '>=1.25.2'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.0-py313h4b8bb8b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
   hash:
-    md5: 2b18fe5b4b2d1611ddf8c2f080a46563
-    sha256: e812ebe8115f8daf005f5788ed8f05a0fdabe47eeb4c30bf0a190f2d1d1da0b6
+    md5: ec81bc03787968decae6765c7f61b7cf
+    sha256: fdd92a119a2a5f89d6e549a326adcb008f5046ea5034a9af409e97b7e20e6f06
   category: main
   optional: false
 - name: scipy
-  version: 1.17.0
+  version: 1.17.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=19'
@@ -17474,14 +18213,14 @@ package:
     numpy: '>=1.25.2'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.17.0-py313h2bd7e7a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.17.1-py313h9cbb6b6_0.conda
   hash:
-    md5: 076afc646e5b800ab4adece0310795db
-    sha256: c30ec7d0e2571f6f2ddaddf3eb64e0e2e16e58c0a4f724f2ee2b894e0ce1a8e4
+    md5: 9e81e20b3d255f8b83b6c814cc0c8924
+    sha256: 026d11963a37f4996047c986806e9b58957277ed219f010764ef4a7c5268e83c
   category: main
   optional: false
 - name: scipy
-  version: 1.17.0
+  version: 1.17.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -17495,10 +18234,10 @@ package:
     numpy: '>=1.25.2'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.0-py313hc753a45_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
   hash:
-    md5: 5b73b1e6d191aac48960c50d65372f19
-    sha256: 2ea17fc46533e8789881732f42265e32c7ae376344cc3d53683e7b2179d947bb
+    md5: 6f3a898962bdea87c076108bc336df2e
+    sha256: d22bf4791d1fc96b35374de0dd904745c3b54282ba23c3d435a994b4ff384719
   category: main
   optional: false
 - name: seaborn
@@ -17631,39 +18370,39 @@ package:
   category: main
   optional: false
 - name: setuptools
-  version: 80.10.2
+  version: 82.0.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   hash:
-    md5: 7b446fcbb6779ee479debb4fd7453e6c
-    sha256: f5fcb7854d2b7639a5b1aca41dd0f2d5a69a60bbc313e7f192e2dc385ca52f86
+    md5: 8e194e7b992f99a5015edbd4ebd38efd
+    sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
   category: main
   optional: false
 - name: setuptools
-  version: 80.10.2
+  version: 82.0.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   hash:
-    md5: 7b446fcbb6779ee479debb4fd7453e6c
-    sha256: f5fcb7854d2b7639a5b1aca41dd0f2d5a69a60bbc313e7f192e2dc385ca52f86
+    md5: 8e194e7b992f99a5015edbd4ebd38efd
+    sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
   category: main
   optional: false
 - name: setuptools
-  version: 80.10.2
+  version: 82.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   hash:
-    md5: 7b446fcbb6779ee479debb4fd7453e6c
-    sha256: f5fcb7854d2b7639a5b1aca41dd0f2d5a69a60bbc313e7f192e2dc385ca52f86
+    md5: 8e194e7b992f99a5015edbd4ebd38efd
+    sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
   category: main
   optional: false
 - name: shapely
@@ -17716,7 +18455,7 @@ package:
   category: main
   optional: false
 - name: simplejson
-  version: 3.20.2
+  version: 4.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -17724,38 +18463,38 @@ package:
     libgcc: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.20.2-py313h07c4f96_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/simplejson-4.1.1-py313h07c4f96_0.conda
   hash:
-    md5: 1cc1de04373b633177f4d367b8b75270
-    sha256: cf44d6bd3dc3be6b683fac251d6b53d508d041506a2101fd7cdb404468cf8be3
+    md5: b53cd9d3018d1f0a129b6c8facaf8fc8
+    sha256: 5fbf29ed50e0fcfc3f737725229f4aa6e40bcf95d6289310999cff16b86c2cc8
   category: main
   optional: false
 - name: simplejson
-  version: 3.20.2
+  version: 4.1.1
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.20.2-py313hf050af9_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/simplejson-4.1.1-py313hf59fe81_0.conda
   hash:
-    md5: 099e12ab59f12207a460dbb029f46a8b
-    sha256: 15b28d63c119b4d42426255bdf3165ada1afb2578840cb6ccf8ac16fc492f148
+    md5: 77706488dadb12fc0b81fe2f11fca40a
+    sha256: 54a5045f2d0c3d3d0fa0760c72eed0017c2fe5537445955dcbe340c1765775a2
   category: main
   optional: false
 - name: simplejson
-  version: 3.20.2
+  version: 4.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/simplejson-3.20.2-py313h6535dbc_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/simplejson-4.1.1-py313h0997733_0.conda
   hash:
-    md5: 27a8bc65b5f0aecb87a01568e573e6ae
-    sha256: ef09659f0248066e8c06a0bd8bd1a360b8158cd2d73c65c969897e20344c6a2a
+    md5: 12e334f651705f947aff922ed2fd1e1e
+    sha256: af30ac19277f231829a8744efe0318afa9d0353442973dce1cd110da8bada531
   category: main
   optional: false
 - name: six
@@ -17834,6 +18573,42 @@ package:
     sha256: cb9305ede19584115f43baecdf09a3866bfcd5bcca0d9e527bd76d9a1dbe2d8d
   category: main
   optional: false
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: 03fe290994c5e4ec17293cfb6bdce520
+    sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
+  category: main
+  optional: false
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: 03fe290994c5e4ec17293cfb6bdce520
+    sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
+  category: main
+  optional: false
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: 03fe290994c5e4ec17293cfb6bdce520
+    sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
+  category: main
+  optional: false
 - name: snuggs
   version: 1.4.7
   manager: conda
@@ -17949,96 +18724,96 @@ package:
   category: main
   optional: false
 - name: sparse
-  version: 0.17.0
+  version: 0.18.0
   manager: conda
   platform: linux-64
   dependencies:
     numba: '>=0.49'
     numpy: '>=1.17'
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.17.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.18.0-pyhcf101f3_0.conda
   hash:
-    md5: 1b59de14a7e5888f939611e1fe329e00
-    sha256: 8406de1065e1d4ba206d611dae9a03de7f226f486ce9fb02ab0f29c3bd031a6a
+    md5: c67d2c8ce612c88ece7221fe0b5357f2
+    sha256: b18229272e7b662f8b3e1be4d768753e7b6e6fdf36c5a82878aeec759c6bfaf5
   category: main
   optional: false
 - name: sparse
-  version: 0.17.0
+  version: 0.18.0
   manager: conda
   platform: osx-64
   dependencies:
     numba: '>=0.49'
     numpy: '>=1.17'
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.17.0-pyhcf101f3_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.18.0-pyhcf101f3_0.conda
   hash:
-    md5: 1b59de14a7e5888f939611e1fe329e00
-    sha256: 8406de1065e1d4ba206d611dae9a03de7f226f486ce9fb02ab0f29c3bd031a6a
+    md5: c67d2c8ce612c88ece7221fe0b5357f2
+    sha256: b18229272e7b662f8b3e1be4d768753e7b6e6fdf36c5a82878aeec759c6bfaf5
   category: main
   optional: false
 - name: sparse
-  version: 0.17.0
+  version: 0.18.0
   manager: conda
   platform: osx-arm64
   dependencies:
     numba: '>=0.49'
     numpy: '>=1.17'
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.17.0-pyhcf101f3_0.conda
+    python: '>=3.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/sparse-0.18.0-pyhcf101f3_0.conda
   hash:
-    md5: 1b59de14a7e5888f939611e1fe329e00
-    sha256: 8406de1065e1d4ba206d611dae9a03de7f226f486ce9fb02ab0f29c3bd031a6a
+    md5: c67d2c8ce612c88ece7221fe0b5357f2
+    sha256: b18229272e7b662f8b3e1be4d768753e7b6e6fdf36c5a82878aeec759c6bfaf5
   category: main
   optional: false
 - name: sqlite
-  version: 3.51.2
+  version: 3.53.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.2,<79.0a0'
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
-    libsqlite: 3.51.2
-    libzlib: '>=1.3.1,<2.0a0'
+    libsqlite: 3.53.0
+    libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     readline: '>=8.3,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.51.2-h04a0ce9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-h04a0ce9_0.conda
   hash:
-    md5: bb88d9335d09e54c7e6b5529d1856917
-    sha256: ccce47d8fe3a817eac5b95f34ca0fcb12423b0c7c5eee249ffb32ac8013e9692
+    md5: dc540e5bd5616d83a1ec46af8315ff98
+    sha256: a0e35087ebf0720fa758cb261583bee0a328143238524ea47625b37108280291
   category: main
   optional: false
 - name: sqlite
-  version: 3.51.2
+  version: 3.53.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libsqlite: 3.51.2
-    libzlib: '>=1.3.1,<2.0a0'
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libsqlite: 3.53.0
+    libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     readline: '>=8.3,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.51.2-h5af3ad2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.53.0-h6775aab_0.conda
   hash:
-    md5: 9eef7504045dd9eb1be950b2f934d542
-    sha256: 89fde12f2a5e58edb9bd1497558a77df9c090878971559bcf0c8513e0966795e
+    md5: 2175dff177aec3cf3cdabe922ec9acb2
+    sha256: 8a1a21843554adeb3ca26bcc296d5e66ff5f239dce7e98cd73718b2be4f34cc1
   category: main
   optional: false
 - name: sqlite
-  version: 3.51.2
+  version: 3.53.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    icu: '>=78.2,<79.0a0'
-    libsqlite: 3.51.2
-    libzlib: '>=1.3.1,<2.0a0'
+    libsqlite: 3.53.0
+    libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     readline: '>=8.3,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.51.2-h77b7338_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.0-h85ec8f2_0.conda
   hash:
-    md5: 93796186d49d0b09243fb5a8f83e53b6
-    sha256: a13c798ad921da0c84c441c390ace3b53e5c40fe6b11d00e07641d985021c4d1
+    md5: 60a9b64bc09b5f7af723273c3fe8d856
+    sha256: 3c92c6268b9bfdc7bb6990a3df73d586d0650f8c0a3111b8b2414391ad7a2f6d
   category: main
   optional: false
 - name: stack_data
@@ -18084,6 +18859,48 @@ package:
   hash:
     md5: b1b505328da7a6b246787df4b5a49fbc
     sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
+  category: main
+  optional: false
+- name: starlette
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: '>=3.6.2,<5'
+    python: ''
+    typing_extensions: '>=4.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
+  hash:
+    md5: 8fbd5b6879350f1b5303c1a652d4b781
+    sha256: 1a1dc376e95491f4b2003f4428e6f7caf4a3de0ef9869248b29dcc9704c34b39
+  category: main
+  optional: false
+- name: starlette
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    anyio: '>=3.6.2,<5'
+    python: '>=3.10'
+    typing_extensions: '>=4.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
+  hash:
+    md5: 8fbd5b6879350f1b5303c1a652d4b781
+    sha256: 1a1dc376e95491f4b2003f4428e6f7caf4a3de0ef9869248b29dcc9704c34b39
+  category: main
+  optional: false
+- name: starlette
+  version: 1.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    anyio: '>=3.6.2,<5'
+    python: '>=3.10'
+    typing_extensions: '>=4.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
+  hash:
+    md5: 8fbd5b6879350f1b5303c1a652d4b781
+    sha256: 1a1dc376e95491f4b2003f4428e6f7caf4a3de0ef9869248b29dcc9704c34b39
   category: main
   optional: false
 - name: statsmodels
@@ -18145,43 +18962,43 @@ package:
   category: main
   optional: false
 - name: svt-av1
-  version: 4.0.0
+  version: 4.0.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.0-hecca717_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
   hash:
-    md5: 9a6117aee038999ffefe6082ff1e9a81
-    sha256: e5e036728ef71606569232cc94a0480722e14ed69da3dd1e363f3d5191d83c01
+    md5: 2a2170a3e5c9a354d09e4be718c43235
+    sha256: 4a1d2005153b9454fc21c9bad1b539df189905be49e851ec62a6212c2e045381
   category: main
   optional: false
 - name: svt-av1
-  version: 4.0.0
+  version: 4.0.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-4.0.0-h991f03e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-4.0.1-h991f03e_0.conda
   hash:
-    md5: 6eeab25fb6115b10f4ae4275dc7e0d57
-    sha256: b5cc8bf6f0a1f53a7f0a0bbd2e157d86f2086a7b69afa3d471a216e5ad67de55
+    md5: 111339b9431e9de1e37ffa8e53040609
+    sha256: 5f8c150f558437364bfe6dade1a81cf1b3fe8ba291d8d8db01f889c32a310f08
   category: main
   optional: false
 - name: svt-av1
-  version: 4.0.0
+  version: 4.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.0-h0cb729a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
   hash:
-    md5: 3dc1d4f4c9829c82c7f6660878abcd32
-    sha256: f7fc5a18f4a6cf61fa4b6697c6aa28426b07a3df2b53a96b25dda28641991532
+    md5: 8badc3bf16b62272aa2458f138223821
+    sha256: bdef3c1c4d2a396ad4f7dc64c5e9a02d4c5a21ff93ed07a33e49574de5d2d18d
   category: main
   optional: false
 - name: tblib
@@ -18293,45 +19110,45 @@ package:
   category: main
   optional: false
 - name: tifffile
-  version: 2026.1.28
+  version: 2026.5.2
   manager: conda
   platform: linux-64
   dependencies:
-    imagecodecs: '>=2025.11.11'
-    numpy: '>=1.19.2'
-    python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.1.28-pyhd8ed1ab_0.conda
+    imagecodecs: '>=2026.3.6'
+    numpy: '>=2.1'
+    python: '>=3.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: e8d6529858171ac4babb28c334306c0d
-    sha256: efd8a9d2b57678e5efb41cc261dace3341ddd877ac514bfccab579f437efd826
+    md5: acb237de455d7fbac79afc8a33eb43c0
+    sha256: 9d5ed48bf06378703699e3282fddbaeb5045fd172e4722131660f1eb1efa2aed
   category: main
   optional: false
 - name: tifffile
-  version: 2026.1.28
+  version: 2026.5.2
   manager: conda
   platform: osx-64
   dependencies:
-    imagecodecs: '>=2025.11.11'
-    numpy: '>=1.19.2'
-    python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.1.28-pyhd8ed1ab_0.conda
+    imagecodecs: '>=2026.3.6'
+    numpy: '>=2.1'
+    python: '>=3.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: e8d6529858171ac4babb28c334306c0d
-    sha256: efd8a9d2b57678e5efb41cc261dace3341ddd877ac514bfccab579f437efd826
+    md5: acb237de455d7fbac79afc8a33eb43c0
+    sha256: 9d5ed48bf06378703699e3282fddbaeb5045fd172e4722131660f1eb1efa2aed
   category: main
   optional: false
 - name: tifffile
-  version: 2026.1.28
+  version: 2026.5.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    imagecodecs: '>=2025.11.11'
-    numpy: '>=1.19.2'
-    python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.1.28-pyhd8ed1ab_0.conda
+    imagecodecs: '>=2026.3.6'
+    numpy: '>=2.1'
+    python: '>=3.12'
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.5.2-pyhd8ed1ab_0.conda
   hash:
-    md5: e8d6529858171ac4babb28c334306c0d
-    sha256: efd8a9d2b57678e5efb41cc261dace3341ddd877ac514bfccab579f437efd826
+    md5: acb237de455d7fbac79afc8a33eb43c0
+    sha256: 9d5ed48bf06378703699e3282fddbaeb5045fd172e4722131660f1eb1efa2aed
   category: main
   optional: false
 - name: tk
@@ -18374,40 +19191,76 @@ package:
     sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
   category: main
   optional: false
-- name: tomli
-  version: 2.4.0
+- name: toml
+  version: 0.10.2
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
   hash:
-    md5: 72e780e9aa2d0a3295f59b1874e3768b
-    sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
+    md5: d0fc809fa4c4d85e959ce4ab6e1de800
+    sha256: fd30e43699cb22ab32ff3134d3acf12d6010b5bbaa63293c37076b50009b91f8
   category: main
   optional: false
-- name: tomli
-  version: 2.4.0
+- name: toml
+  version: 0.10.2
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
   hash:
-    md5: 72e780e9aa2d0a3295f59b1874e3768b
-    sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
+    md5: d0fc809fa4c4d85e959ce4ab6e1de800
+    sha256: fd30e43699cb22ab32ff3134d3acf12d6010b5bbaa63293c37076b50009b91f8
   category: main
   optional: false
-- name: tomli
-  version: 2.4.0
+- name: toml
+  version: 0.10.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
   hash:
-    md5: 72e780e9aa2d0a3295f59b1874e3768b
-    sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
+    md5: d0fc809fa4c4d85e959ce4ab6e1de800
+    sha256: fd30e43699cb22ab32ff3134d3acf12d6010b5bbaa63293c37076b50009b91f8
+  category: main
+  optional: false
+- name: tomli
+  version: 2.4.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  hash:
+    md5: b5325cf06a000c5b14970462ff5e4d58
+    sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  category: main
+  optional: false
+- name: tomli
+  version: 2.4.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  hash:
+    md5: b5325cf06a000c5b14970462ff5e4d58
+    sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  category: main
+  optional: false
+- name: tomli
+  version: 2.4.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  hash:
+    md5: b5325cf06a000c5b14970462ff5e4d58
+    sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
   category: main
   optional: false
 - name: toolz
@@ -18447,7 +19300,7 @@ package:
   category: main
   optional: false
 - name: tornado
-  version: 6.5.3
+  version: 6.5.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -18455,77 +19308,77 @@ package:
     libgcc: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py313h07c4f96_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
   hash:
-    md5: 82da2dcf1ea3e298f2557b50459809e0
-    sha256: 6006d4e5a6ff99be052c939e43adee844a38f2dc148f44a7c11aa0011fd3d811
+    md5: 6c0b0ae017b5bfd9c8d718217efd8f14
+    sha256: 9e8497e1ecca77d03c6be2d3b5f901dfe0ab99686af4fb94ab418b7d449ac547
   category: main
   optional: false
 - name: tornado
-  version: 6.5.4
+  version: 6.5.5
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.4-py313h16c19ce_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.5-py313hf59fe81_0.conda
   hash:
-    md5: d8976bd40232eea804fa55c429774c0d
-    sha256: 94d25f6ad0a21dd788f4e1dddec24696edb36e651939a4c241444ee1340ac006
+    md5: 0e435c1a2ef13ac7b12d7cffe408d7af
+    sha256: 56aa23963d1b239505503292be6b7626a94bb37264cbeeada85c224615c23c0a
   category: main
   optional: false
 - name: tornado
-  version: 6.5.4
+  version: 6.5.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py313h6535dbc_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
   hash:
-    md5: 67a85c1b5c17124eaf9194206afd5159
-    sha256: a8130a361b7bc21190836ba8889276cc263fcb09f52bf22efcaed1de98179948
+    md5: 303333dd882dfeb303cc8bfac178464b
+    sha256: c5b0ee042d8a0b88a3823226dc95b794c042c498aee330aa9b4d78bfad01d099
   category: main
   optional: false
 - name: tqdm
-  version: 4.67.1
+  version: 4.67.3
   manager: conda
   platform: linux-64
   dependencies:
-    colorama: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+    __unix: ''
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
   hash:
-    md5: 9efbfdc37242619130ea42b1cc4ed861
-    sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
+    md5: e5ce43272193b38c2e9037446c1d9206
+    sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
   category: main
   optional: false
 - name: tqdm
-  version: 4.67.1
+  version: 4.67.3
   manager: conda
   platform: osx-64
   dependencies:
-    colorama: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+    __unix: ''
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
   hash:
-    md5: 9efbfdc37242619130ea42b1cc4ed861
-    sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
+    md5: e5ce43272193b38c2e9037446c1d9206
+    sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
   category: main
   optional: false
 - name: tqdm
-  version: 4.67.1
+  version: 4.67.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    colorama: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.1-pyhd8ed1ab_1.conda
+    __unix: ''
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
   hash:
-    md5: 9efbfdc37242619130ea42b1cc4ed861
-    sha256: 11e2c85468ae9902d24a27137b6b39b4a78099806e551d390e394a8c34b48e40
+    md5: e5ce43272193b38c2e9037446c1d9206
+    sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
   category: main
   optional: false
 - name: traitlets
@@ -18605,12 +19458,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10'
+    python: ''
     typing_extensions: '>=4.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
-    md5: a0a4a3035667fc34f29bfbd5c190baa6
-    sha256: 70db27de58a97aeb7ba7448366c9853f91b21137492e0b4430251a1870aa8ff4
+    md5: 53f5409c5cfd6c5a66417d68e3f0a864
+    sha256: 8b90d2f19f9458b8c58a55e1fcdc1d90c1603a847a47654d8a454549413ba60a
   category: main
   optional: false
 - name: typing-inspection
@@ -18620,10 +19473,10 @@ package:
   dependencies:
     python: '>=3.10'
     typing_extensions: '>=4.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
-    md5: a0a4a3035667fc34f29bfbd5c190baa6
-    sha256: 70db27de58a97aeb7ba7448366c9853f91b21137492e0b4430251a1870aa8ff4
+    md5: 53f5409c5cfd6c5a66417d68e3f0a864
+    sha256: 8b90d2f19f9458b8c58a55e1fcdc1d90c1603a847a47654d8a454549413ba60a
   category: main
   optional: false
 - name: typing-inspection
@@ -18633,10 +19486,10 @@ package:
   dependencies:
     python: '>=3.10'
     typing_extensions: '>=4.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   hash:
-    md5: a0a4a3035667fc34f29bfbd5c190baa6
-    sha256: 70db27de58a97aeb7ba7448366c9853f91b21137492e0b4430251a1870aa8ff4
+    md5: 53f5409c5cfd6c5a66417d68e3f0a864
+    sha256: 8b90d2f19f9458b8c58a55e1fcdc1d90c1603a847a47654d8a454549413ba60a
   category: main
   optional: false
 - name: typing_extensions
@@ -18749,7 +19602,7 @@ package:
   category: main
   optional: false
 - name: ujson
-  version: 5.11.0
+  version: 5.12.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -18758,29 +19611,29 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ujson-5.11.0-py313h5d5ffb9_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ujson-5.12.0-py313h5d5ffb9_0.conda
   hash:
-    md5: 3d6453bc28f78bfa0841b18dec45353e
-    sha256: 0ba07c2f26a9c328d437adc38c510827141be0910dc10f6cd7e769774f8af86f
+    md5: 679f3086725a8b3474a26edac6e34327
+    sha256: b70cbfecc1d9485d7da055762b06b021fe667bb6ffedd6344186063251cd4ccc
   category: main
   optional: false
 - name: ujson
-  version: 5.11.0
+  version: 5.12.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     libcxx: '>=19'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/ujson-5.11.0-py313h03db916_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ujson-5.12.0-py313h5fe49f0_0.conda
   hash:
-    md5: 9e01b71fd0f9308e5a079076659528c6
-    sha256: d228a276f8907b3e069b242f90a1e0d660fd003331a3516b1e46927afae939c8
+    md5: b02a60495480dcf035ee37d368cd67d1
+    sha256: 4030dd8312de4c46269d73d2d73ca0cbbd1f17d8774d0453d5a1e7a0831c7c69
   category: main
   optional: false
 - name: ujson
-  version: 5.11.0
+  version: 5.12.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -18788,10 +19641,10 @@ package:
     libcxx: '>=19'
     python: 3.13.*
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ujson-5.11.0-py313hab38a8b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ujson-5.12.0-py313h1188861_0.conda
   hash:
-    md5: 20402be2af0775ceca6f9178cf9c3428
-    sha256: a3a81b9150aa500246dc1022b0c62b6fd0c15575b0c594dab55cfc9b198ce67a
+    md5: 6dddc59ece85e54bc5d6b9c59b32516f
+    sha256: f607c85abf2f5ebde9928824b92e27315e619f9be4f2790f5062edb89c846dea
   category: main
   optional: false
 - name: uriparser
@@ -18834,45 +19687,45 @@ package:
   category: main
   optional: false
 - name: url-normalize
-  version: 2.2.1
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
     idna: ''
-    python: '>=3.9'
+    python: '>=3.10'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/url-normalize-2.2.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/url-normalize-3.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5db19244300bf33e9471a0b13f9b94cb
-    sha256: cca5bed1abaf9b20f444dd5e140ed3c1ad9e27e6f4085499648c6545581a9d2a
+    md5: 49b01263c5348a30838ba148a30126cf
+    sha256: b479c71846946cf17225a2a85a0ca8a621b9deda2f88dd16838dc90a4b6d96ee
   category: main
   optional: false
 - name: url-normalize
-  version: 2.2.1
+  version: 3.0.0
   manager: conda
   platform: osx-64
   dependencies:
     idna: ''
-    python: '>=3.9'
+    python: '>=3.10'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/url-normalize-2.2.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/url-normalize-3.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5db19244300bf33e9471a0b13f9b94cb
-    sha256: cca5bed1abaf9b20f444dd5e140ed3c1ad9e27e6f4085499648c6545581a9d2a
+    md5: 49b01263c5348a30838ba148a30126cf
+    sha256: b479c71846946cf17225a2a85a0ca8a621b9deda2f88dd16838dc90a4b6d96ee
   category: main
   optional: false
 - name: url-normalize
-  version: 2.2.1
+  version: 3.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     idna: ''
-    python: '>=3.9'
+    python: '>=3.10'
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/url-normalize-2.2.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/url-normalize-3.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5db19244300bf33e9471a0b13f9b94cb
-    sha256: cca5bed1abaf9b20f444dd5e140ed3c1ad9e27e6f4085499648c6545581a9d2a
+    md5: 49b01263c5348a30838ba148a30126cf
+    sha256: b479c71846946cf17225a2a85a0ca8a621b9deda2f88dd16838dc90a4b6d96ee
   category: main
   optional: false
 - name: urllib3
@@ -18921,58 +19774,142 @@ package:
   hash:
     md5: 9272daa869e03efe68833e3dc7a02130
     sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
+  category: main
+  optional: false
+- name: uvicorn
+  version: 0.46.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    click: '>=7.0'
+    h11: '>=0.8'
+    python: ''
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.46.0-pyhc90fa1f_0.conda
+  hash:
+    md5: 12fa73aae56b7ce068db549fd542fb32
+    sha256: ba0060f57192ccef46ad722537a50a2b23d4e9c6793e714177ae1b3f73673dcb
+  category: main
+  optional: false
+- name: uvicorn
+  version: 0.46.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    click: '>=7.0'
+    h11: '>=0.8'
+    python: '>=3.10'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.46.0-pyhc90fa1f_0.conda
+  hash:
+    md5: 12fa73aae56b7ce068db549fd542fb32
+    sha256: ba0060f57192ccef46ad722537a50a2b23d4e9c6793e714177ae1b3f73673dcb
+  category: main
+  optional: false
+- name: uvicorn
+  version: 0.46.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+    click: '>=7.0'
+    h11: '>=0.8'
+    python: '>=3.10'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.46.0-pyhc90fa1f_0.conda
+  hash:
+    md5: 12fa73aae56b7ce068db549fd542fb32
+    sha256: ba0060f57192ccef46ad722537a50a2b23d4e9c6793e714177ae1b3f73673dcb
+  category: main
+  optional: false
+- name: varint
+  version: 1.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/varint-1.0.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: d2869388bcb6016cd84ffa032cd17352
+    sha256: d17d6a7bad0d22f68c5d65fb933528531bc9d0d5d8bff18e83ee9ab2180e6bd1
+  category: main
+  optional: false
+- name: varint
+  version: 1.0.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/varint-1.0.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: d2869388bcb6016cd84ffa032cd17352
+    sha256: d17d6a7bad0d22f68c5d65fb933528531bc9d0d5d8bff18e83ee9ab2180e6bd1
+  category: main
+  optional: false
+- name: varint
+  version: 1.0.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/varint-1.0.2-pyhd8ed1ab_1.conda
+  hash:
+    md5: d2869388bcb6016cd84ffa032cd17352
+    sha256: d17d6a7bad0d22f68c5d65fb933528531bc9d0d5d8bff18e83ee9ab2180e6bd1
   category: main
   optional: false
 - name: wayland
-  version: 1.24.0
+  version: 1.25.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libexpat: '>=2.7.1,<3.0a0'
+    libexpat: '>=2.7.4,<3.0a0'
     libffi: '>=3.5.2,<3.6.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
   hash:
-    md5: 035da2e4f5770f036ff704fa17aace24
-    sha256: 3aa04ae8e9521d9b56b562376d944c3e52b69f9d2a0667f77b8953464822e125
+    md5: 996583ea9c796e5b915f7d7580b51ea6
+    sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
   category: main
   optional: false
 - name: wcwidth
-  version: 0.5.2
+  version: 0.7.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 76f0a1179bd0324c03a5d7032b7b73b9
-    sha256: 8cd3605c84960bbd7626f80fdd19c46d44564cfdf87c12e5c3d71f2ea01adfbb
+    md5: eb9538b8e55069434a18547f43b96059
+    sha256: 1ee2d8384972ecbf8630ce8a3ea9d16858358ad3e8566675295e66996d5352da
   category: main
   optional: false
 - name: wcwidth
-  version: 0.5.2
+  version: 0.7.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 76f0a1179bd0324c03a5d7032b7b73b9
-    sha256: 8cd3605c84960bbd7626f80fdd19c46d44564cfdf87c12e5c3d71f2ea01adfbb
+    md5: eb9538b8e55069434a18547f43b96059
+    sha256: 1ee2d8384972ecbf8630ce8a3ea9d16858358ad3e8566675295e66996d5352da
   category: main
   optional: false
 - name: wcwidth
-  version: 0.5.2
+  version: 0.7.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 76f0a1179bd0324c03a5d7032b7b73b9
-    sha256: 8cd3605c84960bbd7626f80fdd19c46d44564cfdf87c12e5c3d71f2ea01adfbb
+    md5: eb9538b8e55069434a18547f43b96059
+    sha256: 1ee2d8384972ecbf8630ce8a3ea9d16858358ad3e8566675295e66996d5352da
   category: main
   optional: false
 - name: webob
@@ -19015,7 +19952,7 @@ package:
   category: main
   optional: false
 - name: wrapt
-  version: 2.0.1
+  version: 2.1.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -19023,128 +19960,128 @@ package:
     libgcc: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.0.1-py313h07c4f96_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.2-py313h07c4f96_0.conda
   hash:
-    md5: c477ba2608513757b68ed0e1acf79086
-    sha256: 5c9073ba9d4015bb5b88984db6e065990953541e3303c80ed447dc6c6433a2a5
+    md5: 4adff3c0154b23cbaad7917cd929c41e
+    sha256: f3c3647092eb58ee2a2fa000c32d7650ff5154d89c6810b69fb6dcda5238e221
   category: main
   optional: false
 - name: wrapt
-  version: 2.0.1
+  version: 2.1.2
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.0.1-py313hf050af9_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.1.2-py313hf59fe81_0.conda
   hash:
-    md5: 9990fddf9ed0ccc25b7cc7c46ade0e82
-    sha256: 3b9e3310303282eb8f81dc6162b8b2137567c704f79e22a2dfbd50ed90f14d5d
+    md5: 7f40a21e6319c0b68e6bada3864caea6
+    sha256: a57f98b175c17cd5e1795129a7358bd688c2762b5d4a6c5809145bcd29d48435
   category: main
   optional: false
 - name: wrapt
-  version: 2.0.1
+  version: 2.1.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.0.1-py313h6535dbc_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.1.2-py313h0997733_0.conda
   hash:
-    md5: a5e07b02c7771658520dde4c1efc9d69
-    sha256: caa3ac613e1ac06178c7995aef7cbc24a0f5b87100eb5727dc13d66b7b7c0f8e
+    md5: 5dc4bd4bdb7fe2b2714db43f82a48689
+    sha256: 783ea9fdbc29e3658261ed3f3695948db5fe0cebbb42bc541dc7e77c8e7b6968
   category: main
   optional: false
 - name: xarray
-  version: 2026.1.0
+  version: 2026.4.0
   manager: conda
   platform: linux-64
   dependencies:
     numpy: '>=1.26'
-    packaging: '>=24.1'
+    packaging: '>=24.2'
     pandas: '>=2.2'
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.1.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
   hash:
-    md5: 397276eff153e81b0e7128acc56deb32
-    sha256: 878d190db1a78f1e3fe90497e053a0dc0941937e82378cc990f43115ffe2bee6
+    md5: 099794df685f800c3f319ff4742dc1bb
+    sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
   category: main
   optional: false
 - name: xarray
-  version: 2026.1.0
+  version: 2026.4.0
   manager: conda
   platform: osx-64
   dependencies:
     numpy: '>=1.26'
-    packaging: '>=24.1'
+    packaging: '>=24.2'
     pandas: '>=2.2'
     python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.1.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
   hash:
-    md5: 397276eff153e81b0e7128acc56deb32
-    sha256: 878d190db1a78f1e3fe90497e053a0dc0941937e82378cc990f43115ffe2bee6
+    md5: 099794df685f800c3f319ff4742dc1bb
+    sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
   category: main
   optional: false
 - name: xarray
-  version: 2026.1.0
+  version: 2026.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     numpy: '>=1.26'
-    packaging: '>=24.1'
+    packaging: '>=24.2'
     pandas: '>=2.2'
     python: '>=3.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.1.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
   hash:
-    md5: 397276eff153e81b0e7128acc56deb32
-    sha256: 878d190db1a78f1e3fe90497e053a0dc0941937e82378cc990f43115ffe2bee6
+    md5: 099794df685f800c3f319ff4742dc1bb
+    sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
   category: main
   optional: false
 - name: xarray-einstats
-  version: 0.9.1
+  version: 0.10.0
   manager: conda
   platform: linux-64
   dependencies:
-    numpy: '>=1.25'
-    python: '>=3.11'
-    scipy: '>=1.11'
-    xarray: '>=2023.06.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.9.1-pyhd8ed1ab_0.conda
+    numpy: '>=2.0'
+    python: '>=3.12'
+    scipy: '>=1.13'
+    xarray: '>=2024.02.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 18860b32ac96f7e9d8be1c91eb601462
-    sha256: 3fefcdb5520c9f7127d67904894cccdc917449a3376f1ccf84127f02ad3aa61b
+    md5: b82273c95432c78efe98f14cbc46be7d
+    sha256: 02943091700f860bc3fc117deabe5fd609ed7bae64fd97da2f70241167c2719d
   category: main
   optional: false
 - name: xarray-einstats
-  version: 0.9.1
+  version: 0.10.0
   manager: conda
   platform: osx-64
   dependencies:
-    numpy: '>=1.25'
-    python: '>=3.11'
-    scipy: '>=1.11'
-    xarray: '>=2023.06.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.9.1-pyhd8ed1ab_0.conda
+    numpy: '>=2.0'
+    python: '>=3.12'
+    scipy: '>=1.13'
+    xarray: '>=2024.02.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 18860b32ac96f7e9d8be1c91eb601462
-    sha256: 3fefcdb5520c9f7127d67904894cccdc917449a3376f1ccf84127f02ad3aa61b
+    md5: b82273c95432c78efe98f14cbc46be7d
+    sha256: 02943091700f860bc3fc117deabe5fd609ed7bae64fd97da2f70241167c2719d
   category: main
   optional: false
 - name: xarray-einstats
-  version: 0.9.1
+  version: 0.10.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    numpy: '>=1.25'
-    python: '>=3.11'
-    scipy: '>=1.11'
-    xarray: '>=2023.06.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.9.1-pyhd8ed1ab_0.conda
+    numpy: '>=2.0'
+    python: '>=3.12'
+    scipy: '>=1.13'
+    xarray: '>=2024.02.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-einstats-0.10.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 18860b32ac96f7e9d8be1c91eb601462
-    sha256: 3fefcdb5520c9f7127d67904894cccdc917449a3376f1ccf84127f02ad3aa61b
+    md5: b82273c95432c78efe98f14cbc46be7d
+    sha256: 02943091700f860bc3fc117deabe5fd609ed7bae64fd97da2f70241167c2719d
   category: main
   optional: false
 - name: xerces-c
@@ -19249,56 +20186,56 @@ package:
   category: main
   optional: false
 - name: xgboost
-  version: 3.1.3
+  version: 3.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    py-xgboost: 3.1.3
+    py-xgboost: 3.2.0
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/xgboost-3.1.3-cpu_pyhb39878e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xgboost-3.2.0-cpu_pyhb39878e_1.conda
   hash:
-    md5: c5052a949e6e5a700e24d9ff2ef0b68b
-    sha256: 81c1814363a237c1427591be5cdb743c6e92c993bb9049e70af33ffa9aaa5bb9
+    md5: 9ef34557350de785c207257317fb6194
+    sha256: ab8806a7345febccec3586152089af47a5b942054cd61a01eea006a8e9a57c94
   category: main
   optional: false
 - name: xgboost
-  version: 3.1.3
+  version: 3.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    py-xgboost: 3.1.3
+    py-xgboost: 3.2.0
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/xgboost-3.1.3-cpu_pyhb39878e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xgboost-3.2.0-cpu_pyhb39878e_1.conda
   hash:
-    md5: c5052a949e6e5a700e24d9ff2ef0b68b
-    sha256: 81c1814363a237c1427591be5cdb743c6e92c993bb9049e70af33ffa9aaa5bb9
+    md5: 9ef34557350de785c207257317fb6194
+    sha256: ab8806a7345febccec3586152089af47a5b942054cd61a01eea006a8e9a57c94
   category: main
   optional: false
 - name: xgboost
-  version: 3.1.3
+  version: 3.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    py-xgboost: 3.1.3
+    py-xgboost: 3.2.0
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/xgboost-3.1.3-cpu_pyhb39878e_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xgboost-3.2.0-cpu_pyhb39878e_1.conda
   hash:
-    md5: c5052a949e6e5a700e24d9ff2ef0b68b
-    sha256: 81c1814363a237c1427591be5cdb743c6e92c993bb9049e70af33ffa9aaa5bb9
+    md5: 9ef34557350de785c207257317fb6194
+    sha256: ab8806a7345febccec3586152089af47a5b942054cd61a01eea006a8e9a57c94
   category: main
   optional: false
 - name: xkeyboard-config
-  version: '2.46'
+  version: '2.47'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    xorg-libx11: '>=1.8.12,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
+    xorg-libx11: '>=1.8.13,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
   hash:
-    md5: 71ae752a748962161b4740eaff510258
-    sha256: aa03b49f402959751ccc6e21932d69db96a65a67343765672f7862332aa32834
+    md5: b56e0c8432b56decafae7e78c5f29ba5
+    sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
   category: main
   optional: false
 - name: xlsxwriter
@@ -19366,17 +20303,17 @@ package:
   category: main
   optional: false
 - name: xorg-libx11
-  version: 1.8.12
+  version: 1.8.13
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
+    libgcc: '>=14'
     libxcb: '>=1.17.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
   hash:
-    md5: db038ce880f100acc74dba10302b5630
-    sha256: 51909270b1a6c5474ed3978628b341b4d4472cd22610e5f22b506855a5e20f67
+    md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+    sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
   category: main
   optional: false
 - name: xorg-libxau
@@ -19417,18 +20354,18 @@ package:
   category: main
   optional: false
 - name: xorg-libxcomposite
-  version: 0.4.6
+  version: 0.4.7
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    xorg-libx11: '>=1.8.10,<2.0a0'
-    xorg-libxfixes: '>=6.0.1,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
+    libgcc: '>=14'
+    xorg-libx11: '>=1.8.12,<2.0a0'
+    xorg-libxfixes: '>=6.0.2,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
   hash:
-    md5: d3c295b50f092ab525ffe3c2aa4b7413
-    sha256: 753f73e990c33366a91fd42cc17a3d19bb9444b9ca5ff983605fa9e953baf57f
+    md5: f2ba4192d38b6cef2bb2c25029071d90
+    sha256: 048c103000af9541c919deef03ae7c5e9c570ffb4024b42ecb58dbde402e373a
   category: main
   optional: false
 - name: xorg-libxcursor
@@ -19696,39 +20633,39 @@ package:
   category: main
   optional: false
 - name: xyzservices
-  version: 2025.11.0
+  version: 2026.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.11.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 16933322051fa260285f1a44aae91dd6
-    sha256: b194a1fbc38f29c563b102ece9d006f7a165bf9074cdfe50563d3bce8cae9f84
+    md5: 4487b9c371d0161d54b5c7bbd890c0fc
+    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
   category: main
   optional: false
 - name: xyzservices
-  version: 2025.11.0
+  version: 2026.3.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.11.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 16933322051fa260285f1a44aae91dd6
-    sha256: b194a1fbc38f29c563b102ece9d006f7a165bf9074cdfe50563d3bce8cae9f84
+    md5: 4487b9c371d0161d54b5c7bbd890c0fc
+    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
   category: main
   optional: false
 - name: xyzservices
-  version: 2025.11.0
+  version: 2026.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.11.0-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 16933322051fa260285f1a44aae91dd6
-    sha256: b194a1fbc38f29c563b102ece9d006f7a165bf9074cdfe50563d3bce8cae9f84
+    md5: 4487b9c371d0161d54b5c7bbd890c0fc
+    sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
   category: main
   optional: false
 - name: yamale
@@ -19808,7 +20745,7 @@ package:
   category: main
   optional: false
 - name: yarl
-  version: 1.22.0
+  version: 1.23.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -19819,31 +20756,31 @@ package:
     propcache: '>=0.2.1'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.22.0-py313h3dea7bd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.23.0-py313h3dea7bd_0.conda
   hash:
-    md5: e9415b0f7b43d2e32a3f24fd889c9e70
-    sha256: 8ce0586516e494f1ea231bdb8dda1d3aac759f34dd49419f11d1db6480b38f9e
+    md5: 0ae42a10e5bf966668ce85d8e0d56357
+    sha256: dface92b02f9d21574ed803a82d311b9def6bf24ca2d9f4894ad661d0f3fd11b
   category: main
   optional: false
 - name: yarl
-  version: 1.22.0
+  version: 1.23.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
+    __osx: '>=11.0'
     idna: '>=2.0'
     multidict: '>=4.0'
     propcache: '>=0.2.1'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.22.0-py313h0f4d31d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.23.0-py313h035b7d0_0.conda
   hash:
-    md5: 06dd2b86a96a57edc0f592f909b268ae
-    sha256: f7f635d59f5cfa53a64032c29f10c9f637467c6e02b4b0407301de469c77b06b
+    md5: 89e89e8253cb448d833a766ab5a05099
+    sha256: 5aab7ac9f93b8b5ca87fc4bbd00e3596ded9f87991ae0ddf205ca9753008754e
   category: main
   optional: false
 - name: yarl
-  version: 1.22.0
+  version: 1.23.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -19853,64 +20790,64 @@ package:
     propcache: '>=0.2.1'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.22.0-py313h7d74516_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.23.0-py313h65a2061_0.conda
   hash:
-    md5: e49ee2a431e4f895b52a2c385b61aed5
-    sha256: 34d3912ba9068a6e20dbec361ff308ad27634ca003294dd573d879f7670fcb38
+    md5: 1dbe09f9442343be4c108103e274740b
+    sha256: 3c429f435254c7ea3ab1f9d0cea4f9b260f2e480f3b882d6e6be9f109ab09200
   category: main
   optional: false
 - name: zarr
-  version: 3.1.5
+  version: 3.2.0
   manager: conda
   platform: linux-64
   dependencies:
     donfig: '>=0.8'
     google-crc32c: '>=1.5'
     numcodecs: '>=0.14'
-    numpy: '>=1.26'
+    numpy: '>=2'
     packaging: '>=22.0'
     python: ''
-    typing_extensions: '>=4.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.5-pyhcf101f3_0.conda
+    typing_extensions: '>=4.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.2.0-pyhc364b38_0.conda
   hash:
-    md5: c1844a94b2be61bb03bbb71574a0abfc
-    sha256: c36bec7d02d2f227409fcc4cf586cf3a658af068b58374de7f8f2d0b5c1c84f9
+    md5: 824dfe766449380ca5a3f18f122610bb
+    sha256: 876c7c1a64d52e20609daada6b6b30502f6cd303a2ef59775424e37786b1ae8d
   category: main
   optional: false
 - name: zarr
-  version: 3.1.5
+  version: 3.2.0
   manager: conda
   platform: osx-64
   dependencies:
     donfig: '>=0.8'
     google-crc32c: '>=1.5'
     numcodecs: '>=0.14'
-    numpy: '>=1.26'
+    numpy: '>=2'
     packaging: '>=22.0'
-    python: '>=3.11'
-    typing_extensions: '>=4.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.5-pyhcf101f3_0.conda
+    python: '>=3.12'
+    typing_extensions: '>=4.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.2.0-pyhc364b38_0.conda
   hash:
-    md5: c1844a94b2be61bb03bbb71574a0abfc
-    sha256: c36bec7d02d2f227409fcc4cf586cf3a658af068b58374de7f8f2d0b5c1c84f9
+    md5: 824dfe766449380ca5a3f18f122610bb
+    sha256: 876c7c1a64d52e20609daada6b6b30502f6cd303a2ef59775424e37786b1ae8d
   category: main
   optional: false
 - name: zarr
-  version: 3.1.5
+  version: 3.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     donfig: '>=0.8'
     google-crc32c: '>=1.5'
     numcodecs: '>=0.14'
-    numpy: '>=1.26'
+    numpy: '>=2'
     packaging: '>=22.0'
-    python: '>=3.11'
-    typing_extensions: '>=4.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.1.5-pyhcf101f3_0.conda
+    python: '>=3.12'
+    typing_extensions: '>=4.13'
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.2.0-pyhc364b38_0.conda
   hash:
-    md5: c1844a94b2be61bb03bbb71574a0abfc
-    sha256: c36bec7d02d2f227409fcc4cf586cf3a658af068b58374de7f8f2d0b5c1c84f9
+    md5: 824dfe766449380ca5a3f18f122610bb
+    sha256: 876c7c1a64d52e20609daada6b6b30502f6cd303a2ef59775424e37786b1ae8d
   category: main
   optional: false
 - name: zfp
@@ -19993,119 +20930,118 @@ package:
   category: main
   optional: false
 - name: zipp
-  version: 3.23.0
+  version: 3.23.1
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
   hash:
-    md5: 30cd29cb87d819caead4d55184c1d115
-    sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
+    md5: e1c36c6121a7c9c76f2f148f1e83b983
+    sha256: 523616c0530d305d2216c2b4a8dfd3872628b60083255b89c5e0d8c42e738cca
   category: main
   optional: false
 - name: zipp
-  version: 3.23.0
+  version: 3.23.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
   hash:
-    md5: 30cd29cb87d819caead4d55184c1d115
-    sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
+    md5: e1c36c6121a7c9c76f2f148f1e83b983
+    sha256: 523616c0530d305d2216c2b4a8dfd3872628b60083255b89c5e0d8c42e738cca
   category: main
   optional: false
 - name: zipp
-  version: 3.23.0
+  version: 3.23.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
   hash:
-    md5: 30cd29cb87d819caead4d55184c1d115
-    sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
+    md5: e1c36c6121a7c9c76f2f148f1e83b983
+    sha256: 523616c0530d305d2216c2b4a8dfd3872628b60083255b89c5e0d8c42e738cca
   category: main
   optional: false
 - name: zlib
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+    libzlib: 1.3.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
   hash:
-    md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
-    sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+    md5: c2a01a08fc991620a74b32420e97868a
+    sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
   category: main
   optional: false
 - name: zlib
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+    __osx: '>=11.0'
+    libzlib: 1.3.2
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
   hash:
-    md5: c989e0295dcbdc08106fe5d9e935f0b9
-    sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+    md5: 6276aa61ffc361cbf130d78cfb88a237
+    sha256: 5dd728cebca2e96fa48d41661f1a35ed0ee3cb722669eee4e2d854c6745655eb
   category: main
   optional: false
 - name: zlib
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+    libzlib: 1.3.2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
   hash:
-    md5: e3170d898ca6cb48f1bb567afb92f775
-    sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+    md5: f1c0bce276210bed45a04949cfe8dc20
+    sha256: 8dd2ac25f0ba714263aac5832d46985648f4bfb9b305b5021d702079badc08d2
   category: main
   optional: false
 - name: zlib-ng
-  version: 2.3.2
+  version: 2.3.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.2-hceb46e0_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
   hash:
-    md5: 40feea2979654ed579f1cda7c63ccb94
-    sha256: f2b6a175677701a0b6ce556b3bd362dc94a4e36ffcd10e3860e52ca036b4ad96
+    md5: 2aadb0d17215603a82a2a6b0afd9a4cb
+    sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
   category: main
   optional: false
 - name: zlib-ng
-  version: 2.3.2
+  version: 2.3.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.2-h8bce59a_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.3.3-h8bce59a_1.conda
   hash:
-    md5: cdd69480d52f2b871fad1a91324d9942
-    sha256: 945725769bc668435af1c23733c3c1dba01eb115ad3bad5393c9df2e23de6cfc
+    md5: b3ecb6480fd46194e3f7dd0ff4445dff
+    sha256: 4a1beb656761c7d8c9a53474bfd3932c30d82af5d93a32b8ef626c01c059d981
   category: main
   optional: false
 - name: zlib-ng
-  version: 2.3.2
+  version: 2.3.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.2-hed4e4f5_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
   hash:
-    md5: 75f39a44c08cb5dc4ea847698de34ba3
-    sha256: ab481487381a6a6213d667e883252e52b8ca867b3b466c31a058126f964efffe
+    md5: d99c2a23a31b0172e90f456f580b695e
+    sha256: a339606a6b224bb230ff3d711e801934f3b3844271df9720165e0353716580d4
   category: main
   optional: false
 - name: zstd


### PR DESCRIPTION
## Description

Update ESMValCore to v2.14.0 and ESMValTool to 2.15.0.dev15+gdead90ca8

Closes #642

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
