### PR TITLE
docs: add Zenodo DOI badge to front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The REF is agnostic to what types of data and metrics are to be performed.
 [![CI](https://github.com/Climate-REF/climate-ref/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/Climate-REF/climate-ref/actions/workflows/ci.yaml)
 [![Coverage](https://codecov.io/gh/Climate-REF/climate-ref/branch/main/graph/badge.svg)](https://codecov.io/gh/Climate-REF/climate-ref)
 [![Docs](https://readthedocs.org/projects/climate-ref/badge/?version=latest)](https://climate-ref.readthedocs.io)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15103441.svg)](https://doi.org/10.5281/zenodo.15103441)
 
 **PyPI :**
 [![PyPI](https://img.shields.io/pypi/v/climate-ref.svg)](https://pypi.org/project/climate-ref/)

--- a/changelog/634.docs.md
+++ b/changelog/634.docs.md
@@ -1,0 +1,1 @@
+Added a Zenodo DOI badge to the README and documentation landing page so users can easily find how to cite the REF.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ REF is a [community project](https://wcrp-cmip.org/cmip-phases/cmip7/rapid-evalu
 [![CI](https://github.com/Climate-REF/climate-ref/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/Climate-REF/climate-ref/actions/workflows/ci.yaml)
 [![Coverage](https://codecov.io/gh/Climate-REF/climate-ref/branch/main/graph/badge.svg)](https://codecov.io/gh/Climate-REF/climate-ref)
 [![Docs](https://readthedocs.org/projects/climate-ref/badge/?version=latest)](https://climate-ref.readthedocs.io)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15103441.svg)](https://doi.org/10.5281/zenodo.15103441)
 
 **PyPI :**
 [![PyPI](https://img.shields.io/pypi/v/climate-ref.svg)](https://pypi.org/project/climate-ref/)


### PR DESCRIPTION
Adds a Zenodo DOI badge to the README and docs landing page so users can easily find how to cite the REF.

DOI: https://doi.org/10.5281/zenodo.15103441

Closes #634