### PR TITLE
fix(esmvaltool): stabilise execution dir for regression capture

### DIFF
--- a/changelog/714.fix.md
+++ b/changelog/714.fix.md
@@ -1,0 +1,1 @@
+Made ESMValTool regression baselines deterministic by giving each captured run a stable execution directory instead of a timestamped one, so re-running a test case no longer churns the committed output.

--- a/packages/climate-ref-core/src/climate_ref_core/diagnostics.py
+++ b/packages/climate-ref-core/src/climate_ref_core/diagnostics.py
@@ -613,6 +613,27 @@ class Diagnostic(AbstractDiagnostic):
         # Build the result from the output bundle
         return self.build_execution_result(definition)
 
+    def prepare_regression_output(self, definition: ExecutionDefinition) -> None:
+        """
+        Normalise native output for deterministic regression capture.
+
+        Hook called by the test-case regression runner *between*
+        :meth:`execute` and :meth:`build_execution_result`, allowing a provider
+        to remove avoidable non-determinism (e.g. timestamped directory names)
+        before the output bundle is built and captured as a baseline.
+
+        This is **not** called during normal execution (:meth:`run`), so it must
+        only be used for regression-capture concerns, never for behaviour that
+        affects production results.
+
+        The default implementation does nothing.
+
+        Parameters
+        ----------
+        definition
+            The configuration the diagnostic was run on.
+        """
+
 
 class CommandLineDiagnostic(Diagnostic):
     """

--- a/packages/climate-ref-core/src/climate_ref_core/diagnostics.py
+++ b/packages/climate-ref-core/src/climate_ref_core/diagnostics.py
@@ -618,13 +618,12 @@ class Diagnostic(AbstractDiagnostic):
         Normalise native output for deterministic regression capture.
 
         Hook called by the test-case regression runner *between*
-        :meth:`execute` and :meth:`build_execution_result`, allowing a provider
-        to remove avoidable non-determinism (e.g. timestamped directory names)
+        :meth:`execute` and :meth:`build_execution_result`,
+        allowing a provider to remove avoidable non-determinism (e.g. timestamped directory names)
         before the output bundle is built and captured as a baseline.
 
-        This is **not** called during normal execution (:meth:`run`), so it must
-        only be used for regression-capture concerns, never for behaviour that
-        affects production results.
+        This is **not** called during normal execution (:meth:`run`),
+        so it must only be used for regression-capture concerns.
 
         The default implementation does nothing.
 

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
@@ -1,4 +1,5 @@
 import fnmatch
+import shutil
 from abc import abstractmethod
 from collections.abc import Iterable
 from pathlib import Path
@@ -30,6 +31,13 @@ from climate_ref_esmvaltool.recipe import (
 from climate_ref_esmvaltool.types import MetricBundleArgs, OutputBundleArgs, Recipe
 
 _DATASETS_REGISTRY_NAME = "esmvaltool-datasets"
+
+_STABLE_SESSION_NAME = "recipe"
+"""Stable name for the ESMValTool session directory.
+
+ESMValTool writes each run into a timestamped ``recipe_<YYYYMMDD>_<HHMMSS>`` session directory.
+We rename it to this fixed name after the run so that the captured regression output is deterministic.
+"""
 
 
 def get_cmip_source_type(
@@ -102,6 +110,52 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
             The arguments needed to create a CMEC diagnostic and output bundle.
         """
         return CMECMetric.model_validate(metric_args), CMECOutput.model_validate(output_args)
+
+    def prepare_regression_output(self, definition: ExecutionDefinition) -> None:
+        """
+        Stabilise the timestamped ESMValTool session directory for regression capture.
+
+        Called only by the regression test-case runner (not during normal execution),
+        so the timestamp rewriting never affects production runs.
+
+        Parameters
+        ----------
+        definition
+            A description of the information needed for this execution of the diagnostic
+        """
+        self._stabilise_execution_dir(definition)
+
+    @staticmethod
+    def _stabilise_execution_dir(definition: ExecutionDefinition) -> None:
+        """
+        Rename the timestamped ESMValTool session directory to a stable name.
+
+        Rename the directory to :data:`_STABLE_SESSION_NAME`
+        and rewrite the timestamped name embedded in the text outputs (provenance, ``index.html``, logs)
+        so the paths they contain resolve to the renamed directory.
+
+        Parameters
+        ----------
+        definition
+            A description of the information needed for this execution of the diagnostic
+        """
+        executions_dir = definition.to_output_path("executions")
+        session_dirs = sorted(path for path in executions_dir.glob("recipe_*") if path.is_dir())
+        if not session_dirs:
+            return
+
+        session_dir = session_dirs[-1]
+        old_name = session_dir.name
+        stable_dir = executions_dir / _STABLE_SESSION_NAME
+        if stable_dir.exists():
+            shutil.rmtree(stable_dir)
+        session_dir.rename(stable_dir)
+
+        for pattern in ("*.json", "*.yml", "*.yaml", "*.txt", "*.html"):
+            for file in stable_dir.rglob(pattern):
+                content = file.read_text(encoding="utf-8")
+                if old_name in content:
+                    file.write_text(content.replace(old_name, _STABLE_SESSION_NAME), encoding="utf-8")
 
     def write_recipe(self, definition: ExecutionDefinition) -> Path:
         """
@@ -285,7 +339,11 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
         :
             The resulting diagnostic.
         """
-        result_dir = max(definition.to_output_path("executions").glob("*"))
+        executions_dir = definition.to_output_path("executions")
+        stable_dir = executions_dir / _STABLE_SESSION_NAME
+        # Prefer the stabilised directory; fall back to the timestamped directory
+        # for regression baselines generated before stabilisation was introduced.
+        result_dir = stable_dir if stable_dir.exists() else max(executions_dir.glob("*"))
 
         metric_args = CMECMetric.create_template()
         output_args = CMECOutput.create_template()

--- a/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
@@ -11,6 +11,7 @@ from climate_ref_esmvaltool.diagnostics.regional_historical_changes import _regi
 from climate_ref_esmvaltool.types import Recipe
 
 from climate_ref_core.datasets import SourceDatasetType
+from climate_ref_core.diagnostics import CommandLineDiagnostic
 from climate_ref_core.metric_values import SeriesMetricValue as SeriesMetricValueType
 from climate_ref_core.metric_values.typing import SeriesDefinition
 from climate_ref_core.pycmec.controlled_vocabulary import CV
@@ -245,3 +246,102 @@ def test_series_validation_failure(tmp_path, metric_definition, mock_diagnostic,
     # Run build_execution_result (should log exception)
     mock_diagnostic.build_execution_result(definition=metric_definition)
     assert log_spy.call_count >= 0  # Should log the validation failure
+
+
+def test_stabilise_execution_dir(metric_definition, mock_diagnostic):
+    """The timestamped session directory is renamed and its references rewritten."""
+    executions_dir = metric_definition.to_output_path("executions")
+    session_dir = executions_dir / "recipe_20260130_162732"
+
+    nc_path = session_dir / "work" / "timeseries" / "script1" / "file0.nc"
+    provenance = session_dir / "run" / "timeseries" / "script1" / "diagnostic_provenance.yml"
+    provenance.parent.mkdir(parents=True)
+    provenance.write_text(yaml.safe_dump({str(nc_path): {"caption": "c"}}), encoding="utf-8")
+    index = session_dir / "index.html"
+    index.write_text(f"<a href='{session_dir}/work'>x</a>", encoding="utf-8")
+
+    mock_diagnostic._stabilise_execution_dir(metric_definition)
+
+    stable_dir = executions_dir / "recipe"
+    assert stable_dir.is_dir()
+    assert not session_dir.exists()
+    # The timestamped name no longer appears, and references resolve to the renamed dir.
+    assert "recipe_20260130_162732" not in (stable_dir / "index.html").read_text(encoding="utf-8")
+    rewritten = yaml.safe_load(
+        (stable_dir / "run" / "timeseries" / "script1" / "diagnostic_provenance.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert all(key.startswith(f"{stable_dir}/") for key in rewritten)
+
+
+def test_stabilise_execution_dir_no_output(metric_definition, mock_diagnostic):
+    """Stabilisation is a no-op when no session directory was produced."""
+    executions_dir = metric_definition.to_output_path("executions")
+    executions_dir.mkdir(parents=True)
+
+    mock_diagnostic._stabilise_execution_dir(metric_definition)
+
+    assert not (executions_dir / "recipe").exists()
+
+
+def test_prepare_regression_output_stabilises(metric_definition, mock_diagnostic):
+    """The regression-capture hook stabilises the timestamped directory."""
+    executions_dir = metric_definition.to_output_path("executions")
+    session_dir = executions_dir / "recipe_20260130_162732"
+    session_dir.mkdir(parents=True)
+    (session_dir / "index.html").write_text(f"{session_dir}", encoding="utf-8")
+
+    mock_diagnostic.prepare_regression_output(metric_definition)
+
+    assert (executions_dir / "recipe").is_dir()
+    assert not session_dir.exists()
+
+
+def test_execute_does_not_stabilise(metric_definition, mock_diagnostic, mocker):
+    """Normal execution leaves the timestamped directory untouched (regression-only)."""
+    executions_dir = metric_definition.to_output_path("executions")
+
+    def fake_execute(_self, definition):
+        session_dir = definition.to_output_path("executions") / "recipe_20260130_162732"
+        session_dir.mkdir(parents=True)
+
+    mocker.patch.object(CommandLineDiagnostic, "execute", autospec=True, side_effect=fake_execute)
+
+    mock_diagnostic.execute(metric_definition)
+
+    assert (executions_dir / "recipe_20260130_162732").is_dir()
+    assert not (executions_dir / "recipe").exists()
+
+
+def test_build_execution_result_prefers_stable_dir(metric_definition, mock_diagnostic):
+    """build_execution_result resolves the stabilised ``recipe`` dir over a timestamped one."""
+    executions_dir = metric_definition.to_output_path("executions")
+
+    # Stabilised directory with one data file and one plot.
+    stable_dir = executions_dir / "recipe"
+    metadata = {}
+    for dirname in "work", "plots":
+        suffix = ".nc" if dirname == "work" else ".png"
+        filepath = stable_dir / dirname / "timeseries" / "script1" / f"file0{suffix}"
+        metadata[str(filepath)] = {"caption": "stable file"}
+    provenance = stable_dir / "run" / "timeseries" / "script1" / "diagnostic_provenance.yml"
+    provenance.parent.mkdir(parents=True)
+    provenance.write_text(yaml.safe_dump(metadata), encoding="utf-8")
+
+    # Decoy timestamped directory that must be ignored when the stable one exists.
+    decoy_dir = executions_dir / "recipe_20990101_000000"
+    decoy_provenance = decoy_dir / "run" / "timeseries" / "script1" / "diagnostic_provenance.yml"
+    decoy_provenance.parent.mkdir(parents=True)
+    decoy_nc = decoy_dir / "work" / "timeseries" / "script1" / "decoy.nc"
+    decoy_provenance.write_text(yaml.safe_dump({str(decoy_nc): {"caption": "decoy"}}), encoding="utf-8")
+
+    result = mock_diagnostic.build_execution_result(definition=metric_definition)
+    output_bundle = json.loads(
+        result.to_output_path(result.output_bundle_filename).read_text(encoding="utf-8")
+    )
+
+    captured = list(output_bundle[OutputCV.DATA.value]) + list(output_bundle[OutputCV.PLOTS.value])
+    assert captured
+    assert all(path.startswith("executions/recipe/") for path in captured)
+    assert not any("recipe_20990101_000000" in path for path in captured)

--- a/packages/climate-ref/src/climate_ref/testing.py
+++ b/packages/climate-ref/src/climate_ref/testing.py
@@ -223,7 +223,6 @@ class TestCaseRunner:
 
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create execution definition
         definition = ExecutionDefinition(
             diagnostic=diagnostic,
             key=f"test-{test_case_name}",
@@ -232,10 +231,8 @@ class TestCaseRunner:
             root_directory=output_dir.parent,
         )
 
-        # Run the diagnostic. This mirrors ``Diagnostic.run`` but inserts the
-        # regression-capture hook between execution and result building, so a
-        # provider can normalise non-deterministic native output (e.g. ESMValTool's
-        # timestamped session directory) before it is baked into the bundle.
+        # Run the diagnostic.
+        # This mirrors ``Diagnostic.run`` but inserts the regression-capture hook before bundling.
         diagnostic.execute(definition)
         diagnostic.prepare_regression_output(definition)
         return diagnostic.build_execution_result(definition)

--- a/packages/climate-ref/src/climate_ref/testing.py
+++ b/packages/climate-ref/src/climate_ref/testing.py
@@ -232,5 +232,10 @@ class TestCaseRunner:
             root_directory=output_dir.parent,
         )
 
-        # Run the diagnostic
-        return diagnostic.run(definition)
+        # Run the diagnostic. This mirrors ``Diagnostic.run`` but inserts the
+        # regression-capture hook between execution and result building, so a
+        # provider can normalise non-deterministic native output (e.g. ESMValTool's
+        # timestamped session directory) before it is baked into the bundle.
+        diagnostic.execute(definition)
+        diagnostic.prepare_regression_output(definition)
+        return diagnostic.build_execution_result(definition)

--- a/packages/climate-ref/tests/unit/test_testing.py
+++ b/packages/climate-ref/tests/unit/test_testing.py
@@ -121,13 +121,13 @@ class TestTestCaseRunnerClass:
             test_cases=(TestCase(name="default", description="Default"),)
         )
         mock_result = MagicMock(successful=True)
-        mock_diagnostic.run.return_value = mock_result
+        mock_diagnostic.build_execution_result.return_value = mock_result
 
         result = runner.run(mock_diagnostic, "default")
 
         assert result.successful
-        # Verify diagnostic.run was called with an ExecutionDefinition
-        call_args = mock_diagnostic.run.call_args[0][0]
+        # Verify the diagnostic was executed with an ExecutionDefinition
+        call_args = mock_diagnostic.execute.call_args[0][0]
         assert "test-cases" in str(call_args.output_directory)
         assert "test-provider" in str(call_args.output_directory)
         assert "test-diag" in str(call_args.output_directory)
@@ -150,16 +150,19 @@ class TestTestCaseRunnerClass:
             )
         )
 
-        # Mock the run method to avoid actual execution
+        # Mock the execution phases to avoid actual execution
         mock_result = MagicMock()
         mock_result.successful = True
-        mock_diagnostic.run.return_value = mock_result
+        mock_diagnostic.build_execution_result.return_value = mock_result
 
         result = runner.run(mock_diagnostic, "default", output_dir=tmp_path)
 
         assert result.successful
-        mock_diagnostic.run.assert_called_once()
-        execution_definition = mock_diagnostic.run.call_args[0][0]
+        # The runner drives the phases itself, inserting the regression-capture hook
+        mock_diagnostic.execute.assert_called_once()
+        mock_diagnostic.prepare_regression_output.assert_called_once()
+        mock_diagnostic.build_execution_result.assert_called_once()
+        execution_definition = mock_diagnostic.execute.call_args[0][0]
         assert execution_definition.datasets == mock_datasets
 
     def test_run_without_paths(self, config, tmp_path):


### PR DESCRIPTION
## Description

ESMValTool writes each run into a timestamped `executions/recipe_<YYYYMMDD>_<HHMMSS>` session directory.
That timestamp gets baked into the committed regression bundles (e.g. paths in `output.json`), which makes regression comparison non-deterministic and churns diffs on every re-run ([#713](https://github.com/Climate-REF/climate-ref/issues/713)).

This adds a regression-only normalisation step so captured output is stable across runs:

- New no-op hook `Diagnostic.prepare_regression_output(definition)` on the core base class.
- `TestCaseRunner.run` drives the phases explicitly run explicitly now to call prepare_regression_output at the appropriate time.
- The ESMValTool diagnostic overrides the hook to rename the session directory to a stable `executions/recipe` and rewrite the timestamped name embedded in the text outputs (provenance, `index.html`, logs) so their paths still resolve.
- `build_execution_result` prefers the stabilised `recipe` directory and falls back to the previous `max(glob("*"))` for baselines generated before this change.

Normal (non-regression) runs are untouched — `Diagnostic.run` used by the executors/celery never calls the hook.

This is an interim fix and can be retired once ESMValCore gains a native option to control the session directory name.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`