### PR TITLE
fix(ingest): exit non-zero on failure and tolerate per-file DRS errors

### DIFF
--- a/changelog/668.fix.md
+++ b/changelog/668.fix.md
@@ -1,0 +1,4 @@
+`ref datasets ingest` now exits with a non-zero status when one or more input directories fail to ingest,
+so cron- and Kubernetes-based deployments can detect failures.
+The CMIP6, CMIP7, and obs4MIPs adapters also now tolerate individual files with missing DRS components:
+those files are logged and skipped instead of aborting the whole batch.

--- a/packages/climate-ref/src/climate_ref/cli/datasets.py
+++ b/packages/climate-ref/src/climate_ref/cli/datasets.py
@@ -148,18 +148,22 @@ def ingest(  # noqa
     # Create a data catalog from the specified file or directory
     adapter = get_dataset_adapter(source_type.value, **kwargs)
 
+    failed_dirs: list[Path] = []
+
     for _dir in file_or_directory:
         _dir = Path(_dir).expanduser()
         logger.info(f"Ingesting {_dir}")
 
         if not _dir.exists():
             logger.error(f"File or directory {_dir} does not exist")
+            failed_dirs.append(_dir)
             continue
 
         # TODO: This assumes that all datasets are nc files.
         # This is true for CMIP6 and obs4MIPs but may not be true for other dataset types in the future.
-        if not next(_dir.rglob("*.nc")):
+        if next(_dir.rglob("*.nc"), None) is None:
             logger.error(f"No .nc files found in {_dir}")
+            failed_dirs.append(_dir)
             continue
 
         try:
@@ -167,6 +171,7 @@ def ingest(  # noqa
             data_catalog = adapter.validate_data_catalog(data_catalog, skip_invalid=skip_invalid)
         except Exception as e:
             logger.exception(f"Error ingesting datasets from {_dir}: {e}")
+            failed_dirs.append(_dir)
             continue
 
         if data_catalog.empty:
@@ -202,6 +207,13 @@ def ingest(  # noqa
             db=db,
             dry_run=dry_run,
         )
+
+    if failed_dirs:
+        logger.error(
+            f"Ingestion failed for {len(failed_dirs)} of {len(file_or_directory)} input(s): "
+            f"{', '.join(str(p) for p in failed_dirs)}"
+        )
+        raise typer.Exit(code=1)
 
 
 _ALLOWED_GROUP_BY = ("source_id", "variable_id")

--- a/packages/climate-ref/src/climate_ref/datasets/cmip6.py
+++ b/packages/climate-ref/src/climate_ref/datasets/cmip6.py
@@ -10,7 +10,7 @@ from climate_ref.datasets.base import DatasetAdapter, DatasetParsingFunction
 from climate_ref.datasets.catalog_builder import build_catalog
 from climate_ref.datasets.cmip6_parsers import parse_cmip6_complete, parse_cmip6_drs
 from climate_ref.datasets.mixins import FinaliseableDatasetAdapterMixin
-from climate_ref.datasets.utils import clean_branch_time, parse_cftime_dates
+from climate_ref.datasets.utils import build_instance_id, clean_branch_time, parse_cftime_dates
 from climate_ref.models.dataset import CMIP6Dataset
 
 
@@ -220,9 +220,7 @@ class CMIP6DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             *self.dataset_id_metadata,
             self.version_metadata,
         ]
-        datasets["instance_id"] = datasets.apply(
-            lambda row: "CMIP6." + ".".join([row[item] for item in drs_items]), axis=1
-        )
+        datasets = build_instance_id(datasets, drs_items, prefix="CMIP6")
 
         # Add in any missing metadata columns
         missing_columns = set(self.dataset_specific_metadata + self.file_specific_metadata) - set(

--- a/packages/climate-ref/src/climate_ref/datasets/cmip7.py
+++ b/packages/climate-ref/src/climate_ref/datasets/cmip7.py
@@ -16,7 +16,7 @@ from climate_ref.datasets.base import DatasetAdapter, DatasetParsingFunction
 from climate_ref.datasets.catalog_builder import build_catalog
 from climate_ref.datasets.cmip7_parsers import parse_cmip7_complete, parse_cmip7_drs
 from climate_ref.datasets.mixins import FinaliseableDatasetAdapterMixin
-from climate_ref.datasets.utils import clean_branch_time, parse_cftime_dates
+from climate_ref.datasets.utils import build_instance_id, clean_branch_time, parse_cftime_dates
 from climate_ref.models.dataset import CMIP7Dataset
 
 
@@ -224,9 +224,7 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             *self.dataset_id_metadata,
             self.version_metadata,
         ]
-        datasets["instance_id"] = datasets.apply(
-            lambda row: "CMIP7." + ".".join([str(row[item]) for item in drs_items]), axis=1
-        )
+        datasets = build_instance_id(datasets, drs_items, prefix="CMIP7")
 
         # Add in any missing metadata columns
         missing_columns = set(self.dataset_specific_metadata + self.file_specific_metadata) - set(
@@ -237,6 +235,9 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
                 datasets[column] = pd.NA
 
         # Add branded_variable for the raw catalog (before DB ingestion)
-        datasets["branded_variable"] = datasets["variable_id"] + "_" + datasets["branding_suffix"]
+        if not datasets.empty:
+            datasets["branded_variable"] = datasets["variable_id"] + "_" + datasets["branding_suffix"]
+        else:
+            datasets["branded_variable"] = pd.Series(dtype="object")
 
         return datasets

--- a/packages/climate-ref/src/climate_ref/datasets/obs4mips.py
+++ b/packages/climate-ref/src/climate_ref/datasets/obs4mips.py
@@ -16,7 +16,7 @@ from climate_ref.datasets.netcdf_utils import (
     read_variable_attrs,
     read_vertical_levels,
 )
-from climate_ref.datasets.utils import parse_cftime_dates
+from climate_ref.datasets.utils import build_instance_id, parse_cftime_dates
 from climate_ref.models.dataset import Dataset, Obs4MIPsDataset
 
 
@@ -183,17 +183,10 @@ class Obs4MIPsDatasetAdapter(DatasetAdapter):
             *self.dataset_id_metadata,
             self.version_metadata,
         ]
-        datasets["instance_id"] = datasets.apply(
-            lambda row: (
-                "obs4MIPs."
-                + ".".join(
-                    [
-                        row[item].replace(" ", "") if item == "nominal_resolution" else row[item]
-                        for item in drs_items
-                    ]
-                )
-            ),
-            axis=1,
-        )
+
+        def _transform(item: str, value: Any) -> str:
+            return str(value).replace(" ", "") if item == "nominal_resolution" else str(value)
+
+        datasets = build_instance_id(datasets, drs_items, prefix="obs4MIPs", transform=_transform)
         datasets["finalised"] = True
         return datasets

--- a/packages/climate-ref/src/climate_ref/datasets/utils.py
+++ b/packages/climate-ref/src/climate_ref/datasets/utils.py
@@ -5,6 +5,7 @@ Shared utility functions for dataset adapters
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -213,6 +214,65 @@ def parse_drs_daterange(date_range: str) -> tuple[str | None, str | None]:
     except ValueError:
         logger.error(f"Invalid date range format: {date_range}")
         return None, None
+
+
+def build_instance_id(
+    datasets: pd.DataFrame,
+    drs_items: list[str],
+    prefix: str,
+    transform: Callable[[str, Any], str] | None = None,
+) -> pd.DataFrame:
+    """
+    Add an ``instance_id`` column built from DRS components.
+
+    Rows where any required DRS component is None/NA are dropped with a warning
+    so a single malformed file does not abort the whole ingestion batch.
+
+    Parameters
+    ----------
+    datasets
+        Data catalog with one row per file.
+    drs_items
+        Column names that make up the instance id, in order.
+    prefix
+        Prefix to use for the instance id (e.g. ``"CMIP6"``).
+    transform
+        Optional per-column value transform; defaults to ``str(value)``.
+
+    Returns
+    -------
+    :
+        Catalog with the ``instance_id`` column added and invalid rows removed.
+    """
+    if datasets.empty:
+        datasets = datasets.copy()
+        datasets["instance_id"] = pd.Series(dtype="object")
+        return datasets
+
+    def _build(row: pd.Series) -> str | None:
+        parts: list[str] = []
+        for item in drs_items:
+            val = row[item]
+            if _is_na(val):
+                return None
+            parts.append(transform(item, val) if transform else str(val))
+        return f"{prefix}." + ".".join(parts)
+
+    datasets = datasets.copy()
+    datasets["instance_id"] = pd.Series(
+        [_build(row) for _, row in datasets.iterrows()],
+        index=datasets.index,
+        dtype="object",
+    )
+    invalid_mask = datasets["instance_id"].isna()
+    if invalid_mask.any():
+        invalid_rows = datasets.loc[invalid_mask]
+        for _, row in invalid_rows.iterrows():
+            missing = [c for c in drs_items if _is_na(row[c])]
+            path = row.get("path", "<unknown>")
+            logger.warning(f"Skipping {path}: missing required DRS components for instance_id: {missing}")
+        datasets = datasets.loc[~invalid_mask].copy()
+    return datasets
 
 
 def validate_path(raw_path: str) -> Path:

--- a/packages/climate-ref/tests/unit/cli/test_datasets.py
+++ b/packages/climate-ref/tests/unit/cli/test_datasets.py
@@ -227,10 +227,31 @@ class TestIngest:
                 "--source-type",
                 "cmip6",
             ],
+            expected_exit_code=1,
         )
 
-        # Continues past the missing directory
+        # Logs the missing directory and exits non-zero so cron/k8s see the failure.
         assert f"File or directory {sample_data_dir / 'missing'} does not exist" in result.stderr
+        assert "Ingestion failed for 1 of 1 input(s)" in result.stderr
+
+    def test_ingest_partial_failure_exits_nonzero(self, sample_data_dir, db, invoke_cli):
+        # One valid dir, one missing dir: ingestion still runs for the valid dir,
+        # but the CLI exits non-zero so the failure is observable in cron/k8s.
+        result = invoke_cli(
+            [
+                "datasets",
+                "ingest",
+                str(sample_data_dir / self.data_dir),
+                str(sample_data_dir / "missing"),
+                "--source-type",
+                "cmip6",
+            ],
+            expected_exit_code=1,
+        )
+
+        expected_dataset_count = 6
+        assert db.session.query(Dataset).count() == expected_dataset_count
+        assert "Ingestion failed for 1 of 2 input(s)" in result.stderr
 
     def test_ingest_dryrun(self, sample_data_dir, db, invoke_cli):
         invoke_cli(

--- a/packages/climate-ref/tests/unit/datasets/test_utils.py
+++ b/packages/climate-ref/tests/unit/datasets/test_utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import ClassVar
 
 import cftime
 import numpy as np
@@ -6,6 +7,7 @@ import pandas as pd
 import pytest
 
 from climate_ref.datasets.utils import (
+    build_instance_id,
     clean_branch_time,
     parse_cftime_dates,
     parse_drs_daterange,
@@ -180,3 +182,75 @@ class TestParseCftimeDates:
         )
         assert result.iloc[0] == cftime.datetime(2000, 1, 15, calendar="standard")
         assert result.iloc[1] == cftime.datetime(2000, 1, 15, calendar="360_day")
+
+
+class TestBuildInstanceId:
+    drs_items: ClassVar[list[str]] = ["activity_id", "variable_id", "version"]
+
+    def _frame(self, rows):
+        return pd.DataFrame(rows)
+
+    def test_all_components_present(self):
+        df = self._frame(
+            [
+                {"activity_id": "CMIP", "variable_id": "tas", "version": "v1", "path": "/a.nc"},
+                {"activity_id": "CMIP", "variable_id": "pr", "version": "v1", "path": "/b.nc"},
+            ]
+        )
+        out = build_instance_id(df, self.drs_items, prefix="CMIP6")
+        assert out["instance_id"].tolist() == ["CMIP6.CMIP.tas.v1", "CMIP6.CMIP.pr.v1"]
+        assert len(out) == 2
+
+    def test_drops_rows_with_none_component(self, caplog):
+        df = self._frame(
+            [
+                {"activity_id": "CMIP", "variable_id": "tas", "version": "v1", "path": "/a.nc"},
+                {"activity_id": "CMIP", "variable_id": None, "version": "v1", "path": "/bad.nc"},
+                {"activity_id": "CMIP", "variable_id": "pr", "version": np.nan, "path": "/bad2.nc"},
+            ]
+        )
+        out = build_instance_id(df, self.drs_items, prefix="CMIP6")
+
+        assert out["instance_id"].tolist() == ["CMIP6.CMIP.tas.v1"]
+        # Two warnings, one per dropped row, naming the path + missing column(s).
+        warning_messages = [r.message for r in caplog.records]
+        assert any("/bad.nc" in m and "variable_id" in m for m in warning_messages)
+        assert any("/bad2.nc" in m and "version" in m for m in warning_messages)
+
+    def test_empty_input(self):
+        df = pd.DataFrame(columns=["activity_id", "variable_id", "version", "path"])
+        out = build_instance_id(df, self.drs_items, prefix="CMIP6")
+        assert out.empty
+        assert "instance_id" in out.columns
+
+    def test_custom_transform(self):
+        df = self._frame(
+            [
+                {
+                    "activity_id": "obs4MIPs",
+                    "variable_id": "tas",
+                    "nominal_resolution": "100 km",
+                    "version": "v1",
+                    "path": "/a.nc",
+                }
+            ]
+        )
+        out = build_instance_id(
+            df,
+            ["activity_id", "nominal_resolution", "variable_id", "version"],
+            prefix="obs4MIPs",
+            transform=lambda item, value: (
+                str(value).replace(" ", "") if item == "nominal_resolution" else str(value)
+            ),
+        )
+        assert out["instance_id"].iloc[0] == "obs4MIPs.obs4MIPs.100km.tas.v1"
+
+    def test_does_not_mutate_input(self):
+        df = self._frame(
+            [
+                {"activity_id": "CMIP", "variable_id": "tas", "version": "v1", "path": "/a.nc"},
+            ]
+        )
+        original = df.copy()
+        build_instance_id(df, self.drs_items, prefix="CMIP6")
+        pd.testing.assert_frame_equal(df, original)


### PR DESCRIPTION
## Summary

Closes #668 (partial: covers the two bullets under "ingest silently exits 0").

- `ref datasets ingest` now exits with a **non-zero status** when any input directory fails (missing path, no `.nc` files, or an unhandled parsing exception). Cron and Kubernetes Job status can now trust the exit code instead of seeing every run as "successful".
- The CMIP6/CMIP7/obs4MIPs adapters now tolerate **per-file DRS errors**. Previously, one file with a missing DRS attribute (e.g. `experiment_id`) caused `TypeError: sequence item 3: expected str instance, NoneType found` while building `instance_id`, which aborted the entire 67k-file scan. A shared `build_instance_id` helper now drops those rows with a logged warning and continues with the remaining files.

The default `skip_invalid=True` behaviour is preserved.

The two remaining items from the issue ("summary line / `--output json`" and "single-source-type per call / `ref datasets sync`") are larger feature work and not included here.

## Test plan

- [x] `uv run pytest packages/climate-ref/tests/unit/datasets/` (175 passed, 1 xfailed)
- [x] `uv run pytest packages/climate-ref/tests/unit/cli/` (287 passed)
- [x] `uv run pytest packages/climate-ref/tests/integration/datasets/` (28 passed)
- [x] `uv run ruff check` + `uv run mypy` (both clean)
- [x] New unit tests:
  - `TestBuildInstanceId` covers happy path, per-row None dropping with warning, empty input, custom transform, and non-mutation of input.
  - `test_ingest_missing` now asserts `exit_code=1` and the summary log line.
  - `test_ingest_partial_failure_exits_nonzero` ingests one valid + one missing directory and asserts the valid one was ingested but the CLI exit is non-zero.