### PR TITLE
fix: correct the data path for the new pmp cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,14 @@ build: clean  ## build the packages to be deployed to PyPI
 	cp LICENCE NOTICE packages/climate-ref-esmvaltool
 	cp LICENCE NOTICE packages/climate-ref-ilamb
 	cp LICENCE NOTICE packages/climate-ref-pmp
+	cp LICENCE NOTICE packages/climate-ref-example
 	uv build --package climate-ref --no-sources
 	uv build --package climate-ref-core --no-sources
 	uv build --package climate-ref-celery --no-sources
 	uv build --package climate-ref-esmvaltool --no-sources
 	uv build --package climate-ref-ilamb --no-sources
 	uv build --package climate-ref-pmp --no-sources
+	uv build --package climate-ref-example --no-sources
 
 .PHONY: ruff-fixes
 ruff-fixes:  ## fix the code using ruff

--- a/changelog/685.fix.md
+++ b/changelog/685.fix.md
@@ -1,0 +1,1 @@
+Updates the PMP provider data directory

--- a/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
+++ b/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
@@ -21,6 +21,30 @@ from climate_ref_core.env import env
 DATASET_URL = env.str("REF_DATASET_URL", default="https://obs4ref.climate-ref.org")
 
 
+def resolve_cache_dir(cache_name: str) -> pathlib.Path:
+    """
+    Resolve the cache directory for a registry.
+
+    If the ``REF_DATASET_CACHE_DIR`` environment variable is set, use that as the root.
+    Otherwise, fall back to the OS cache under ``climate_ref``.
+
+    Parameters
+    ----------
+    cache_name
+        Subdirectory name within the cache root.
+
+    Returns
+    -------
+        The resolved cache directory path.
+    """
+    if env_cache_dir := os.environ.get("REF_DATASET_CACHE_DIR"):
+        cache_dir = pathlib.Path(os.path.expandvars(env_cache_dir)).expanduser()
+    else:
+        cache_dir = pooch.os_cache("climate_ref")
+
+    return cache_dir / cache_name
+
+
 def _verify_hash_matches(fname: str | pathlib.Path, known_hash: str) -> bool:
     """
     Check if the hash of a file matches a known hash.
@@ -207,30 +231,6 @@ class DatasetRegistryManager:
         return list(self._registries.keys())
 
     @staticmethod
-    def _resolve_cache_dir(cache_name: str) -> pathlib.Path:
-        """
-        Resolve the cache directory for a registry.
-
-        If the ``REF_DATASET_CACHE_DIR`` environment variable is set,
-        use that as the root. Otherwise, fall back to the OS cache
-        under ``climate_ref``.
-
-        Parameters
-        ----------
-        cache_name
-            Subdirectory name within the cache root.
-
-        Returns
-        -------
-            The resolved cache directory path.
-        """
-        if env_cache_dir := os.environ.get("REF_DATASET_CACHE_DIR"):
-            cache_dir = pathlib.Path(os.path.expandvars(env_cache_dir)).expanduser()
-        else:
-            cache_dir = pooch.os_cache("climate_ref")
-
-        return cache_dir / cache_name
-
     @staticmethod
     def _migrate_cache(
         registry: pooch.Pooch,
@@ -314,7 +314,7 @@ class DatasetRegistryManager:
         if cache_name is None:
             cache_name = name
 
-        cache_path = self._resolve_cache_dir(cache_name)
+        cache_path = resolve_cache_dir(cache_name)
 
         # Before v0.13.0 everything was cached directly under
         # pooch.os_cache("climate_ref") with no per-registry subdirectory.

--- a/packages/climate-ref-core/tests/unit/test_dataset_registry/test_dataset_registry.py
+++ b/packages/climate-ref-core/tests/unit/test_dataset_registry/test_dataset_registry.py
@@ -252,11 +252,7 @@ class TestMigrateCache:
 
         new_dir = tmp_path / "new_cache" / "test_registry"
 
-        mocker.patch.object(
-            DatasetRegistryManager,
-            "_resolve_cache_dir",
-            return_value=new_dir,
-        )
+        mocker.patch("climate_ref_core.dataset_registry.resolve_cache_dir", return_value=new_dir)
 
         registry_path, package, resource = fake_registry_file
         with registry_path.open("w") as f:

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
@@ -15,6 +15,7 @@ from climate_ref_core.dataset_registry import (
     DATASET_URL,
     dataset_registry_manager,
     fetch_all_files,
+    resolve_cache_dir,
     validate_registry_cache,
 )
 from climate_ref_core.providers import CondaDiagnosticProvider
@@ -62,7 +63,7 @@ class ESMValToolProvider(CondaDiagnosticProvider):
 
     def get_data_path(self) -> Path | None:
         """Get the path where ESMValTool data is cached."""
-        return Path(pooch.os_cache("climate_ref"))
+        return resolve_cache_dir("esmvaltool")
 
 
 # Initialise the diagnostics manager.

--- a/packages/climate-ref-esmvaltool/tests/unit/test_provider.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_provider.py
@@ -31,7 +31,7 @@ class TestESMValToolProviderHooks:
         data_path = provider.get_data_path()
         assert data_path is not None
         assert isinstance(data_path, Path)
-        assert data_path == Path(pooch.os_cache("climate_ref"))
+        assert data_path == Path(pooch.os_cache("climate_ref")) / "esmvaltool"
 
     def test_fetch_data(self, mocker):
         """Test that fetch_data calls fetch_all_files."""

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
@@ -12,7 +12,6 @@ import importlib.resources
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pooch
 import yaml
 from loguru import logger
 
@@ -20,6 +19,7 @@ from climate_ref_core.dataset_registry import (
     DATASET_URL,
     dataset_registry_manager,
     fetch_all_files,
+    resolve_cache_dir,
     validate_registry_cache,
 )
 from climate_ref_core.providers import DiagnosticProvider
@@ -64,7 +64,8 @@ class ILAMBProvider(DiagnosticProvider):
     def get_data_path(self) -> Path | None:
         """Get the path where ILAMB data is cached."""
         # All ILAMB registries use the same cache
-        return Path(pooch.os_cache("climate_ref"))
+        # TODO: There are more than one registry
+        return resolve_cache_dir("ilamb")
 
 
 provider = ILAMBProvider("ILAMB", __version__)

--- a/packages/climate-ref-ilamb/tests/unit/test_provider.py
+++ b/packages/climate-ref-ilamb/tests/unit/test_provider.py
@@ -25,7 +25,7 @@ class TestILAMBProviderHooks:
         data_path = provider.get_data_path()
         assert data_path is not None
         assert isinstance(data_path, Path)
-        assert data_path == Path(pooch.os_cache("climate_ref"))
+        assert data_path == Path(pooch.os_cache("climate_ref")) / "ilamb"
 
     def test_fetch_data(self, mocker):
         """Test that fetch_data calls fetch_all_files for all registries."""

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
@@ -9,13 +9,13 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import pooch
 from loguru import logger
 
 from climate_ref_core.dataset_registry import (
     DATASET_URL,
     dataset_registry_manager,
     fetch_all_files,
+    resolve_cache_dir,
     validate_registry_cache,
 )
 from climate_ref_core.providers import CondaDiagnosticProvider
@@ -73,7 +73,7 @@ class PMPDiagnosticProvider(CondaDiagnosticProvider):
 
     def get_data_path(self) -> Path | None:
         """Get the path where PMP data is cached."""
-        return Path(pooch.os_cache("climate_ref"))
+        return resolve_cache_dir(_REGISTRY_NAME)
 
     def ingest_data(self, config: Config, db: Any) -> None:
         """

--- a/packages/climate-ref-pmp/tests/unit/test_provider.py
+++ b/packages/climate-ref-pmp/tests/unit/test_provider.py
@@ -21,7 +21,7 @@ class TestPMPProviderHooks:
         data_path = provider.get_data_path()
         assert data_path is not None
         assert isinstance(data_path, Path)
-        assert data_path == Path(pooch.os_cache("climate_ref"))
+        assert data_path == Path(pooch.os_cache("climate_ref")) / "pmp-climatology"
 
     def test_fetch_data(self, mocker):
         """Test that fetch_data calls fetch_all_files."""


### PR DESCRIPTION
## Description

Update the data path for PMP files to point to the new cache.

This might cause some warning for older dbs that include paths from the old cache, but I think it still works

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
