### PR TITLE
feat(versioning): activate diagnostic versioning write path

### DIFF
--- a/changelog/667.feature.md
+++ b/changelog/667.feature.md
@@ -1,0 +1,5 @@
+Activated the diagnostic versioning write path:
+bumping a diagnostic's ``version`` now creates a fresh execution group
+(preserving the prior version's group and results) instead of overwriting
+it, and each execution is stamped with the provider version that produced
+it.

--- a/changelog/667.feature.md
+++ b/changelog/667.feature.md
@@ -1,5 +1,5 @@
-Activated the diagnostic versioning write path:
-bumping a diagnostic's ``version`` now creates a fresh execution group
-(preserving the prior version's group and results) instead of overwriting
-it, and each execution is stamped with the provider version that produced
-it.
+Write the diagnostic `version` to the database.
+
+Bumping a diagnostic's ``version`` now creates a fresh execution group
+(preserving the prior version's group and results) instead of overwriting it,
+and each execution is stamped with the provider version that produced it.

--- a/docs/versioning-and-compatibility.md
+++ b/docs/versioning-and-compatibility.md
@@ -91,6 +91,37 @@ When a stable API needs to change:
 3. Remove the deprecated API in the next **major** release
 4. Maintain at least one minor release with the deprecation warning
 
+## Diagnostic Versioning
+
+Each diagnostic carries an integer ``version`` class attribute (default ``1``).
+The solver reads this attribute when creating an ``ExecutionGroup`` and
+stores it as ``ExecutionGroup.diagnostic_version``.
+
+```python
+class MyDiagnostic(Diagnostic):
+    name = "My diagnostic"
+    slug = "my-diagnostic"
+    version = 2  # bump when results change
+```
+
+Bump the version whenever a code or data-requirement change should invalidate previously computed results.
+The value is append-only: always increment, never reuse a previous number.
+
+### What happens when you bump a version
+
+- Existing ``ExecutionGroup`` rows for the previous version are preserved.
+- The next solve will creates fresh groups for the new version.
+- ``Diagnostic.promoted_version`` is recomputed to ``max(ExecutionGroup.diagnostic_version)``,
+  so default queries (CLI, API) immediately return only the new version's results.
+- Older versions remain reachable for audit via
+  ``get_execution_group_and_latest_filtered(..., include_superseded=True)``.
+
+### Provider version stamping
+
+Each ``Execution`` records ``provider_version`` -- a snapshot of the worker-installed ``DiagnosticProvider.version`` at run time.
+This is informational only; it is not used for validation or recomputation triggers,
+but is useful for auditing which provider release produced a given result.
+
 ## Provider Dependency Guidelines
 
 ### For provider authors

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -266,6 +266,7 @@ def reingest_execution(
                     execution_group=execution_group,
                     dataset_hash=execution.dataset_hash,
                     output_fragment=PLACEHOLDER_FRAGMENT,
+                    provider_version=diagnostic.provider.version,
                 )
                 database.session.add(new_execution)
 

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -651,14 +651,18 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
         limit_reached = False
 
         diagnostic_id = diagnostic_id_by_slug[(provider_slug, potential_execution.diagnostic.slug)]
+        diagnostic_version = potential_execution.diagnostic.version
 
         # Use a transaction to make sure that the models
         # are created correctly before potentially executing out of process
         with db.session.begin():
+            # diagnostic_version is part of the lookup key so bumping
+            # ``Diagnostic.version`` produces a fresh v2 group instead of reusing the v1 row.
             execution_group, created = db.get_or_create(
                 ExecutionGroup,
                 key=definition.key,
                 diagnostic_id=diagnostic_id,
+                diagnostic_version=diagnostic_version,
                 defaults={
                     "selectors": potential_execution.selectors,
                     "dirty": True,
@@ -706,6 +710,7 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
                     execution_group=execution_group,
                     dataset_hash=definition.datasets.hash,
                     output_fragment=PLACEHOLDER_FRAGMENT,
+                    provider_version=potential_execution.provider.version,
                 )
                 db.session.add(execution)
 

--- a/packages/climate-ref/tests/unit/test_versioning.py
+++ b/packages/climate-ref/tests/unit/test_versioning.py
@@ -1,4 +1,4 @@
-"""Tests for diagnostic versioning read-path foundations.
+"""Tests for diagnostic versioning
 
 Covers:
 1. Migration up/down + backfill
@@ -6,7 +6,8 @@ Covers:
 3. recompute_promoted_version helper
 4. stats() aggregation filter (promoted_version only)
 5. mark_failed_running operational invariant (version-agnostic)
-6. Dormancy regression (solver does NOT branch on Diagnostic.version)
+6. solver branches on Diagnostic.version
+7. Execution.provider_version stamping
 """
 
 import importlib.resources
@@ -338,39 +339,78 @@ class TestMarkFailedRunningVersionAgnostic:
         assert remaining_running == 0, "All in-flight executions must be marked failed"
 
 
-class TestDormancyRegression:
-    """The solver's get_or_create still uses only (diagnostic_id, key) as lookup keys
-    Newly created groups must always have diagnostic_version=1
-    regardless of the Python-side Diagnostic.version class attribute.
+class TestSolverVersionBranching:
+    """The solver branches on ``Diagnostic.version`` when creating ExecutionGroups.
+
+    Bumping the class attribute produces a fresh v2 row instead of reusing the v1 row,
+    and ``recompute_promoted_version`` advances the diagnostic's promoted version.
     """
 
-    def test_solver_creates_group_at_version_1_even_when_diagnostic_version_is_2(
+    def _solve_with_example_provider(self, db: Database, config) -> None:
+        local_solver = ExecutionSolver.build_from_db(config, db)
+        local_solver.provider_registry = ProviderRegistry(providers=[example_provider])
+        solve_required_executions(db, config=config, solver=local_solver, dry_run=False)
+
+    def _example_diagnostic_row(self, db: Database) -> Diagnostic:
+        slug = example_provider.diagnostics()[0].slug
+        return db.session.query(Diagnostic).filter_by(slug=slug).one()
+
+    def test_solver_creates_v2_group_when_diagnostic_version_bumped(
         self, db_seeded: Database, config, monkeypatch
     ) -> None:
-        # Monkeypatch the version attribute on the example diagnostic class to 2.
-        example_diag_cls = type(example_provider.diagnostics()[0])
-        monkeypatch.setattr(example_diag_cls, "version", 2, raising=False)
-
-        # Build a solver with the example provider (same as test_solver.py `solver` fixture).
-        local_solver = ExecutionSolver.build_from_db(config, db_seeded)
-        local_solver.provider_registry = ProviderRegistry(providers=[example_provider])
-
-        # dry_run=True so we get the group creation side effects without running diagnostics.
-        solve_required_executions(db_seeded, config=config, solver=local_solver, dry_run=True)
-
-        # All newly created groups must have diagnostic_version=1 (write-path not activated)
-        groups = db_seeded.session.query(ExecutionGroup).all()
-        assert groups, "Solver should create at least one ExecutionGroup"
-        for eg in groups:
-            assert eg.diagnostic_version == 1, (
-                f"ExecutionGroup {eg.key!r} has diagnostic_version={eg.diagnostic_version}; "
-                "solver must not branch on Diagnostic.version"
+        # Pre-seed a v1 group directly so we can detect that the solver does
+        # not overwrite or reuse it when the live class attribute is bumped to 2.
+        with db_seeded.session.begin():
+            diag = self._example_diagnostic_row(db_seeded)
+            diagnostic_id = diag.id
+            db_seeded.session.add(
+                ExecutionGroup(
+                    key="preexisting-v1",
+                    diagnostic_id=diagnostic_id,
+                    diagnostic_version=1,
+                    selectors={"cmip6": [["source_id", "MODEL-X"]]},
+                )
             )
 
-        # promoted_version on all diagnostics must also remain at 1
-        diags = db_seeded.session.query(Diagnostic).all()
-        for d in diags:
-            assert d.promoted_version == 1, (
-                f"Diagnostic {d.slug!r} has promoted_version={d.promoted_version}; "
-                "recompute_promoted_version must not promote beyond 1 when all groups are v1"
+        # Bump the example diagnostic to v2 and run the solver.
+        example_diag_cls = type(example_provider.diagnostics()[0])
+        monkeypatch.setattr(example_diag_cls, "version", 2, raising=False)
+        self._solve_with_example_provider(db_seeded, config)
+
+        # The pre-seeded v1 group must survive.
+        assert (
+            db_seeded.session.query(ExecutionGroup)
+            .filter_by(diagnostic_id=diagnostic_id, diagnostic_version=1, key="preexisting-v1")
+            .first()
+            is not None
+        ), "Solver must not delete the pre-existing v1 ExecutionGroup"
+
+        # Newly created groups for this diagnostic must be at version 2.
+        v2_groups = (
+            db_seeded.session.query(ExecutionGroup)
+            .filter_by(diagnostic_id=diagnostic_id, diagnostic_version=2)
+            .all()
+        )
+        assert v2_groups, "Solver must create v2 ExecutionGroups when Diagnostic.version=2"
+
+    def test_promoted_version_advances_after_version_bump(
+        self, db_seeded: Database, config, monkeypatch
+    ) -> None:
+        example_diag_cls = type(example_provider.diagnostics()[0])
+        monkeypatch.setattr(example_diag_cls, "version", 2, raising=False)
+        self._solve_with_example_provider(db_seeded, config)
+
+        diag = self._example_diagnostic_row(db_seeded)
+        assert diag.promoted_version == 2, (
+            f"Expected promoted_version=2 after solver run at version=2, got {diag.promoted_version}"
+        )
+
+    def test_solver_records_provider_version_on_execution(self, db_seeded: Database, config) -> None:
+        self._solve_with_example_provider(db_seeded, config)
+        executions = db_seeded.session.query(Execution).all()
+        assert executions, "Solver must create Execution rows"
+        for execution in executions:
+            assert execution.provider_version == example_provider.version, (
+                f"Execution {execution.id} provider_version={execution.provider_version!r}; "
+                f"expected {example_provider.version!r}"
             )


### PR DESCRIPTION
## Description

Activates the diagnostic versioning write path so bumping `Diagnostic.version` produces a fresh `ExecutionGroup` row instead of reusing the prior one.

- Solver now threads `Diagnostic.version` into the `ExecutionGroup` lookup + defaults, so a v2 bump preserves the v1 group and creates v2 groups.
- Each `Execution` is stamped with `provider_version` (worker-installed `provider.version`) at create time, in both the solver and the reingest path.
- `TestWritePathActivation` replaces the read-path-era dormancy regression: bumping the example diagnostic to `version=2` must (a) preserve the v1 group, (b) create v2 groups, (c) advance `Diagnostic.promoted_version` via `recompute_promoted_version`, and (d) stamp `Execution.provider_version` from the live provider.
- Documents the diagnostic-versioning workflow in `docs/versioning-and-compatibility.md`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`