### PR TITLE
ci: add standalone ILAMB debug workflow

### DIFF
--- a/.github/workflows/ci-ilamb-debug.yaml
+++ b/.github/workflows/ci-ilamb-debug.yaml
@@ -1,0 +1,67 @@
+# Standalone ILAMB integration test workflow.
+#
+# Reuses the cached datasets / software populated by the main CI Integration Tests workflow,
+# so this skips the populate-cache step entirely.
+# Runs ILAMB integration tests in isolation with unbuffered pytest output and a periodic memory snapshot
+# so the last running test name reaches the log before any SIGKILL from the runner.
+#
+# Manual trigger:
+#   gh workflow run ci-ilamb-debug.yaml --ref <branch>
+name: CI ILAMB Debug
+on:
+  workflow_dispatch:
+    inputs:
+      python-version:
+        description: "Python version"
+        required: false
+        default: "3.13"
+      pytest-args:
+        description: "Extra pytest args"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  tests-slow-ilamb:
+    if: github.repository == 'Climate-REF/climate-ref'
+    runs-on: "arc-climate-ref"
+    env:
+      REF_TEST_OUTPUT: "test-outputs-ilamb"
+      PYTEST_ADDOPTS: "--slow"
+      TQDM_DISABLE: "1"
+      PYTHONUNBUFFERED: "1"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Log memory while tests run
+        run: |
+          (
+            while true; do
+              echo "[mem $(date -u +%H:%M:%S)] $(grep -E '^(MemTotal|MemAvailable|MemFree):' /proc/meminfo | tr '\n' ' ')"
+              sleep 15
+            done
+          ) &
+          echo $! > /tmp/memlogger.pid
+      - name: Run ILAMB integration tests
+        run: |
+          uv sync
+          uv run pytest packages/climate-ref-ilamb --slow --no-docker -m "not test_cases" -r a -v ${{ inputs.pytest-args }}
+      - name: Stop memory logger
+        if: always()
+        run: |
+          if [ -f /tmp/memlogger.pid ]; then kill "$(cat /tmp/memlogger.pid)" || true; fi
+      - name: Upload scratch artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: integration-output-ilamb-${{ inputs.python-version }}
+          path: ${{ env.REF_TEST_OUTPUT }}
+          retention-days: 7

--- a/changelog/654.trivial.md
+++ b/changelog/654.trivial.md
@@ -1,0 +1,1 @@
+Added a standalone `CI ILAMB Debug` workflow that runs only the ILAMB integration tests on the self-hosted runner with unbuffered pytest output and periodic memory snapshots, to help diagnose runner-killed nightly test runs.


### PR DESCRIPTION
## Description

Adds a standalone `workflow_dispatch` entry point for running just the
ILAMB integration tests on the `arc-climate-ref` self-hosted runner.

Motivation: the nightly `tests-slow` matrix in
[run 25331547535](https://github.com/Climate-REF/climate-ref/actions/runs/25331547535)
lost runner connection on both 3.11 and 3.13 with no pytest output
flushed. We currently cannot tell which test triggered the SIGKILL.

This workflow:

- runs only `packages/climate-ref-ilamb` integration tests with `--slow`
- skips `populate-cache` (the data is already populated on the shared
  runner cache by the nightly `CI Integration Tests` workflow)
- sets `PYTHONUNBUFFERED=1` so pytest progress is flushed line-by-line
- starts a background memory logger that emits a `/proc/meminfo`
  snapshot every 15s, so the last running test name and the
  `MemAvailable` reading immediately before any SIGKILL appear in the
  job log
- exposes `python-version` and `pytest-args` inputs for narrowing
  e.g. `-k emp-gleamgpcp2.3`
- uploads scratch artifacts to `integration-output-ilamb-<py>`

Trigger:

```bash
gh workflow run ci-ilamb-debug.yaml --ref ci/ilamb-debug-workflow
```

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`