### PR TITLE
test(core): add series.json regression comparison

### DIFF
--- a/changelog/706.trivial.md
+++ b/changelog/706.trivial.md
@@ -1,0 +1,1 @@
+Added a regression check that compares diagnostic series outputs (`series.json`) against the committed expected data, so changes to series creation are now caught by the test suite.

--- a/packages/climate-ref-core/src/climate_ref_core/testing.py
+++ b/packages/climate-ref-core/src/climate_ref_core/testing.py
@@ -10,6 +10,7 @@ This module provides:
 
 from __future__ import annotations
 
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -28,6 +29,7 @@ from climate_ref_core.datasets import (
 )
 from climate_ref_core.diagnostics import ExecutionDefinition, ExecutionResult
 from climate_ref_core.esgf.base import ESGFRequest
+from climate_ref_core.metric_values.typing import SeriesMetricValue
 from climate_ref_core.pycmec.metric import CMECMetric
 from climate_ref_core.pycmec.output import CMECOutput
 
@@ -499,6 +501,13 @@ def validate_cmec_bundles(diagnostic: Diagnostic, result: ExecutionResult) -> No
     AssertionError
         If the result is not successful or bundles are invalid
     """
+    # TODO: Add content regression checks for the CMEC bundles (diagnostic.json /
+    # output.json), mirroring `validate_series_regression`. These bundles are only
+    # structurally validated here, so a diagnostic can change the metric/output
+    # values without any regression test failing (see issue #703 for the series
+    # equivalent). A content comparison must sanitise the regenerated bundle first
+    # via `ExecutionRegression.output_replacements`, since the committed bundles
+    # store `<OUTPUT_DIR>` / `<TEST_DATA_DIR>` placeholders.
     assert result.successful, f"Execution failed: {result}"
 
     # Validate metric bundle
@@ -515,6 +524,71 @@ def validate_cmec_bundles(diagnostic: Diagnostic, result: ExecutionResult) -> No
 
     # Validate output bundle
     CMECOutput.load_from_json(result.to_output_path(result.output_bundle_filename))
+
+
+def _load_series_sanitised(path: Path, replacements: dict[str, str]) -> list[SeriesMetricValue]:
+    """
+    Load series from ``path``, replacing real paths with regression placeholders.
+    """
+    text = path.read_text(encoding="utf-8")
+    # Apply replacements longest-key-first in case of nested repleacements
+    for real, placeholder in sorted(replacements.items(), key=lambda kv: len(kv[0]), reverse=True):
+        text = text.replace(real, placeholder)
+    data = json.loads(text)
+    if not isinstance(data, list):
+        raise ValueError(f"Expected a list of series values, got {type(data)}")
+    return [SeriesMetricValue.model_validate(s, strict=True) for s in data]
+
+
+def validate_series_regression(
+    expected_path: Path,
+    actual_path: Path,
+    *,
+    slug: str,
+    replacements: dict[str, str] | None = None,
+) -> None:
+    """
+    Assert that regenerated series match the committed regression series.
+
+    If ``expected_path`` does not exist (legacy regression data without a stored series),
+    the check is skipped.
+
+    Parameters
+    ----------
+    expected_path
+        Path to the committed ``series.json`` regression artifact. This file
+        stores sanitized placeholders (e.g. ``<OUTPUT_DIR>``).
+    actual_path
+        Path to the freshly regenerated ``series.json`` in the output directory.
+        This file contains expanded absolute paths.
+    slug
+        The diagnostic slug, used for error messages.
+    replacements
+        Optional ``real path -> placeholder`` mapping applied to the regenerated series before comparison,
+        mirroring the sanitisation used when the regression data was written.
+
+    Raises
+    ------
+    AssertionError
+        If the regenerated series differ from the committed series.
+    """
+    if not expected_path.exists():
+        return
+
+    expected = SeriesMetricValue.load_from_json(expected_path)
+    actual = _load_series_sanitised(actual_path, replacements or {})
+
+    def _sorted_dump(series: list[SeriesMetricValue]) -> list[dict[str, Any]]:
+        return sorted((s.model_dump(mode="json") for s in series), key=lambda s: repr(s["dimensions"]))
+
+    assert len(actual) == len(expected), (
+        f"Diagnostic {slug} produced {len(actual)} series but the committed series.json "
+        f"has {len(expected)}. Regenerate the regression data with `--force-regen`."
+    )
+    assert _sorted_dump(actual) == _sorted_dump(expected), (
+        f"Diagnostic {slug} produced series that differ from the committed series.json. "
+        f"Regenerate the regression data with `--force-regen`."
+    )
 
 
 @frozen
@@ -585,10 +659,19 @@ class RegressionValidator:
         )
 
     def validate(self, definition: ExecutionDefinition) -> None:
-        """Validate CMEC bundles in the regression output."""
+        """Validate CMEC bundles and series in the regression output."""
         result = self.diagnostic.build_execution_result(definition)
         result.to_output_path("out.log").touch()  # Log file not tracked in regression
         validate_cmec_bundles(self.diagnostic, result)
+        validate_series_regression(
+            expected_path=self.paths.regression / "series.json",
+            actual_path=definition.output_directory / "series.json",
+            slug=self.diagnostic.slug,
+            replacements={
+                str(definition.output_directory): "<OUTPUT_DIR>",
+                str(self.test_data_dir): "<TEST_DATA_DIR>",
+            },
+        )
 
 
 def collect_test_case_params(provider: DiagnosticProvider) -> list[ParameterSet]:

--- a/packages/climate-ref-core/tests/unit/test_testing.py
+++ b/packages/climate-ref-core/tests/unit/test_testing.py
@@ -8,6 +8,7 @@ import yaml
 
 from climate_ref_core.datasets import DatasetCollection, ExecutionDatasetCollection, SourceDatasetType
 from climate_ref_core.diagnostics import ExecutionResult
+from climate_ref_core.metric_values.typing import SeriesMetricValue
 from climate_ref_core.testing import (
     RegressionValidator,
     TestCase,
@@ -19,6 +20,7 @@ from climate_ref_core.testing import (
     load_datasets_from_yaml,
     save_datasets_to_yaml,
     validate_cmec_bundles,
+    validate_series_regression,
 )
 
 
@@ -912,3 +914,120 @@ class TestRegressionValidator:
 
         # Verify build_execution_result was called
         mock_diagnostic.build_execution_result.assert_called_once_with(mock_definition)
+
+
+def _series(value: float, *, dim: str = "M1", index_name: str = "year", attrs=None) -> SeriesMetricValue:
+    """Build a small SeriesMetricValue for testing."""
+    return SeriesMetricValue(
+        dimensions={"source_id": dim},
+        values=[value, value + 1.0],
+        index=["2000", "2001"],
+        index_name=index_name,
+        attributes=attrs,
+    )
+
+
+def _write_series(path: Path, series: list[SeriesMetricValue]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    SeriesMetricValue.dump_to_json(path, series)
+    return path
+
+
+class TestValidateSeriesRegression:
+    def test_matching_series_passes(self, tmp_path):
+        series = [_series(1.0), _series(5.0, dim="M2")]
+        expected = _write_series(tmp_path / "expected" / "series.json", series)
+        actual = _write_series(tmp_path / "actual" / "series.json", series)
+
+        validate_series_regression(expected, actual, slug="my-diag")
+
+    def test_order_insensitive(self, tmp_path):
+        a, b = _series(1.0, dim="M1"), _series(5.0, dim="M2")
+        expected = _write_series(tmp_path / "expected" / "series.json", [a, b])
+        actual = _write_series(tmp_path / "actual" / "series.json", [b, a])
+
+        validate_series_regression(expected, actual, slug="my-diag")
+
+    def test_missing_expected_is_skipped(self, tmp_path):
+        actual = _write_series(tmp_path / "actual" / "series.json", [_series(1.0)])
+        missing_expected = tmp_path / "expected" / "series.json"
+
+        # Must not raise, even though actual is non-empty.
+        validate_series_regression(missing_expected, actual, slug="my-diag")
+
+    def test_count_mismatch_raises(self, tmp_path):
+        """A different number of series fails with a count message (Check for #703)."""
+        expected = _write_series(tmp_path / "expected" / "series.json", [])
+        actual = _write_series(tmp_path / "actual" / "series.json", [_series(1.0)])
+
+        with pytest.raises(AssertionError, match=r"produced 1 series but the committed series\.json has 0"):
+            validate_series_regression(expected, actual, slug="my-diag")
+
+    def test_value_mismatch_raises(self, tmp_path):
+        """Same count but different values fails with a content message."""
+        expected = _write_series(tmp_path / "expected" / "series.json", [_series(1.0)])
+        actual = _write_series(tmp_path / "actual" / "series.json", [_series(2.0)])
+
+        with pytest.raises(AssertionError, match="produced series that differ"):
+            validate_series_regression(expected, actual, slug="my-diag")
+
+    def test_attribute_mismatch_raises(self, tmp_path):
+        """Differences in series attributes are detected."""
+        expected = _write_series(
+            tmp_path / "expected" / "series.json", [_series(1.0, attrs={"caption": "old"})]
+        )
+        actual = _write_series(tmp_path / "actual" / "series.json", [_series(1.0, attrs={"caption": "new"})])
+
+        with pytest.raises(AssertionError, match="produced series that differ"):
+            validate_series_regression(expected, actual, slug="my-diag")
+
+    def test_slug_in_error_message(self, tmp_path):
+        """The diagnostic slug is surfaced in failure messages."""
+        expected = _write_series(tmp_path / "expected" / "series.json", [])
+        actual = _write_series(tmp_path / "actual" / "series.json", [_series(1.0)])
+
+        with pytest.raises(AssertionError, match="Diagnostic some-slug"):
+            validate_series_regression(expected, actual, slug="some-slug")
+
+    def test_sanitised_path_placeholders_are_normalised(self, tmp_path):
+        """Committed placeholders compare equal to expanded regenerated paths."""
+        expected = _write_series(
+            tmp_path / "expected" / "series.json",
+            [_series(1.0, attrs={"source_file": "<TEST_DATA_DIR>/input.nc"})],
+        )
+        actual = _write_series(
+            tmp_path / "actual" / "series.json",
+            [_series(1.0, attrs={"source_file": f"{tmp_path}/input.nc"})],
+        )
+
+        validate_series_regression(
+            expected,
+            actual,
+            slug="my-diag",
+            replacements={str(tmp_path): "<TEST_DATA_DIR>"},
+        )
+
+    def test_nested_replacements(self, tmp_path):
+        """A nested output dir is substituted before its parent test-data dir."""
+        test_data_dir = tmp_path / "test-data"
+        output_dir = test_data_dir / "diag" / "default" / "output"
+        output_dir.mkdir(parents=True)
+
+        expected = _write_series(
+            test_data_dir / "expected" / "series.json",
+            [_series(1.0, attrs={"plot": "<OUTPUT_DIR>/plot.png", "input": "<TEST_DATA_DIR>/in.nc"})],
+        )
+        actual = _write_series(
+            output_dir / "series.json",
+            [_series(1.0, attrs={"plot": f"{output_dir}/plot.png", "input": f"{test_data_dir}/in.nc"})],
+        )
+
+        validate_series_regression(
+            expected,
+            actual,
+            slug="my-diag",
+            replacements={
+                str(output_dir): "<OUTPUT_DIR>",
+                str(test_data_dir): "<TEST_DATA_DIR>",
+            },
+        )

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -62,6 +62,7 @@ from climate_ref_core.diagnostics import DataRequirement, Diagnostic, ExecutionD
 from climate_ref_core.exceptions import TestCaseError
 from climate_ref_core.logging import add_log_handler, remove_log_handler
 from climate_ref_core.providers import DiagnosticProvider
+from climate_ref_core.testing import validate_series_regression
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -464,15 +465,16 @@ class ExecutionRegression:
             for file in output_dir.rglob(glob):
                 self._replace_file(file, replacements)
 
+    def output_replacements(self, output_directory: Path) -> dict[str, str]:
+        """Map real paths to regression placeholders for a given output directory."""
+        return {str(output_directory): "<OUTPUT_DIR>", **self.replacements}
+
     def check(self, key: str, output_directory: Path) -> None:
         """Check and optionally regenerate regression data."""
         if not self.request.config.getoption("force_regen"):
             logger.info("Not regenerating regression results")
             return
-        self.replace_references(
-            output_directory,
-            {str(output_directory): "<OUTPUT_DIR>", **self.replacements},
-        )
+        self.replace_references(output_directory, self.output_replacements(output_directory))
         logger.info(f"Regenerating regression output for {self.diagnostic.full_slug()}")
         output_dir = self.path(key)
         if output_dir.exists():
@@ -546,10 +548,16 @@ class DiagnosticValidator:
             self.execution_regression.check(key=definition.key, output_directory=definition.output_directory)
 
     def validate(self, definition: ExecutionDefinition) -> None:
-        """Validate CMEC bundles and store the execution result."""
+        """Validate CMEC bundles and series, and store the execution result."""
         result = self.diagnostic.build_execution_result(definition)
         result.to_output_path("out.log").touch()
         validate_result(self.diagnostic, self.config, result)
+        validate_series_regression(
+            expected_path=self.execution_regression.path(definition.key) / "series.json",
+            actual_path=definition.output_directory / "series.json",
+            slug=self.diagnostic.slug,
+            replacements=self.execution_regression.output_replacements(definition.output_directory),
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Closes #703.

Diagnostic series outputs (`series.json`) were never compared against the committed regression data. `build_execution_result` re-extracts and overwrites `series.json` on every run, and validation only checked CMEC bundle *structure* an empty or stale `series.json` passed silently. A diagnostic could change which series it emits (or have wrong/empty committed data) without any regression test failing.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`