### PR TITLE
feat(versioning): diagnostic versioning read-path foundations

### DIFF
--- a/changelog/665.improvement.md
+++ b/changelog/665.improvement.md
@@ -1,0 +1,5 @@
+Added diagnostic versioning read-path foundations.
+New database columns track the diagnostic version for each execution group,
+the promoted version for each diagnostic, and the provider version for each execution.
+Default queries now return only results at the promoted version,
+and the ``ref executions stats`` command reflects the same filter.

--- a/changelog/665.improvement.md
+++ b/changelog/665.improvement.md
@@ -1,5 +1,4 @@
 Added diagnostic versioning read-path foundations.
 New database columns track the diagnostic version for each execution group,
 the promoted version for each diagnostic, and the provider version for each execution.
-Default queries now return only results at the promoted version,
-and the ``ref executions stats`` command reflects the same filter.
+Default queries now return only results at the promoted version, and the ``ref executions stats`` command reflects the same filter.

--- a/packages/climate-ref-core/src/climate_ref_core/diagnostics.py
+++ b/packages/climate-ref-core/src/climate_ref_core/diagnostics.py
@@ -551,6 +551,17 @@ class Diagnostic(AbstractDiagnostic):
     See (climate_ref_example.example.ExampleDiagnostic)[] for an example implementation.
     """
 
+    version: int = 1
+    """
+    Diagnostic version.
+
+    Bump when the diagnostic's results change in a way that requires recomputation
+    (algorithm tweaks, bug fixes, data-requirement changes).
+    The value is append-only: always increment, never reuse a previous number.
+
+    Existing diagnostics inherit ``version = 1`` implicitly.
+    """
+
     series: Sequence[SeriesDefinition] = tuple()
     files: Sequence[FileDefinition] = tuple()
     test_data_spec: TestDataSpecification | None = None

--- a/packages/climate-ref-core/tests/unit/test_diagnostics.py
+++ b/packages/climate-ref-core/tests/unit/test_diagnostics.py
@@ -10,6 +10,7 @@ from climate_ref_core.datasets import FacetFilter, SourceDatasetType
 from climate_ref_core.diagnostics import (
     CommandLineDiagnostic,
     DataRequirement,
+    Diagnostic,
     ExecutionDefinition,
     ExecutionResult,
     ensure_relative_path,
@@ -126,6 +127,39 @@ class TestDiagnostic:
         mock_diagnostic.provider = None
         with pytest.raises(ValueError, match=r"register .* with a DiagnosticProvider before using"):
             mock_diagnostic.provider
+
+    def test_version_default_is_1(self):
+        """Diagnostic.version defaults to 1 when not overridden."""
+
+        class DefaultVersionDiag(Diagnostic):
+            name = "test-default-version"
+            slug = "test-default-version"
+            data_requirements = (
+                DataRequirement(source_type=SourceDatasetType.CMIP6, filters=(), group_by=None),
+            )
+
+            def run(self, definition: ExecutionDefinition) -> ExecutionResult:
+                return ExecutionResult.build_from_failure(definition)
+
+        assert DefaultVersionDiag.version == 1
+        assert DefaultVersionDiag().version == 1
+
+    def test_version_can_be_overridden(self):
+        """A subclass can set version = 2."""
+
+        class V2Diagnostic(Diagnostic):
+            name = "test-v2"
+            slug = "test-v2"
+            version = 2
+            data_requirements = (
+                DataRequirement(source_type=SourceDatasetType.CMIP6, filters=(), group_by=None),
+            )
+
+            def run(self, definition: ExecutionDefinition) -> ExecutionResult:
+                return ExecutionResult.build_from_failure(definition)
+
+        assert V2Diagnostic.version == 2
+        assert V2Diagnostic().version == 2
 
 
 class TestCommandLineDiagnostic:

--- a/packages/climate-ref/src/climate_ref/cli/executions.py
+++ b/packages/climate-ref/src/climate_ref/cli/executions.py
@@ -688,6 +688,7 @@ def stats(
             func.sum(case((ExecutionGroup.dirty.is_(True), 1), else_=0)).label("dirty"),
         )
         .join(Diagnostic, ExecutionGroup.diagnostic_id == Diagnostic.id)
+        .filter(ExecutionGroup.diagnostic_version == Diagnostic.promoted_version)
         .join(Provider, Diagnostic.provider_id == Provider.id)
         .outerjoin(latest_exec_subquery, ExecutionGroup.id == latest_exec_subquery.c.execution_group_id)
         .outerjoin(

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -368,6 +368,7 @@ def get_executions_for_reingest(
         diagnostic_filters=diagnostic_filters,
         provider_filters=provider_filters,
         successful=None if include_failed else True,
+        include_superseded=True,
     )
 
     # Filter by execution group IDs if provided

--- a/packages/climate-ref/src/climate_ref/migrations/versions/2026-05-11T0000_b1c2d3e4f5a6_add_diagnostic_version.py
+++ b/packages/climate-ref/src/climate_ref/migrations/versions/2026-05-11T0000_b1c2d3e4f5a6_add_diagnostic_version.py
@@ -1,0 +1,86 @@
+"""add diagnostic versioning columns
+
+Adds the read-path schema for diagnostic versioning:
+
+- ``execution_group.diagnostic_version`` -- the diagnostic version that produced this group.
+- ``diagnostic.promoted_version`` -- the currently-promoted version for default queries.
+- ``execution.provider_version`` -- snapshot of the provider version at run time.
+
+Also flips ``execution_group``'s unique constraint from ``(diagnostic_id, key)`` to
+``(diagnostic_id, key, diagnostic_version)`` so that v1 and v2 groups for the same
+key can coexist.
+
+Existing rows backfill to ``diagnostic_version = 1`` and ``promoted_version = 1``;
+``provider_version`` stays NULL for executions that predate the column.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a3b4c5d6e7f8
+Create Date: 2026-05-11 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "a3b4c5d6e7f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Apply diagnostic-versioning schema changes."""
+    # execution_group.diagnostic_version + swap unique constraint
+    # The column defaults to 1 so existing rows backfill cleanly,
+    # and the new unique constraint allows v1/v2 coexistence for the same key.
+    with op.batch_alter_table("execution_group", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "diagnostic_version",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("1"),
+            )
+        )
+        batch_op.drop_constraint("execution_ident", type_="unique")
+        batch_op.create_unique_constraint(
+            "execution_ident",
+            ["diagnostic_id", "key", "diagnostic_version"],
+        )
+
+    # diagnostic.promoted_version -- naive max(diagnostic_version) cache.
+    with op.batch_alter_table("diagnostic", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "promoted_version",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("1"),
+            )
+        )
+
+    # execution.provider_version -- nullable snapshot recorded by the worker at run time.
+    # Rows that predate this column stay NULL; there is no backfill source.
+    with op.batch_alter_table("execution", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("provider_version", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Revert diagnostic-versioning schema changes."""
+    with op.batch_alter_table("execution", schema=None) as batch_op:
+        batch_op.drop_column("provider_version")
+
+    with op.batch_alter_table("diagnostic", schema=None) as batch_op:
+        batch_op.drop_column("promoted_version")
+
+    with op.batch_alter_table("execution_group", schema=None) as batch_op:
+        batch_op.drop_constraint("execution_ident", type_="unique")
+        batch_op.create_unique_constraint(
+            "execution_ident",
+            ["diagnostic_id", "key"],
+        )
+        batch_op.drop_column("diagnostic_version")

--- a/packages/climate-ref/src/climate_ref/models/diagnostic.py
+++ b/packages/climate-ref/src/climate_ref/models/diagnostic.py
@@ -78,16 +78,13 @@ def recompute_promoted_version(diagnostic_id: int, session: Session) -> int:
 
     The largest ``diagnostic_version`` seen across this diagnostic's groups
     becomes the version that default queries return.
-    A v2 group with zero successful executions still becomes the promoted
-    version; success-gated promotion is not implemented.
+    A v2 group with zero successful executions still becomes the promoted version.
 
-    This helper is called explicitly from the solver after a new ``ExecutionGroup``
-    is inserted.
+    This helper is called explicitly from the solver after a new ``ExecutionGroup`` is inserted.
     It is not a SQLAlchemy event listener because event-driven recomputation is
     harder to reason about during flush and harder to test in isolation.
 
-    If the diagnostic has no execution groups yet, ``promoted_version`` is left at
-    its default of 1.
+    If the diagnostic has no execution groups yet, ``promoted_version`` is left at its default of 1.
 
     Parameters
     ----------

--- a/packages/climate-ref/src/climate_ref/models/diagnostic.py
+++ b/packages/climate-ref/src/climate_ref/models/diagnostic.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKey, UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import ForeignKey, UniqueConstraint, func, select
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from climate_ref.models.base import Base
 from climate_ref.models.mixins import CreatedUpdatedMixin
@@ -44,6 +44,16 @@ class Diagnostic(CreatedUpdatedMixin, Base):
     If a diagnostic is not enabled, it will not be used for any calculations.
     """
 
+    promoted_version: Mapped[int] = mapped_column(default=1, server_default="1")
+    """
+    Currently promoted diagnostic version for default queries.
+
+    Default query helpers filter ``ExecutionGroup.diagnostic_version == Diagnostic.promoted_version``
+    so consumers see exactly one version's worth of results.
+    Recomputed as ``max(ExecutionGroup.diagnostic_version)`` after a new group is inserted
+    (see ``recompute_promoted_version``).
+    """
+
     provider: Mapped["Provider"] = relationship(back_populates="diagnostics")
     execution_groups: Mapped[list["ExecutionGroup"]] = relationship(back_populates="diagnostic")
 
@@ -60,3 +70,50 @@ class Diagnostic(CreatedUpdatedMixin, Base):
             Full slug of the diagnostic
         """
         return f"{self.provider.slug}/{self.slug}"
+
+
+def recompute_promoted_version(diagnostic_id: int, session: Session) -> int:
+    """
+    Recompute ``Diagnostic.promoted_version`` as ``max(ExecutionGroup.diagnostic_version)``.
+
+    The largest ``diagnostic_version`` seen across this diagnostic's groups
+    becomes the version that default queries return.
+    A v2 group with zero successful executions still becomes the promoted
+    version; success-gated promotion is not implemented.
+
+    This helper is called explicitly from the solver after a new ``ExecutionGroup``
+    is inserted.
+    It is not a SQLAlchemy event listener because event-driven recomputation is
+    harder to reason about during flush and harder to test in isolation.
+
+    If the diagnostic has no execution groups yet, ``promoted_version`` is left at
+    its default of 1.
+
+    Parameters
+    ----------
+    diagnostic_id
+        Primary key of the diagnostic to recompute.
+    session
+        SQLAlchemy session.  The caller is responsible for committing.
+
+    Returns
+    -------
+    :
+        The newly-stored ``promoted_version`` value.
+    """
+    # Avoid a circular import: ExecutionGroup's module imports Diagnostic at module load.
+    from climate_ref.models.execution import ExecutionGroup  # noqa: PLC0415
+
+    max_version = session.execute(
+        select(func.max(ExecutionGroup.diagnostic_version)).where(
+            ExecutionGroup.diagnostic_id == diagnostic_id
+        )
+    ).scalar_one_or_none()
+
+    diagnostic = session.get(Diagnostic, diagnostic_id)
+    if diagnostic is None:
+        raise ValueError(f"Diagnostic with id={diagnostic_id} not found")
+
+    new_promoted = max_version if max_version is not None else 1
+    diagnostic.promoted_version = new_promoted
+    return new_promoted

--- a/packages/climate-ref/src/climate_ref/models/execution.py
+++ b/packages/climate-ref/src/climate_ref/models/execution.py
@@ -39,7 +39,7 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
     """
 
     __tablename__ = "execution_group"
-    __table_args__ = (UniqueConstraint("diagnostic_id", "key", name="execution_ident"),)
+    __table_args__ = (UniqueConstraint("diagnostic_id", "key", "diagnostic_version", name="execution_ident"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
@@ -51,6 +51,15 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
     key: Mapped[str] = mapped_column(index=True)
     """
     Key for the datasets in this Execution group.
+    """
+
+    diagnostic_version: Mapped[int] = mapped_column(default=1, server_default="1")
+    """
+    Diagnostic version that produced this group.
+
+    Read from the live ``Diagnostic.version`` class attribute at solve time.
+    Combined with ``diagnostic_id`` and ``key`` to form the unique identifier,
+    so v1 and v2 groups for the same key coexist as separate rows.
     """
 
     dirty: Mapped[bool] = mapped_column(default=False)
@@ -204,6 +213,15 @@ class Execution(CreatedUpdatedMixin, Base):
     This may happen if a dataset has been retracted, or if the diagnostic execution was incorrect.
     Rather than delete the values, they are marked as retracted.
     These data may still be visible in the UI, but should be marked as retracted.
+    """
+
+    provider_version: Mapped[str | None] = mapped_column(nullable=True)
+    """
+    Provider version recorded by the worker at run time.
+
+    Snapshot of the worker-installed ``provider.version`` when the execution ran.
+    Purely informational for audit; not used for validation or recomputation triggers.
+    Rows that predate the column stay NULL.
     """
 
     execution_group: Mapped["ExecutionGroup"] = relationship(back_populates="executions")
@@ -484,9 +502,15 @@ def get_execution_group_and_latest_filtered(  # noqa: PLR0913
     facet_filters: dict[str, list[str]] | None = None,
     dirty: bool | None = None,
     successful: bool | None = None,
+    include_superseded: bool = False,
 ) -> list[tuple[ExecutionGroup, Execution | None]]:
     """
     Query execution groups with filtering capabilities.
+
+    By default, returns only execution groups whose ``diagnostic_version`` matches
+    the parent diagnostic's ``promoted_version`` so consumers see exactly one
+    version's worth of results.
+    Pass ``include_superseded=True`` to bypass the version filter and see the full history.
 
     Parameters
     ----------
@@ -507,6 +531,13 @@ def get_execution_group_and_latest_filtered(  # noqa: PLR0913
         If True, only return execution groups whose latest execution was successful.
         If False, only return execution groups whose latest execution was unsuccessful or has no executions.
         If None, do not filter by execution success.
+    include_superseded
+        If True, include execution groups for diagnostic versions older than the
+        currently promoted version.
+        If False (default), join ``Diagnostic`` and filter to ``ExecutionGroup.diagnostic_version
+        == Diagnostic.promoted_version``.
+        Set this for recovery / audit callers that need the full version history
+        (e.g. ``executor/reingest.py``).
 
     Returns
     -------
@@ -519,13 +550,25 @@ def get_execution_group_and_latest_filtered(  # noqa: PLR0913
     - Different filter types use AND logic
     - Facet filters can either be key=value (searches all dataset types)
       or dataset_type.key=value (searches specific dataset type)
+    - This helper is the only sanctioned path for new callers that should respect
+      the promoted-version filter. The one acknowledged exception is the
+      ``cli/executions.py::stats`` aggregation, which inlines
+      ``.join(Diagnostic).filter(ExecutionGroup.diagnostic_version == Diagnostic.promoted_version)``
+      because it returns aggregate rows rather than a list of tuples and so cannot
+      reuse this helper. Operational queries that must remain version-agnostic
+      (e.g. ``mark_failed_running`` in the same module) intentionally do not use
+      this helper at all.
     """
     # Start with base query
     query = get_execution_group_and_latest(session)
 
-    if diagnostic_filters or provider_filters:
-        # Join through to the Diagnostic table
+    # Join Diagnostic when needed for filtering (by name or by promoted version).
+    needs_diagnostic_join = bool(diagnostic_filters or provider_filters) or not include_superseded
+    if needs_diagnostic_join:
         query = query.join(Diagnostic, ExecutionGroup.diagnostic_id == Diagnostic.id)
+
+    if not include_superseded:
+        query = query.filter(ExecutionGroup.diagnostic_version == Diagnostic.promoted_version)
 
     # Apply diagnostic filter (OR logic for multiple values)
     if diagnostic_filters:

--- a/packages/climate-ref/src/climate_ref/models/execution.py
+++ b/packages/climate-ref/src/climate_ref/models/execution.py
@@ -550,14 +550,13 @@ def get_execution_group_and_latest_filtered(  # noqa: PLR0913
     - Different filter types use AND logic
     - Facet filters can either be key=value (searches all dataset types)
       or dataset_type.key=value (searches specific dataset type)
-    - This helper is the only sanctioned path for new callers that should respect
-      the promoted-version filter. The one acknowledged exception is the
-      ``cli/executions.py::stats`` aggregation, which inlines
+    - This helper is the only sanctioned path for new callers that should respect the promoted-version filter.
+      The one acknowledged exception is the ``cli/executions.py::stats`` aggregation,
+      which inlines
       ``.join(Diagnostic).filter(ExecutionGroup.diagnostic_version == Diagnostic.promoted_version)``
-      because it returns aggregate rows rather than a list of tuples and so cannot
-      reuse this helper. Operational queries that must remain version-agnostic
-      (e.g. ``mark_failed_running`` in the same module) intentionally do not use
-      this helper at all.
+      because it returns aggregate rows rather than a list of tuples and so cannot reuse this helper.
+      Operational queries that must remain version-agnostic
+      (e.g. ``mark_failed_running`` in the same module) intentionally do not use this helper at all.
     """
     # Start with base query
     query = get_execution_group_and_latest(session)

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -29,6 +29,7 @@ from climate_ref.executor.fragment import PLACEHOLDER_FRAGMENT, assign_execution
 from climate_ref.models import Diagnostic as DiagnosticModel
 from climate_ref.models import ExecutionGroup
 from climate_ref.models import Provider as ProviderModel
+from climate_ref.models.diagnostic import recompute_promoted_version
 from climate_ref.models.execution import Execution
 from climate_ref.provider_registry import ProviderRegistry
 from climate_ref_core.constraints import apply_constraint
@@ -667,6 +668,7 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
             if created:
                 logger.info(f"Created new execution group: {potential_execution.execution_slug()!r}")
                 db.session.flush()
+                recompute_promoted_version(diagnostic_id, db.session)
 
             # TODO: Move this logic to the solver
             # Check if we should run given the one_per_provider or one_per_diagnostic flags

--- a/packages/climate-ref/tests/unit/test_versioning.py
+++ b/packages/climate-ref/tests/unit/test_versioning.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import importlib.resources
+import re
 
 import pytest
 from alembic import command
@@ -294,12 +295,27 @@ class TestStatsPromotedVersionFilter:
         return db_seeded
 
     def test_stats_shows_only_promoted_version_totals(self, db_stats_versions: Database, invoke_cli) -> None:
+        """stats() must count only the promoted-version group, not both versions.
+
+        Regression guard: if the promoted_version filter in stats() is removed,
+        both the v1 and v2 groups would be counted and total would be 2, not 1.
+        """
         result = invoke_cli(["executions", "stats", "--diagnostic", "enso_tel"])
         assert result.exit_code == 0
-        # Total for enso_tel should be 1 (only the v2 group), not 2.
-        # The row shows total counts; if both were included total would be >=2.
-        # We assert "1" appears in the row and the table is non-empty.
         assert "enso_tel" in result.stdout
+
+        # Find the enso_tel row and extract all integers from it.
+        # The rich table row looks like: "│ enso_tel │ 0 │ 0 │ 1 │ 0 │ 0 │ 1 │"
+        # The last integer is the `total` column. It must be 1, not 2.
+        enso_line = next((line for line in result.stdout.splitlines() if "enso_tel" in line), None)
+        assert enso_line is not None, "enso_tel row missing from stats output"
+        numbers = [int(m) for m in re.findall(r"\b(\d+)\b", enso_line)]
+        assert numbers, "No numeric values found in enso_tel stats row"
+        total = numbers[-1]
+        assert total == 1, (
+            f"stats() total for enso_tel is {total}, expected 1. "
+            "The promoted_version filter may be missing — both v1 and v2 groups are visible."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/climate-ref/tests/unit/test_versioning.py
+++ b/packages/climate-ref/tests/unit/test_versioning.py
@@ -25,10 +25,6 @@ from climate_ref.models.execution import Execution, ExecutionGroup, get_executio
 from climate_ref.provider_registry import ProviderRegistry, _register_provider
 from climate_ref.solver import ExecutionSolver, solve_required_executions
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _get_columns(engine, table_name: str) -> set[str]:
     insp = inspect(engine)
@@ -38,11 +34,6 @@ def _get_columns(engine, table_name: str) -> set[str]:
 def _get_unique_constraints(engine, table_name: str) -> list[dict]:
     insp = inspect(engine)
     return insp.get_unique_constraints(table_name)
-
-
-# ---------------------------------------------------------------------------
-# Test case 1: migration up/down + backfill
-# ---------------------------------------------------------------------------
 
 
 class TestMigrationUpDown:
@@ -122,11 +113,6 @@ class TestMigrationUpDown:
         db.close()
 
 
-# ---------------------------------------------------------------------------
-# Test case 2: helper version filtering
-# ---------------------------------------------------------------------------
-
-
 class TestHelperVersionFiltering:
     """get_execution_group_and_latest_filtered respects include_superseded."""
 
@@ -163,11 +149,6 @@ class TestHelperVersionFiltering:
         returned_versions = {eg.diagnostic_version for eg, _ in results}
         assert 1 in returned_versions
         assert 2 in returned_versions
-
-
-# ---------------------------------------------------------------------------
-# Test case 3: recompute_promoted_version helper
-# ---------------------------------------------------------------------------
 
 
 class TestRecomputePromotedVersion:
@@ -243,11 +224,6 @@ class TestRecomputePromotedVersion:
         assert fresh_diag.promoted_version == 1
 
 
-# ---------------------------------------------------------------------------
-# Test case 4: stats() aggregation filter
-# ---------------------------------------------------------------------------
-
-
 class TestStatsPromotedVersionFilter:
     """stats() CLI command only counts groups at the promoted version."""
 
@@ -318,11 +294,6 @@ class TestStatsPromotedVersionFilter:
         )
 
 
-# ---------------------------------------------------------------------------
-# Test case 5: mark_failed_running operational invariant
-# ---------------------------------------------------------------------------
-
-
 class TestMarkFailedRunningVersionAgnostic:
     """fail-running must surface in-flight executions regardless of diagnostic_version."""
 
@@ -367,16 +338,9 @@ class TestMarkFailedRunningVersionAgnostic:
         assert remaining_running == 0, "All in-flight executions must be marked failed"
 
 
-# ---------------------------------------------------------------------------
-# Test case 6: dormancy regression
-# ---------------------------------------------------------------------------
-
-
 class TestDormancyRegression:
-    """The solver must not branch on ``Diagnostic.version``.
-
-    The solver's get_or_create still uses only (diagnostic_id, key) as lookup
-    keys, so newly created groups must always have diagnostic_version=1
+    """The solver's get_or_create still uses only (diagnostic_id, key) as lookup keys
+    Newly created groups must always have diagnostic_version=1
     regardless of the Python-side Diagnostic.version class attribute.
     """
 

--- a/packages/climate-ref/tests/unit/test_versioning.py
+++ b/packages/climate-ref/tests/unit/test_versioning.py
@@ -1,0 +1,396 @@
+"""Tests for diagnostic versioning read-path foundations.
+
+Covers:
+1. Migration up/down + backfill
+2. Helper version filtering (include_superseded)
+3. recompute_promoted_version helper
+4. stats() aggregation filter (promoted_version only)
+5. mark_failed_running operational invariant (version-agnostic)
+6. Dormancy regression (solver does NOT branch on Diagnostic.version)
+"""
+
+import importlib.resources
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from climate_ref_example import provider as example_provider
+from climate_ref_pmp import provider as pmp_provider
+from sqlalchemy import inspect
+
+from climate_ref.database import Database
+from climate_ref.models.diagnostic import Diagnostic, recompute_promoted_version
+from climate_ref.models.execution import Execution, ExecutionGroup, get_execution_group_and_latest_filtered
+from climate_ref.provider_registry import ProviderRegistry, _register_provider
+from climate_ref.solver import ExecutionSolver, solve_required_executions
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_columns(engine, table_name: str) -> set[str]:
+    insp = inspect(engine)
+    return {c["name"] for c in insp.get_columns(table_name)}
+
+
+def _get_unique_constraints(engine, table_name: str) -> list[dict]:
+    insp = inspect(engine)
+    return insp.get_unique_constraints(table_name)
+
+
+# ---------------------------------------------------------------------------
+# Test case 1: migration up/down + backfill
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationUpDown:
+    """Verify the diagnostic-versioning migration applies and reverts cleanly."""
+
+    def test_new_columns_present_after_migrate(self, db: Database) -> None:
+        """After migration the three new columns exist."""
+        cols_eg = _get_columns(db._engine, "execution_group")
+        cols_diag = _get_columns(db._engine, "diagnostic")
+        cols_exec = _get_columns(db._engine, "execution")
+
+        assert "diagnostic_version" in cols_eg
+        assert "promoted_version" in cols_diag
+        assert "provider_version" in cols_exec
+
+    def test_unique_constraint_is_three_columns(self, db: Database) -> None:
+        """The unique constraint on execution_group must include diagnostic_version."""
+        constraints = _get_unique_constraints(db._engine, "execution_group")
+        named = {c["name"]: set(c["column_names"]) for c in constraints}
+        # The constraint is renamed in place; look for execution_ident or any that
+        # contains all three columns.
+        three_col = any(
+            {"diagnostic_id", "key", "diagnostic_version"} == set(c["column_names"]) for c in constraints
+        )
+        assert three_col, f"Expected 3-column unique constraint, got: {named}"
+
+    def test_existing_rows_backfilled_to_version_1(self, db_seeded: Database) -> None:
+        """All existing execution_group rows must have diagnostic_version=1."""
+        with db_seeded.session.begin():
+            eg = ExecutionGroup(key="backfill-test", diagnostic_id=1)
+            db_seeded.session.add(eg)
+        db_seeded.session.commit()
+
+        eg_reloaded = db_seeded.session.query(ExecutionGroup).filter_by(key="backfill-test").one()
+        assert eg_reloaded.diagnostic_version == 1
+
+    def test_diagnostic_promoted_version_default_1(self, db_seeded: Database) -> None:
+        """All existing diagnostic rows must have promoted_version=1."""
+        diags = db_seeded.session.query(Diagnostic).all()
+        assert diags, "db_seeded must have at least one diagnostic"
+        for d in diags:
+            assert d.promoted_version == 1, f"Diagnostic {d.slug} has promoted_version={d.promoted_version}"
+
+    def test_downgrade_removes_columns(self, config) -> None:
+        """Migration downgrade removes the three columns and restores 2-column constraint."""
+        alembic_cfg = AlembicConfig()
+        alembic_cfg.set_main_option(
+            "script_location",
+            str(importlib.resources.files("climate_ref").parent / "climate_ref" / "migrations"),
+        )
+        alembic_cfg.set_main_option("sqlalchemy.url", config.db.database_url)
+
+        # Start from the migrated state (db fixture already migrated)
+        db = Database.from_config(config, run_migrations=True)
+
+        # Downgrade to the previous revision
+        command.downgrade(alembic_cfg, "a3b4c5d6e7f8")
+
+        cols_eg = _get_columns(db._engine, "execution_group")
+        cols_diag = _get_columns(db._engine, "diagnostic")
+        cols_exec = _get_columns(db._engine, "execution")
+
+        assert "diagnostic_version" not in cols_eg
+        assert "promoted_version" not in cols_diag
+        assert "provider_version" not in cols_exec
+
+        # Two-column constraint must be back
+        two_col = any(
+            {"diagnostic_id", "key"} == set(c["column_names"])
+            and "diagnostic_version" not in c["column_names"]
+            for c in _get_unique_constraints(db._engine, "execution_group")
+        )
+        assert two_col, "Expected 2-column constraint after downgrade"
+
+        # Re-apply so the fixture teardown doesn't fail
+        command.upgrade(alembic_cfg, "head")
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test case 2: helper version filtering
+# ---------------------------------------------------------------------------
+
+
+class TestHelperVersionFiltering:
+    """get_execution_group_and_latest_filtered respects include_superseded."""
+
+    @pytest.fixture
+    def db_two_versions(self, db_seeded: Database) -> Database:
+        """Insert v1 and v2 groups for the same diagnostic; set promoted_version=2."""
+        diag = db_seeded.session.query(Diagnostic).first()
+        diag.promoted_version = 2
+
+        with db_seeded.session.begin_nested():
+            eg_v1 = ExecutionGroup(
+                key="version-filter-key",
+                diagnostic_id=diag.id,
+                diagnostic_version=1,
+            )
+            eg_v2 = ExecutionGroup(
+                key="version-filter-key",
+                diagnostic_id=diag.id,
+                diagnostic_version=2,
+            )
+            db_seeded.session.add_all([eg_v1, eg_v2])
+        db_seeded.session.commit()
+        return db_seeded
+
+    def test_default_returns_only_promoted_version(self, db_two_versions: Database) -> None:
+        results = get_execution_group_and_latest_filtered(db_two_versions.session)
+        returned_versions = {eg.diagnostic_version for eg, _ in results}
+        # Only v2 (the promoted version) should be visible
+        assert 2 in returned_versions
+        assert 1 not in returned_versions
+
+    def test_include_superseded_returns_both_versions(self, db_two_versions: Database) -> None:
+        results = get_execution_group_and_latest_filtered(db_two_versions.session, include_superseded=True)
+        returned_versions = {eg.diagnostic_version for eg, _ in results}
+        assert 1 in returned_versions
+        assert 2 in returned_versions
+
+
+# ---------------------------------------------------------------------------
+# Test case 3: recompute_promoted_version helper
+# ---------------------------------------------------------------------------
+
+
+class TestRecomputePromotedVersion:
+    """recompute_promoted_version correctly tracks max(diagnostic_version)."""
+
+    def test_single_v1_group_promotes_to_1(self, db_seeded: Database) -> None:
+        diag = db_seeded.session.query(Diagnostic).first()
+        with db_seeded.session.begin_nested():
+            eg = ExecutionGroup(
+                key="recompute-test-1",
+                diagnostic_id=diag.id,
+                diagnostic_version=1,
+            )
+            db_seeded.session.add(eg)
+        db_seeded.session.flush()
+
+        result = recompute_promoted_version(diag.id, db_seeded.session)
+        assert result == 1
+        db_seeded.session.refresh(diag)
+        assert diag.promoted_version == 1
+
+    def test_v2_group_promotes_to_2(self, db_seeded: Database) -> None:
+        # Use a fresh diagnostic with no pre-existing groups to avoid interference
+        # from the seeded data which already has v1 groups.
+        seed_diag = db_seeded.session.query(Diagnostic).first()
+        fresh_diag = Diagnostic(
+            slug="recompute-test-v2-diag",
+            name="Recompute Test V2",
+            provider_id=seed_diag.provider_id,
+        )
+        db_seeded.session.add(fresh_diag)
+        db_seeded.session.commit()
+
+        db_seeded.session.add(
+            ExecutionGroup(
+                key="recompute-test-2a",
+                diagnostic_id=fresh_diag.id,
+                diagnostic_version=1,
+            )
+        )
+        db_seeded.session.add(
+            ExecutionGroup(
+                key="recompute-test-2b",
+                diagnostic_id=fresh_diag.id,
+                diagnostic_version=2,
+            )
+        )
+        db_seeded.session.commit()
+
+        result = recompute_promoted_version(fresh_diag.id, db_seeded.session)
+        assert result == 2
+        # Flush so the DB row is updated, then reload to confirm the write landed.
+        db_seeded.session.flush()
+        db_seeded.session.refresh(fresh_diag)
+        assert fresh_diag.promoted_version == 2
+
+    def test_no_groups_leaves_promoted_version_at_1(self, db_seeded: Database) -> None:
+        diag = db_seeded.session.query(Diagnostic).first()
+        # Ensure no groups for this diagnostic (use a fresh diagnostic)
+        with db_seeded.session.begin_nested():
+            fresh_diag = Diagnostic(
+                slug="fresh-diag-recompute",
+                name="Fresh Diagnostic",
+                provider_id=diag.provider_id,
+            )
+            db_seeded.session.add(fresh_diag)
+        db_seeded.session.flush()
+
+        result = recompute_promoted_version(fresh_diag.id, db_seeded.session)
+        # No groups → stays at default 1
+        assert result == 1
+        db_seeded.session.refresh(fresh_diag)
+        assert fresh_diag.promoted_version == 1
+
+
+# ---------------------------------------------------------------------------
+# Test case 4: stats() aggregation filter
+# ---------------------------------------------------------------------------
+
+
+class TestStatsPromotedVersionFilter:
+    """stats() CLI command only counts groups at the promoted version."""
+
+    @pytest.fixture
+    def db_stats_versions(self, db_seeded: Database) -> Database:
+        """v1 and v2 groups for one diagnostic; promoted_version=2."""
+        with db_seeded.session.begin():
+            _register_provider(db_seeded, pmp_provider)
+
+        diag = db_seeded.session.query(Diagnostic).filter_by(slug="enso_tel").first()
+        diag.promoted_version = 2
+
+        with db_seeded.session.begin_nested():
+            eg_v1 = ExecutionGroup(
+                key="stats-filter-key",
+                diagnostic_id=diag.id,
+                diagnostic_version=1,
+                selectors={"cmip6": [["source_id", "MODEL-A"]]},
+            )
+            eg_v2 = ExecutionGroup(
+                key="stats-filter-key",
+                diagnostic_id=diag.id,
+                diagnostic_version=2,
+                selectors={"cmip6": [["source_id", "MODEL-A"]]},
+            )
+            db_seeded.session.add_all([eg_v1, eg_v2])
+        db_seeded.session.flush()
+        db_seeded.session.add(
+            Execution(
+                execution_group_id=eg_v1.id,
+                successful=True,
+                output_fragment="out-v1",
+                dataset_hash="hash-v1",
+            )
+        )
+        db_seeded.session.add(
+            Execution(
+                execution_group_id=eg_v2.id,
+                successful=True,
+                output_fragment="out-v2",
+                dataset_hash="hash-v2",
+            )
+        )
+        db_seeded.session.commit()
+        return db_seeded
+
+    def test_stats_shows_only_promoted_version_totals(self, db_stats_versions: Database, invoke_cli) -> None:
+        result = invoke_cli(["executions", "stats", "--diagnostic", "enso_tel"])
+        assert result.exit_code == 0
+        # Total for enso_tel should be 1 (only the v2 group), not 2.
+        # The row shows total counts; if both were included total would be >=2.
+        # We assert "1" appears in the row and the table is non-empty.
+        assert "enso_tel" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Test case 5: mark_failed_running operational invariant
+# ---------------------------------------------------------------------------
+
+
+class TestMarkFailedRunningVersionAgnostic:
+    """fail-running must surface in-flight executions regardless of diagnostic_version."""
+
+    @pytest.fixture
+    def db_with_v2_running(self, db_seeded: Database) -> Database:
+        """In-flight execution on a v2 group while promoted_version=1."""
+        with db_seeded.session.begin():
+            _register_provider(db_seeded, pmp_provider)
+
+        diag = db_seeded.session.query(Diagnostic).filter_by(slug="enso_tel").first()
+        # promoted_version stays at 1 (default); group is at v2
+        diag.promoted_version = 1
+
+        with db_seeded.session.begin_nested():
+            eg_v2 = ExecutionGroup(
+                key="fail-running-v2",
+                diagnostic_id=diag.id,
+                diagnostic_version=2,
+                selectors={"cmip6": [["source_id", "MODEL-X"]]},
+            )
+            db_seeded.session.add(eg_v2)
+        db_seeded.session.flush()
+        db_seeded.session.add(
+            Execution(
+                execution_group_id=eg_v2.id,
+                successful=None,  # in-flight
+                output_fragment="out-v2-running",
+                dataset_hash="hash-v2-r",
+            )
+        )
+        db_seeded.session.commit()
+        return db_seeded
+
+    def test_fail_running_catches_v2_in_flight(self, db_with_v2_running: Database, invoke_cli) -> None:
+        result = invoke_cli(["executions", "fail-running", "--force"])
+        assert result.exit_code == 0
+        # At least the v2 in-flight execution was marked failed
+        assert "Successfully marked" in result.stdout
+
+        session = db_with_v2_running.session
+        remaining_running = session.query(Execution).filter(Execution.successful.is_(None)).count()
+        assert remaining_running == 0, "All in-flight executions must be marked failed"
+
+
+# ---------------------------------------------------------------------------
+# Test case 6: dormancy regression
+# ---------------------------------------------------------------------------
+
+
+class TestDormancyRegression:
+    """The solver must not branch on ``Diagnostic.version``.
+
+    The solver's get_or_create still uses only (diagnostic_id, key) as lookup
+    keys, so newly created groups must always have diagnostic_version=1
+    regardless of the Python-side Diagnostic.version class attribute.
+    """
+
+    def test_solver_creates_group_at_version_1_even_when_diagnostic_version_is_2(
+        self, db_seeded: Database, config, monkeypatch
+    ) -> None:
+        # Monkeypatch the version attribute on the example diagnostic class to 2.
+        example_diag_cls = type(example_provider.diagnostics()[0])
+        monkeypatch.setattr(example_diag_cls, "version", 2, raising=False)
+
+        # Build a solver with the example provider (same as test_solver.py `solver` fixture).
+        local_solver = ExecutionSolver.build_from_db(config, db_seeded)
+        local_solver.provider_registry = ProviderRegistry(providers=[example_provider])
+
+        # dry_run=True so we get the group creation side effects without running diagnostics.
+        solve_required_executions(db_seeded, config=config, solver=local_solver, dry_run=True)
+
+        # All newly created groups must have diagnostic_version=1 (write-path not activated)
+        groups = db_seeded.session.query(ExecutionGroup).all()
+        assert groups, "Solver should create at least one ExecutionGroup"
+        for eg in groups:
+            assert eg.diagnostic_version == 1, (
+                f"ExecutionGroup {eg.key!r} has diagnostic_version={eg.diagnostic_version}; "
+                "solver must not branch on Diagnostic.version"
+            )
+
+        # promoted_version on all diagnostics must also remain at 1
+        diags = db_seeded.session.query(Diagnostic).all()
+        for d in diags:
+            assert d.promoted_version == 1, (
+                f"Diagnostic {d.slug!r} has promoted_version={d.promoted_version}; "
+                "recompute_promoted_version must not promote beyond 1 when all groups are v1"
+            )


### PR DESCRIPTION
## Summary

- Add three new DB columns (`execution_group.diagnostic_version`, `diagnostic.promoted_version`, `execution.provider_version`) via an Alembic migration that backfills existing rows to version 1 and flips the `execution_group` unique constraint from `(diagnostic_id, key)` to `(diagnostic_id, key, diagnostic_version)`.
- Extend `get_execution_group_and_latest_filtered` with `include_superseded: bool = False` — default queries see only the promoted version; reingest passes `include_superseded=True` to recover the full history.
- Add `recompute_promoted_version(diagnostic_id, session)` helper that sets `Diagnostic.promoted_version = max(diagnostic_version)` across groups; wired from the solver after each new `ExecutionGroup` is created.
- Filter `stats()` CLI aggregation to `ExecutionGroup.diagnostic_version == Diagnostic.promoted_version`; `mark_failed_running` is intentionally left version-agnostic (operational invariant).
- Add `Diagnostic.version: int = 1` class attribute to `climate-ref-core`.