### PR TITLE
fix(ingest): keep files absent from current ingest, warn instead of abort

### DIFF
--- a/changelog/677.fix.md
+++ b/changelog/677.fix.md
@@ -1,0 +1,9 @@
+Fixed `ref datasets ingest` aborting with
+`NotImplementedError("Removing files is not yet supported")` when the
+same dataset (same `instance_id`) was registered twice in one run with
+different file paths --- e.g. a CMIP6 mirror that stores the same
+netCDF file under two parent activity directories, parsed via the
+content-based `complete` parser. Files absent from the current ingest
+slice are now kept in place with a warning instead of aborting the
+whole run, matching the existing `TODO` in `register_dataset` about
+preserving datasets that diagnostics have already used.

--- a/changelog/677.fix.md
+++ b/changelog/677.fix.md
@@ -1,9 +1,1 @@
-Fixed `ref datasets ingest` aborting with
-`NotImplementedError("Removing files is not yet supported")` when the
-same dataset (same `instance_id`) was registered twice in one run with
-different file paths --- e.g. a CMIP6 mirror that stores the same
-netCDF file under two parent activity directories, parsed via the
-content-based `complete` parser. Files absent from the current ingest
-slice are now kept in place with a warning instead of aborting the
-whole run, matching the existing `TODO` in `register_dataset` about
-preserving datasets that diagnostics have already used.
+Changed the behaviour for `register_dataset` treatment of files absent from the current ingest slice as kept-in-place with a warning, instead of raising NotImplementedError.

--- a/packages/climate-ref/src/climate_ref/datasets/base.py
+++ b/packages/climate-ref/src/climate_ref/datasets/base.py
@@ -304,10 +304,10 @@ class DatasetAdapter(Protocol):
         db.session.flush()
 
         # Initialize result tracking
-        files_added = []
-        files_updated = []
-        files_removed = []
-        files_unchanged = []
+        files_added: list[str] = []
+        files_updated: list[str] = []
+        files_removed: list[str] = []
+        files_unchanged: list[str] = []
 
         # Get current files for this dataset
         current_files = db.session.query(DatasetFile).filter_by(dataset_id=dataset.id).all()
@@ -326,13 +326,21 @@ class DatasetAdapter(Protocol):
         new_file_paths = set(new_file_lookup.keys())
         existing_file_paths = set(current_file_paths.keys())
 
-        # TODO: support removing files that are no longer present
-        # We want to keep a record of the dataset if it was used by a diagnostic in the past
+        # Files that exist in the database but are absent from the incoming catalog
+        # slice. Removal isn't supported yet (we want to preserve a record of
+        # diagnostics that already used the file), but raising here aborts the
+        # whole ingest -- including the streaming path, where a dataset can appear
+        # in two different chunks (e.g. a CMIP6 mirror that stores the same
+        # netCDF file under both an "actual" activity directory and a misfiled
+        # parent activity directory). Emit a warning and keep the existing rows
+        # in place so subsequent register_dataset calls for the same slug just
+        # add their own paths.
         files_to_remove = existing_file_paths - new_file_paths
         if files_to_remove:
-            files_removed = list(files_to_remove)
-            logger.warning(f"Files to remove: {files_removed}")
-            raise NotImplementedError("Removing files is not yet supported")
+            logger.warning(
+                f"Dataset {slug}: {len(files_to_remove)} file(s) absent from the current ingest "
+                f"are being kept (removal not yet supported): {sorted(files_to_remove)}"
+            )
 
         # Update existing files if any file-specific metadata has changed.
         # Compare via _to_db_str on the incoming value so it matches the on-disk str form

--- a/packages/climate-ref/tests/unit/datasets/test_datasets.py
+++ b/packages/climate-ref/tests/unit/datasets/test_datasets.py
@@ -266,10 +266,16 @@ def test_register_dataset_updates_and_adds_without_removal(monkeypatch, test_db)
     assert f2_file.end_time == "2001-12-31"
 
 
-def test_register_dataset_raises_on_removal(monkeypatch, test_db):
+def test_register_dataset_keeps_absent_files_with_warning(monkeypatch, test_db, caplog):
+    """
+    Files that exist in the DB but are absent from the current register_dataset call
+    are kept in place with a warning, instead of aborting the run. This lets streaming
+    ingest survive the case where the same dataset (same slug) appears in two chunks
+    with different file paths -- e.g. a CMIP6 mirror that stores the same netCDF file
+    under two different parent activity directories.
+    """
     adapter, db = test_db
 
-    # First, create initial dataset with files
     initial_df = _mk_df(
         rows=[
             {
@@ -288,7 +294,8 @@ def test_register_dataset_raises_on_removal(monkeypatch, test_db):
     with db.session.begin():
         adapter.register_dataset(db=db, data_catalog_dataset=initial_df)
 
-    # New catalog omits "remove.nc" -> triggers removal path
+    # New catalog omits "remove.nc" and adds "added.nc" — exercises both the
+    # "absent from current chunk" path and the regular add path.
     updated_df = _mk_df(
         rows=[
             {
@@ -296,12 +303,34 @@ def test_register_dataset_raises_on_removal(monkeypatch, test_db):
                 "start_time": "2001-01-01",
                 "end_time": "2001-12-31",
             },
+            {
+                "path": "added.nc",
+                "start_time": "2002-01-01",
+                "end_time": "2002-12-31",
+            },
         ]
     )
 
-    with pytest.raises(NotImplementedError, match="Removing files is not yet supported"):
-        with db.session.begin():
-            adapter.register_dataset(db=db, data_catalog_dataset=updated_df)
+    caplog.clear()
+    with db.session.begin():
+        result = adapter.register_dataset(db=db, data_catalog_dataset=updated_df)
+
+    assert set(result.files_added) == {"added.nc"}
+    assert set(result.files_unchanged) == {"keep.nc"}
+    assert result.files_removed == []
+
+    dataset = db.session.query(CMIP6Dataset).filter_by(slug="CESM2.tas.gn").first()
+    paths_in_db = {f.path for f in db.session.query(DatasetFile).filter_by(dataset_id=dataset.id)}
+    # All three paths are now in the DB — the absent file was kept, not removed.
+    assert paths_in_db == {"keep.nc", "remove.nc", "added.nc"}
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelname == "WARNING" and "absent from the current ingest" in r.message
+    ]
+    assert len(warnings) == 1
+    assert "remove.nc" in warnings[0].message
 
 
 def test_register_dataset_multiple_datasets_error(monkeypatch, test_db):


### PR DESCRIPTION
## Summary

`ref datasets ingest` aborts with `NotImplementedError("Removing files is not yet supported")` whenever the same `instance_id` is registered twice in one run with a different set of file paths each time. 

Honestly this should never happen under the DRS... but it does...

The `complete` parser reads attributes from file content, not from the path. The following instance_ids have identical files (which conflict with their metadata on ESGF).

- CMIP6.DAMIP.IPSL.IPSL-CM6A-LR.hist-GHG.r1i1p1f1.Amon.psl.gr.v20180914
- CMIP6.DAMIP.NASA-GISS.GISS-E2-1-G.hist-GHG.r1i1p1f1.Amon.ts.gn.v20180907

This PR makes `register_dataset` treat *files absent from the current ingest slice* as kept-in-place with a warning, instead of raising. This will likely break an execution which will now see both datasets, but I'd rather that than work around this because its just wrong.

## Test plan

- [x] Replaced `test_register_dataset_raises_on_removal` with `test_register_dataset_keeps_absent_files_with_warning` asserting the new union-then-warn behaviour
- [x] `pytest packages/climate-ref/tests/unit/datasets/` (203 passed, 1 xfailed)
- [x] `ruff check`, `ruff format`, `mypy` (pre-commit)

Closes #676