### PR TITLE
fix(ingest): stop re-ingesting unchanged CMIP6 files every run

### DIFF
--- a/changelog/673.fix.md
+++ b/changelog/673.fix.md
@@ -1,0 +1,6 @@
+Stopped re-ingesting unchanged CMIP6 files on every run.
+Previously, `ref datasets ingest` reported every file as updated and emitted a
+"Updating file metadata" warning per file even when nothing on disk had changed,
+because the file-metadata comparison treated a `str` loaded from the database as
+unequal to a freshly parsed `cftime.datetime`. Re-ingesting an unchanged directory
+is now a no-op.

--- a/packages/climate-ref/src/climate_ref/datasets/base.py
+++ b/packages/climate-ref/src/climate_ref/datasets/base.py
@@ -316,10 +316,8 @@ class DatasetAdapter(Protocol):
             raise NotImplementedError("Removing files is not yet supported")
 
         # Update existing files if any file-specific metadata has changed.
-        # Compare via _to_db_str on the incoming value so it matches the
-        # on-disk str form (DatasetFile.@validates coerces cftime -> str).
-        # Without this, a fresh cftime parse compared to the str loaded from
-        # the DB always evaluates !=, forcing spurious updates every run.
+        # Compare via _to_db_str on the incoming value so it matches the on-disk str form
+        # (DatasetFile.@validates coerces cftime -> str).
         for file_path, existing_file in current_file_paths.items():
             if file_path in new_file_lookup:
                 new_meta = new_file_lookup[file_path]

--- a/packages/climate-ref/src/climate_ref/datasets/base.py
+++ b/packages/climate-ref/src/climate_ref/datasets/base.py
@@ -7,7 +7,7 @@ from loguru import logger
 from sqlalchemy.orm import joinedload
 
 from climate_ref.database import Database, ModelState
-from climate_ref.datasets.utils import _is_na, parse_cftime_dates, validate_path
+from climate_ref.datasets.utils import _is_na, _to_db_str, parse_cftime_dates, validate_path
 from climate_ref.models.dataset import Dataset, DatasetFile
 from climate_ref_core.exceptions import RefException
 
@@ -315,14 +315,18 @@ class DatasetAdapter(Protocol):
             logger.warning(f"Files to remove: {files_removed}")
             raise NotImplementedError("Removing files is not yet supported")
 
-        # Update existing files if any file-specific metadata has changed
+        # Update existing files if any file-specific metadata has changed.
+        # Compare via _to_db_str on the incoming value so it matches the
+        # on-disk str form (DatasetFile.@validates coerces cftime -> str).
+        # Without this, a fresh cftime parse compared to the str loaded from
+        # the DB always evaluates !=, forcing spurious updates every run.
         for file_path, existing_file in current_file_paths.items():
             if file_path in new_file_lookup:
                 new_meta = new_file_lookup[file_path]
                 changed = any(
                     not _is_na(new_meta.get(c))
                     and hasattr(existing_file, c)
-                    and getattr(existing_file, c) != new_meta[c]
+                    and getattr(existing_file, c) != _to_db_str(new_meta[c])
                     for c in file_meta_cols
                     if c in new_meta
                 )

--- a/packages/climate-ref/src/climate_ref/datasets/utils.py
+++ b/packages/climate-ref/src/climate_ref/datasets/utils.py
@@ -29,12 +29,11 @@ def _to_db_str(value: Any) -> str | None:
     """
     Coerce a value to its on-disk string form.
 
-    Matches the @validates coercion used by DatasetFile (e.g.
-    cftime.datetime -> str(cftime_obj)). This is the normalised form for
-    comparing a freshly-parsed in-memory value against the str loaded back
-    from the database. Without it, a cross-type ``str != cftime.datetime``
-    comparison always evaluates True and every file appears changed on
-    re-ingest.
+    Matches the @validates coercion used by DatasetFile (e.g. cftime.datetime -> str(cftime_obj)).
+    This is the normalised form for comparing a freshly-parsed in-memory value
+    against the str loaded back from the database.
+    Without it, a cross-type ``str != cftime.datetime`` comparison always evaluates True
+    and every file appears changed onre-ingest.
     """
     if value is None:
         return None

--- a/packages/climate-ref/src/climate_ref/datasets/utils.py
+++ b/packages/climate-ref/src/climate_ref/datasets/utils.py
@@ -25,6 +25,24 @@ def _is_na(value: Any) -> bool:
         return False
 
 
+def _to_db_str(value: Any) -> str | None:
+    """
+    Coerce a value to its on-disk string form.
+
+    Matches the @validates coercion used by DatasetFile (e.g.
+    cftime.datetime -> str(cftime_obj)). This is the normalised form for
+    comparing a freshly-parsed in-memory value against the str loaded back
+    from the database. Without it, a cross-type ``str != cftime.datetime``
+    comparison always evaluates True and every file appears changed on
+    re-ingest.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 def sort_data_catalog(catalog: pd.DataFrame) -> pd.DataFrame:
     """
     Sort a dataset catalog DataFrame by instance_id and start_time (with NA values last).

--- a/packages/climate-ref/tests/integration/test_lazy_ingest_idempotency.py
+++ b/packages/climate-ref/tests/integration/test_lazy_ingest_idempotency.py
@@ -1,0 +1,65 @@
+"""
+Integration tests for the idempotency of CMIP6 dataset ingestion.
+
+Re-running ``ingest_datasets`` on an unchanged directory must be a complete
+no-op: no UPDATED states, no "Updating file metadata" warnings.
+
+These tests previously failed because ``DatasetFile.start_time`` /
+``end_time`` are stored as ``str`` (via the @validates coercion on the model)
+but ``register_dataset`` compared the DB-loaded ``str`` against a freshly
+parsed ``cftime.datetime`` from ``find_local_datasets``.
+The cross-type ``!=`` was always True, so every file was flagged as changed
+on every run.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from climate_ref.datasets import ingest_datasets
+from climate_ref.datasets.cmip6 import CMIP6DatasetAdapter
+
+
+class TestReingestIdempotency:
+    """Re-ingesting the same directory must be a no-op."""
+
+    def test_second_ingest_reports_no_updated_files(self, config, db, sample_data_dir):
+        """The second ingest of the same directory updates zero files and zero datasets."""
+        adapter = CMIP6DatasetAdapter(config=config)
+        data_dir = sample_data_dir / "CMIP6"
+
+        stats1 = ingest_datasets(adapter, data_dir, db)
+        assert stats1.datasets_created > 0, "first ingest must create at least one dataset"
+        assert stats1.files_added > 0, "first ingest must add at least one file"
+
+        stats2 = ingest_datasets(adapter, data_dir, db)
+
+        assert stats2.datasets_created == 0, (
+            f"second ingest created {stats2.datasets_created} dataset(s); expected 0"
+        )
+        assert stats2.files_added == 0, f"second ingest added {stats2.files_added} file(s); expected 0"
+        assert stats2.files_updated == 0, (
+            f"second ingest reported {stats2.files_updated} file(s) as updated; expected 0. "
+            "Root cause: file metadata comparison treats DB str vs freshly parsed "
+            "cftime.datetime as always unequal."
+        )
+        assert stats2.datasets_updated == 0, (
+            f"second ingest reported {stats2.datasets_updated} dataset(s) as updated; expected 0"
+        )
+
+    def test_second_ingest_is_quiet(self, config, db, sample_data_dir, caplog):
+        """The second ingest must not emit 'Updating file metadata' warnings."""
+        adapter = CMIP6DatasetAdapter(config=config)
+        data_dir = sample_data_dir / "CMIP6"
+
+        ingest_datasets(adapter, data_dir, db)
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            ingest_datasets(adapter, data_dir, db)
+
+        updating = [r for r in caplog.records if "Updating file metadata" in r.message]
+        assert updating == [], (
+            f"re-ingest emitted {len(updating)} spurious 'Updating file metadata' "
+            "warning(s) on identical input:\n" + "\n".join(r.message for r in updating)
+        )


### PR DESCRIPTION
## Description

`DatasetFile.start_time` / `end_time` are stored as `str` in the database (via the `@validates` coercion on the model that calls `str(cftime_obj)`),
but `register_dataset`'s update-existing-files loop compared the DB-loaded
`str` against a freshly parsed `cftime.datetime` from `find_local_datasets`. The cross-type `str != cftime.datetime` comparison always evaluates `True`, so every file was flagged as updated on every ingest, producing `UPDATED` states and noisy `Updating file metadata` warnings even when nothing on disk had changed.

This change introduces a `_to_db_str` helper mirroring the model's `@validates` coercion and uses it on the in-memory value before comparing to the DB-stored `str`. Re-ingest of an unchanged directory is now a true no-op.

## Checklist

- [x] Tests added (`packages/climate-ref/tests/integration/test_lazy_ingest_idempotency.py`)
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`