### PR TITLE
fix(database): make get_or_create / update_or_create race-safe

### DIFF
--- a/changelog/679.fix.md
+++ b/changelog/679.fix.md
@@ -1,0 +1,5 @@
+Fixed a race in `ref solve` that crashed with `UNIQUE constraint failed: execution_group`
+when two solver workers (e.g. under `--no-wait` celery fan-out) tried to create the same
+`ExecutionGroup` concurrently.
+`Database.get_or_create` and `Database.update_or_create` now wrap the INSERT in a SAVEPOINT
+and re-fetch the winning row on conflict instead of aborting the transaction.

--- a/changelog/679.fix.md
+++ b/changelog/679.fix.md
@@ -1,5 +1,3 @@
-Fixed a race in `ref solve` that crashed with `UNIQUE constraint failed: execution_group`
-when two solver workers (e.g. under `--no-wait` celery fan-out) tried to create the same
-`ExecutionGroup` concurrently.
+Fixed a race condition when trying to create the same `ExecutionGroup` concurrently.
 `Database.get_or_create` and `Database.update_or_create` now wrap the INSERT in a SAVEPOINT
 and re-fetch the winning row on conflict instead of aborting the transaction.

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -525,8 +525,11 @@ class Database:
                 self.session.add(instance)
             return instance, ModelState.CREATED
         except IntegrityError:
-            # Another transaction inserted a matching row between our SELECT and INSERT.
-            # Drop cached state so the re-SELECT hits the database and returns the winner.
-            self.session.expire_all()
-            instance = self.session.query(model).filter_by(**kwargs).one()
+            # Could be a racing INSERT on the same unique key, OR a genuine integrity
+            # bug (NOT NULL violation, missing FK, failed CHECK).  Distinguish by
+            # re-running the lookup: a racing winner will now be visible; a real bug
+            # leaves the SELECT empty, in which case we re-raise the original error.
+            instance = self.session.query(model).filter_by(**kwargs).first()
+            if instance is None:
+                raise
             return instance, None

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -24,6 +24,7 @@ from alembic.config import Config as AlembicConfig
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from loguru import logger
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from climate_ref.models import MetricValue, Table
@@ -443,7 +444,15 @@ class Database:
         """
         Update an existing instance or create a new one
 
-        This doesn't commit the transaction,
+        Safe under concurrent writers: creation goes through :meth:`get_or_create`,
+        which wraps the INSERT in a SAVEPOINT so a racing writer's UNIQUE conflict
+        resolves to fetching the winner's row. Field updates are then applied on top.
+
+        Note: last-writer-wins for the update step. If two callers update the same
+        pre-existing row concurrently, the later-committing transaction's values win.
+        This race is inherent to update semantics and is not addressed here.
+
+        This doesn't commit the outer transaction,
         so you will need to call `session.commit()` after this method
         or use a transaction context manager.
 
@@ -461,23 +470,19 @@ class Database:
         :
             A tuple containing the instance and a state enum indicating if the instance was created or updated
         """
-        instance = self.session.query(model).filter_by(**kwargs).first()
-        state: ModelState | None = None
-        if instance:
-            # Update existing instance with defaults
-            if defaults:
-                for key, value in defaults.items():
-                    if _values_differ(getattr(instance, key), value):
-                        logger.debug(f"Updating {model.__name__} {key} to {value}")
-                        setattr(instance, key, value)
-                        state = ModelState.UPDATED
+        instance, state = self.get_or_create(model, defaults=defaults, **kwargs)
+        if state is ModelState.CREATED:
             return instance, state
-        else:
-            # Create new instance
-            params = {**kwargs, **(defaults or {})}
-            instance = model(**params)
-            self.session.add(instance)
-            return instance, ModelState.CREATED
+
+        # Row pre-existed (or a racing writer's row was fetched).
+        # Apply caller-provided defaults as updates on top.
+        if defaults:
+            for key, value in defaults.items():
+                if _values_differ(getattr(instance, key), value):
+                    logger.debug(f"Updating {model.__name__} {key} to {value}")
+                    setattr(instance, key, value)
+                    state = ModelState.UPDATED
+        return instance, state
 
     def get_or_create(
         self, model: type[Table], defaults: dict[str, Any] | None = None, **kwargs: Any
@@ -485,7 +490,12 @@ class Database:
         """
         Get or create an instance of a model
 
-        This doesn't commit the transaction,
+        To support concurrent writers, a SAVEPOINT is wrapped around the INSERT operation.
+        This allows for a UNIQUE-constraint violation from a racing transaction to be caught
+        and the row inserted by the winner to be re-fetched instead of crashing.
+        The surrounding transaction (if any) is left intact.
+
+        This doesn't commit the outer transaction,
         so you will need to call `session.commit()` after this method
         or use a transaction context manager.
 
@@ -506,8 +516,17 @@ class Database:
         instance = self.session.query(model).filter_by(**kwargs).first()
         if instance:
             return instance, None
-        else:
-            params = {**kwargs, **(defaults or {})}
-            instance = model(**params)
-            self.session.add(instance)
+
+        params = {**kwargs, **(defaults or {})}
+        try:
+            # Avoiding dialect-specific on_conflict_do_nothing syntax to maintain compatibility
+            with self.session.begin_nested():
+                instance = model(**params)
+                self.session.add(instance)
             return instance, ModelState.CREATED
+        except IntegrityError:
+            # Another transaction inserted a matching row between our SELECT and INSERT.
+            # Drop cached state so the re-SELECT hits the database and returns the winner.
+            self.session.expire_all()
+            instance = self.session.query(model).filter_by(**kwargs).one()
+            return instance, None

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -1,4 +1,5 @@
 import re
+import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from sqlalchemy import inspect
 from climate_ref.database import (
     Database,
     MigrationState,
+    ModelState,
     _create_backup,
     _get_sqlite_path,
     _make_readonly_sqlite_url,
@@ -18,7 +20,9 @@ from climate_ref.database import (
     validate_database_url,
 )
 from climate_ref.models import MetricValue
+from climate_ref.models.base import Base
 from climate_ref.models.dataset import CMIP6Dataset, Dataset, Obs4MIPsDataset
+from climate_ref.models.provider import Provider
 from climate_ref_core.datasets import SourceDatasetType
 from climate_ref_core.pycmec.controlled_vocabulary import CV
 
@@ -404,6 +408,93 @@ class TestValuesDiffer:
         assert _values_differ(True, pd.NA)
         assert _values_differ(False, pd.NA)
         assert _values_differ(pd.NA, True)
+
+
+class TestConcurrentCreate:
+    """
+    Two writers racing on the same unique key must not crash with IntegrityError.
+
+    Regression for the solver race exposed by celery fan-out: two transactions both
+    SELECT (see nothing), both INSERT, second hits UNIQUE.
+    """
+
+    @staticmethod
+    def _bootstrap(db_path: Path) -> str:
+        """Create the schema on a fresh file-based SQLite DB and return the URL."""
+        url = f"sqlite:///{db_path}"
+        db = Database(url)
+        Base.metadata.create_all(db._engine)
+        db.close()
+        return url
+
+    def _run_two_writers(self, url: str, op):
+        """Run ``op(db)`` in two threads, gated by a barrier so both SELECT before either commits."""
+        barrier = threading.Barrier(2)
+        results: list = []
+        errors: list = []
+
+        def worker(name: str) -> None:
+            db = Database(url)
+            try:
+                with db.session.begin():
+                    instance, state = op(db)
+                    barrier.wait()
+                    db.session.flush()
+                    row_id = instance.id
+                results.append((name, state, row_id))
+            except BaseException as e:
+                errors.append((name, e))
+            finally:
+                db.close()
+
+        t1 = threading.Thread(target=worker, args=("A",))
+        t2 = threading.Thread(target=worker, args=("B",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        return results, errors
+
+    def test_get_or_create_handles_unique_race(self, tmp_path):
+        url = self._bootstrap(tmp_path / "race.db")
+
+        def op(db: Database):
+            return db.get_or_create(
+                Provider,
+                defaults={"name": "Example", "version": "1.0"},
+                slug="example",
+            )
+
+        results, errors = self._run_two_writers(url, op)
+
+        assert errors == [], errors
+        assert len(results) == 2
+        # Both threads must agree on the same row.
+        assert results[0][2] == results[1][2]
+        # Exactly one thread reports CREATED; the other reports None (fetched winner's row).
+        states = sorted(r[1] for r in results if r[1] is not None)
+        assert states == [ModelState.CREATED]
+
+    def test_update_or_create_handles_unique_race(self, tmp_path):
+        url = self._bootstrap(tmp_path / "race.db")
+
+        def op(db: Database):
+            return db.update_or_create(
+                Provider,
+                defaults={"name": "Example", "version": "1.0"},
+                slug="example",
+            )
+
+        results, errors = self._run_two_writers(url, op)
+
+        assert errors == [], errors
+        assert len(results) == 2
+        # Both threads see the same surviving row.
+        assert results[0][2] == results[1][2]
+        # One winner reports CREATED; loser reports either UPDATED or None
+        # (depending on whether its defaults differed from the winner's row).
+        states = [r[1] for r in results]
+        assert ModelState.CREATED in states
 
 
 class TestReadOnlyDatabase:

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -1,5 +1,4 @@
 import re
-import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -20,7 +19,6 @@ from climate_ref.database import (
     validate_database_url,
 )
 from climate_ref.models import MetricValue
-from climate_ref.models.base import Base
 from climate_ref.models.dataset import CMIP6Dataset, Dataset, Obs4MIPsDataset
 from climate_ref.models.provider import Provider
 from climate_ref_core.datasets import SourceDatasetType
@@ -412,89 +410,100 @@ class TestValuesDiffer:
 
 class TestConcurrentCreate:
     """
-    Two writers racing on the same unique key must not crash with IntegrityError.
+    Regression for the solver race exposed by celery fan-out: two writers both
+    SELECT (see nothing), both INSERT, second hits UNIQUE.  ``get_or_create``
+    must recover by re-fetching the winner's row.
 
-    Regression for the solver race exposed by celery fan-out: two transactions both
-    SELECT (see nothing), both INSERT, second hits UNIQUE.
+    Reproduced deterministically: the initial SELECT inside ``get_or_create``
+    is patched to miss (simulating a stale snapshot), with the conflicting row
+    pre-inserted via a separate connection so the SAVEPOINT INSERT fails with
+    ``IntegrityError`` exactly once per call.  No threads, no SQLite locking
+    timing dependencies.
     """
 
     @staticmethod
-    def _bootstrap(db_path: Path) -> str:
-        """Create the schema on a fresh file-based SQLite DB and return the URL."""
-        url = f"sqlite:///{db_path}"
-        db = Database(url)
-        Base.metadata.create_all(db._engine)
-        db.close()
-        return url
+    def _commit_conflict_row(url: str, **fields) -> None:
+        """Commit a ``Provider`` row on an independent connection."""
+        with Database(url) as other, other.session.begin():
+            other.session.add(Provider(**fields))
 
-    def _run_two_writers(self, url: str, op):
-        """Run ``op(db)`` in two threads, gated by a barrier so both SELECT before either commits."""
-        barrier = threading.Barrier(2)
-        results: list = []
-        errors: list = []
+    @staticmethod
+    def _make_initial_select_miss(mocker, db, model) -> None:
+        """Force the next ``session.query(model).filter_by(...).first()`` to return None.
 
-        def worker(name: str) -> None:
-            db = Database(url)
-            try:
-                with db.session.begin():
-                    instance, state = op(db)
-                    barrier.wait()
-                    db.session.flush()
-                    row_id = instance.id
-                results.append((name, state, row_id))
-            except BaseException as e:
-                errors.append((name, e))
-            finally:
-                db.close()
+        Subsequent queries (including the recovery SELECT inside the
+        ``IntegrityError`` handler) run normally and see committed rows.
+        """
+        original_query = db.session.query
+        consumed: list = []
 
-        t1 = threading.Thread(target=worker, args=("A",))
-        t2 = threading.Thread(target=worker, args=("B",))
-        t1.start()
-        t2.start()
-        t1.join()
-        t2.join()
-        return results, errors
+        def patched_query(*args, **kwargs):
+            q = original_query(*args, **kwargs)
+            if args == (model,) and not consumed:
+                consumed.append(True)
+                original_filter_by = q.filter_by
 
-    def test_get_or_create_handles_unique_race(self, tmp_path):
-        url = self._bootstrap(tmp_path / "race.db")
+                def filter_by_miss(**kw):
+                    chained = original_filter_by(**kw)
+                    chained.first = lambda: None
+                    return chained
 
-        def op(db: Database):
-            return db.get_or_create(
+                q.filter_by = filter_by_miss
+            return q
+
+        mocker.patch.object(db.session, "query", side_effect=patched_query)
+
+    def test_get_or_create_recovers_from_unique_conflict(self, db, mocker):
+        # Racing winner is already committed by the time our INSERT runs.
+        self._commit_conflict_row(db.url, slug="example", name="winner", version="1.0")
+        self._make_initial_select_miss(mocker, db, Provider)
+
+        with db.session.begin():
+            instance, state = db.get_or_create(
                 Provider,
-                defaults={"name": "Example", "version": "1.0"},
+                defaults={"name": "loser", "version": "2.0"},
                 slug="example",
             )
 
-        results, errors = self._run_two_writers(url, op)
+        # IntegrityError handler ran; loser fetched the winner's row instead of crashing.
+        assert state is None
+        assert instance.name == "winner"
+        assert instance.version == "1.0"
+        # And the row count stayed at one — no duplicate slipped in.
+        assert db.session.query(Provider).filter_by(slug="example").count() == 1
 
-        assert errors == [], errors
-        assert len(results) == 2
-        # Both threads must agree on the same row.
-        assert results[0][2] == results[1][2]
-        # Exactly one thread reports CREATED; the other reports None (fetched winner's row).
-        states = sorted(r[1] for r in results if r[1] is not None)
-        assert states == [ModelState.CREATED]
+    def test_update_or_create_recovers_from_unique_conflict(self, db, mocker):
+        self._commit_conflict_row(db.url, slug="example", name="winner", version="1.0")
+        self._make_initial_select_miss(mocker, db, Provider)
 
-    def test_update_or_create_handles_unique_race(self, tmp_path):
-        url = self._bootstrap(tmp_path / "race.db")
-
-        def op(db: Database):
-            return db.update_or_create(
+        with db.session.begin():
+            instance, state = db.update_or_create(
                 Provider,
-                defaults={"name": "Example", "version": "1.0"},
+                defaults={"name": "loser", "version": "2.0"},
                 slug="example",
             )
 
-        results, errors = self._run_two_writers(url, op)
+        # Loser found the racing row via the IntegrityError recovery path, then
+        # applied its own defaults on top (last-writer-wins update semantics).
+        assert state is ModelState.UPDATED
+        assert instance.name == "loser"
+        assert instance.version == "2.0"
+        assert db.session.query(Provider).filter_by(slug="example").count() == 1
 
-        assert errors == [], errors
-        assert len(results) == 2
-        # Both threads see the same surviving row.
-        assert results[0][2] == results[1][2]
-        # One winner reports CREATED; loser reports either UPDATED or None
-        # (depending on whether its defaults differed from the winner's row).
-        states = [r[1] for r in results]
-        assert ModelState.CREATED in states
+    def test_get_or_create_reraises_unrelated_integrity_errors(self, db, mocker):
+        """Non-race integrity violations (NOT NULL, etc.) must surface, not be swallowed."""
+        self._make_initial_select_miss(mocker, db, Provider)
+
+        # ``version`` is NOT NULL; passing None triggers an IntegrityError that has
+        # nothing to do with a racing writer.  The recovery SELECT still misses, so
+        # the original error must be re-raised.
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            with db.session.begin():
+                db.get_or_create(
+                    Provider,
+                    defaults={"name": "broken", "version": None},
+                    slug="broken-row",
+                )
 
 
 class TestReadOnlyDatabase:


### PR DESCRIPTION
## Description

`ref solve --no-wait` crashes with
`sqlite3.IntegrityError: UNIQUE constraint failed: execution_group.diagnostic_id, execution_group.key, execution_group.diagnostic_version`
whenever two solver workers race to create the same `ExecutionGroup`. I think this isn't the root cause of the issue I was seeing, but its still a valid concern.

This now savepoints before the insert and then reselects in the case of a race condition

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable
- [x] Changelog item added to `changelog/`