### PR TITLE
refactor(core): extract shared output-file operations

### DIFF
--- a/changelog/719.trivial.md
+++ b/changelog/719.trivial.md
@@ -1,0 +1,1 @@
+Refactored diagnostic execution-output handling so the curated scratch-to-results copy and path-sanitisation logic live in a single shared module (`climate_ref_core.output_files`), reused by both production persistence and regression testing. No user-facing change.

--- a/changelog/719.trivial.md
+++ b/changelog/719.trivial.md
@@ -1,1 +1,1 @@
-Refactored diagnostic execution-output handling so the curated scratch-to-results copy and path-sanitisation logic live in a single shared module (`climate_ref_core.output_files`), reused by both production persistence and regression testing. No user-facing change.
+Refactored diagnostic execution-output handling so the curated scratch-to-results copy and the path-sanitisation logic live in a single shared module (`climate_ref_core.output_files`).

--- a/packages/climate-ref-core/src/climate_ref_core/output_files.py
+++ b/packages/climate-ref-core/src/climate_ref_core/output_files.py
@@ -3,9 +3,15 @@ Raw-file operations on diagnostic execution outputs.
 
 This module groups every operation that manipulates the files produced by a diagnostic execution.
 Execution output is written to the ``scratch`` directory.
-When the execution is ingested, a curated subset of outputs
-(log + metric bundle + output bundle + the files the output bundle references + series)
-are copied from the scratch directory to the results directory.
+When the execution is ingested,
+a curated subset of outputs are copied from the scratch directory to the results directory:
+
+- logs
+- the metric bundle
+- the output bundle
+- the files the output bundle references (plots/data/html)
+- the series bundle
+
 Only files in the results directory are accessed by the API/public.
 
 For some tests we must sanitise paths to files as well as the contents of text files
@@ -46,11 +52,25 @@ Binary outputs (``.nc``, ``.png``, ...) are never rewritten.
 """
 
 
-def _rewrite_tree(directory: Path, replacements: dict[str, str], globs: tuple[str, ...]) -> None:
+def rewrite_tree(
+    directory: Path,
+    replacements: dict[str, str],
+    globs: tuple[str, ...] = SANITISED_FILE_GLOBS,
+) -> None:
     """Apply ``replacements`` to the text content of every matching file under ``directory``.
 
     Keys are applied longest-first so that an overlapping shorter path cannot
     partially shadow a longer one.
+    Only files matching ``globs`` are rewritten while binary artefacts are never touched.
+
+    Parameters
+    ----------
+    directory
+        The tree of files to rewrite in place.
+    replacements
+        Mapping of substring to replacement, applied to every matching file.
+    globs
+        File globs whose contents are rewritten.
     """
     ordered = sorted(replacements.items(), key=lambda kv: len(kv[0]), reverse=True)
     for glob in globs:
@@ -74,8 +94,8 @@ def to_placeholders(
     Rewrite absolute paths in committed artefacts to portable placeholders ("to").
 
     Replaces the absolute ``output_dir`` with ``<OUTPUT_DIR>`` and the absolute
-    ``test_data_dir`` with ``<TEST_DATA_DIR>`` in every text artefact under
-    ``directory``. Binary files are never touched.
+    ``test_data_dir`` with ``<TEST_DATA_DIR>`` in every text artefact under ``directory``.
+    Binary files are never touched.
 
     Parameters
     ----------
@@ -88,7 +108,7 @@ def to_placeholders(
     globs
         File globs whose contents are rewritten.
     """
-    _rewrite_tree(
+    rewrite_tree(
         directory,
         {str(output_dir): PLACEHOLDER_OUTPUT_DIR, str(test_data_dir): PLACEHOLDER_TEST_DATA_DIR},
         globs,
@@ -105,9 +125,9 @@ def from_placeholders(
     """
     Rewrite portable placeholders back to absolute paths ("from").
 
-    Inverse of :func:`to_placeholders`: replaces ``<OUTPUT_DIR>`` with the absolute
-    ``output_dir`` and ``<TEST_DATA_DIR>`` with the absolute ``test_data_dir`` in
-    every text artefact under ``directory``.
+    Inverse of :func:`to_placeholders`: replaces ``<OUTPUT_DIR>`` with the absolute ``output_dir``
+    and ``<TEST_DATA_DIR>`` with the absolute ``test_data_dir`` in every text artefact under ``directory``.
+    Binary files are never touched.
 
     Parameters
     ----------
@@ -120,7 +140,7 @@ def from_placeholders(
     globs
         File globs whose contents are rewritten.
     """
-    _rewrite_tree(
+    rewrite_tree(
         directory,
         {PLACEHOLDER_OUTPUT_DIR: str(output_dir), PLACEHOLDER_TEST_DATA_DIR: str(test_data_dir)},
         globs,
@@ -153,7 +173,9 @@ def copy_output_file(
     :
         The copied file's path, relative to ``fragment``.
     """
-    assert results_directory != scratch_directory
+    if results_directory == scratch_directory:
+        raise ValueError("results_directory and scratch_directory must differ")
+
     input_directory = scratch_directory / fragment
     output_directory = results_directory / fragment
 
@@ -200,7 +222,6 @@ def copy_execution_outputs(
 
     This is the canonical definition of *what REF persists* for a successful execution,
 
-
     - the metric bundle
     - the output bundle
     - every file it references (plots/data/html)
@@ -240,11 +261,11 @@ def copy_execution_outputs(
     )
 
     if result.output_bundle_filename:
-        copied.append(
-            copy_output_file(scratch_directory, results_directory, fragment, result.output_bundle_filename)
+        output_bundle_relpath = copy_output_file(
+            scratch_directory, results_directory, fragment, result.output_bundle_filename
         )
-        scratch_base = scratch_directory / fragment
-        bundle_path = scratch_base / ensure_relative_path(result.output_bundle_filename, scratch_base)
+        copied.append(output_bundle_relpath)
+        bundle_path = scratch_directory / fragment / output_bundle_relpath
         copied.extend(_copy_output_bundle_files(scratch_directory, results_directory, fragment, bundle_path))
 
     if result.series_filename:

--- a/packages/climate-ref-core/src/climate_ref_core/output_files.py
+++ b/packages/climate-ref-core/src/climate_ref_core/output_files.py
@@ -1,0 +1,255 @@
+"""
+Raw-file operations on diagnostic execution outputs.
+
+This module groups every operation that manipulates the files produced by a diagnostic execution.
+Execution output is written to the ``scratch`` directory.
+When the execution is ingested, a curated subset of outputs
+(log + metric bundle + output bundle + the files the output bundle references + series)
+are copied from the scratch directory to the results directory.
+Only files in the results directory are accessed by the API/public.
+
+For some tests we must sanitise paths to files as well as the contents of text files
+(:func:`to_placeholders` / :func:`from_placeholders`).
+This ensures that the regression data is machine independent.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from climate_ref_core.diagnostics import ensure_relative_path
+from climate_ref_core.logging import EXECUTION_LOG_FILENAME
+from climate_ref_core.pycmec.output import CMECOutput
+
+if TYPE_CHECKING:
+    from climate_ref_core.diagnostics import ExecutionResult
+
+PLACEHOLDER_OUTPUT_DIR = "<OUTPUT_DIR>"
+"""Placeholder substituted for the absolute execution output directory."""
+
+PLACEHOLDER_TEST_DATA_DIR = "<TEST_DATA_DIR>"
+"""Placeholder substituted for the absolute provider test-data directory."""
+
+SANITISED_FILE_GLOBS: tuple[str, ...] = (
+    "*.json",
+    "*.txt",
+    "*.yaml",
+    "*.yml",
+    "*.html",
+    "*.xml",
+)
+"""Text artefacts whose absolute paths are rewritten for portability.
+
+Binary outputs (``.nc``, ``.png``, ...) are never rewritten.
+"""
+
+
+def _rewrite_tree(directory: Path, replacements: dict[str, str], globs: tuple[str, ...]) -> None:
+    """Apply ``replacements`` to the text content of every matching file under ``directory``.
+
+    Keys are applied longest-first so that an overlapping shorter path cannot
+    partially shadow a longer one.
+    """
+    ordered = sorted(replacements.items(), key=lambda kv: len(kv[0]), reverse=True)
+    for glob in globs:
+        for file in sorted(directory.rglob(glob)):
+            text = file.read_text(encoding="utf-8")
+            rewritten = text
+            for old, new in ordered:
+                rewritten = rewritten.replace(old, new)
+            if rewritten != text:
+                file.write_text(rewritten, encoding="utf-8")
+
+
+def to_placeholders(
+    directory: Path,
+    *,
+    output_dir: Path,
+    test_data_dir: Path,
+    globs: tuple[str, ...] = SANITISED_FILE_GLOBS,
+) -> None:
+    """
+    Rewrite absolute paths in committed artefacts to portable placeholders ("to").
+
+    Replaces the absolute ``output_dir`` with ``<OUTPUT_DIR>`` and the absolute
+    ``test_data_dir`` with ``<TEST_DATA_DIR>`` in every text artefact under
+    ``directory``. Binary files are never touched.
+
+    Parameters
+    ----------
+    directory
+        The tree of committed artefacts to sanitise in place.
+    output_dir
+        The absolute execution output directory.
+    test_data_dir
+        The absolute provider test-data directory.
+    globs
+        File globs whose contents are rewritten.
+    """
+    _rewrite_tree(
+        directory,
+        {str(output_dir): PLACEHOLDER_OUTPUT_DIR, str(test_data_dir): PLACEHOLDER_TEST_DATA_DIR},
+        globs,
+    )
+
+
+def from_placeholders(
+    directory: Path,
+    *,
+    output_dir: Path,
+    test_data_dir: Path,
+    globs: tuple[str, ...] = SANITISED_FILE_GLOBS,
+) -> None:
+    """
+    Rewrite portable placeholders back to absolute paths ("from").
+
+    Inverse of :func:`to_placeholders`: replaces ``<OUTPUT_DIR>`` with the absolute
+    ``output_dir`` and ``<TEST_DATA_DIR>`` with the absolute ``test_data_dir`` in
+    every text artefact under ``directory``.
+
+    Parameters
+    ----------
+    directory
+        The tree of artefacts to hydrate in place.
+    output_dir
+        The absolute execution output directory to substitute in.
+    test_data_dir
+        The absolute provider test-data directory to substitute in.
+    globs
+        File globs whose contents are rewritten.
+    """
+    _rewrite_tree(
+        directory,
+        {PLACEHOLDER_OUTPUT_DIR: str(output_dir), PLACEHOLDER_TEST_DATA_DIR: str(test_data_dir)},
+        globs,
+    )
+
+
+def copy_output_file(
+    scratch_directory: Path,
+    results_directory: Path,
+    fragment: Path | str,
+    filename: Path | str,
+) -> Path:
+    """
+    Copy a single output file from the scratch directory to the results directory.
+
+    Parameters
+    ----------
+    scratch_directory
+        The base directory where the file is currently located.
+    results_directory
+        The base directory where the file should be copied to.
+    fragment
+        The per-execution fragment under both base directories.
+    filename
+        The file to copy, relative to ``scratch_directory / fragment`` (an absolute
+        path under that directory is also accepted).
+
+    Returns
+    -------
+    :
+        The copied file's path, relative to ``fragment``.
+    """
+    assert results_directory != scratch_directory
+    input_directory = scratch_directory / fragment
+    output_directory = results_directory / fragment
+
+    relative_filename = ensure_relative_path(filename, input_directory)
+
+    if not (input_directory / relative_filename).exists():
+        raise FileNotFoundError(f"Could not find {relative_filename} in {input_directory}")
+
+    output_filename = output_directory / relative_filename
+    output_filename.parent.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy(input_directory / relative_filename, output_filename)
+    return relative_filename
+
+
+def _copy_output_bundle_files(
+    scratch_directory: Path,
+    results_directory: Path,
+    fragment: Path | str,
+    cmec_output_bundle_filename: Path,
+) -> list[Path]:
+    """Copy the plots/data/html files referenced by a CMEC output bundle."""
+    cmec_output_bundle = CMECOutput.load_from_json(cmec_output_bundle_filename)
+    scratch_base = scratch_directory / fragment
+
+    copied: list[Path] = []
+    for attr in ("plots", "data", "html"):
+        for output_info in (getattr(cmec_output_bundle, attr) or {}).values():
+            filename = ensure_relative_path(output_info.filename, scratch_base)
+            copied.append(copy_output_file(scratch_directory, results_directory, fragment, filename))
+    return copied
+
+
+def copy_execution_outputs(
+    scratch_directory: Path,
+    results_directory: Path,
+    fragment: Path | str,
+    result: ExecutionResult,
+    *,
+    include_log: bool = False,
+) -> list[Path]:
+    """
+    Copy the curated set of persisted outputs from scratch to results.
+
+    This is the canonical definition of *what REF persists* for a successful execution,
+
+
+    - the metric bundle
+    - the output bundle
+    - every file it references (plots/data/html)
+    - the series bundle
+    - the execution log (if ``include_log=True``)
+
+    Parameters
+    ----------
+    scratch_directory
+        Base scratch directory the diagnostic wrote into.
+    results_directory
+        Base results directory to copy the curated subset into.
+    fragment
+        The per-execution fragment under both base directories.
+    result
+        The successful execution result (must carry a metric bundle filename).
+    include_log
+        If True, copy the execution log.
+
+    Returns
+    -------
+    :
+        The copied files, each relative to ``fragment`` (the manifest key set).
+    """
+    if result.metric_bundle_filename is None:
+        raise ValueError("Cannot copy outputs for a result without a metric bundle")
+
+    copied: list[Path] = []
+
+    if include_log:
+        copied.append(
+            copy_output_file(scratch_directory, results_directory, fragment, EXECUTION_LOG_FILENAME)
+        )
+
+    copied.append(
+        copy_output_file(scratch_directory, results_directory, fragment, result.metric_bundle_filename)
+    )
+
+    if result.output_bundle_filename:
+        copied.append(
+            copy_output_file(scratch_directory, results_directory, fragment, result.output_bundle_filename)
+        )
+        scratch_base = scratch_directory / fragment
+        bundle_path = scratch_base / ensure_relative_path(result.output_bundle_filename, scratch_base)
+        copied.extend(_copy_output_bundle_files(scratch_directory, results_directory, fragment, bundle_path))
+
+    if result.series_filename:
+        copied.append(
+            copy_output_file(scratch_directory, results_directory, fragment, result.series_filename)
+        )
+
+    return copied

--- a/packages/climate-ref-core/src/climate_ref_core/testing.py
+++ b/packages/climate-ref-core/src/climate_ref_core/testing.py
@@ -30,6 +30,7 @@ from climate_ref_core.datasets import (
 from climate_ref_core.diagnostics import ExecutionDefinition, ExecutionResult
 from climate_ref_core.esgf.base import ESGFRequest
 from climate_ref_core.metric_values.typing import SeriesMetricValue
+from climate_ref_core.output_files import from_placeholders
 from climate_ref_core.pycmec.metric import CMECMetric
 from climate_ref_core.pycmec.output import CMECOutput
 
@@ -639,15 +640,8 @@ class RegressionValidator:
         output_dir.mkdir(parents=True, exist_ok=True)
         shutil.copytree(regression_path, output_dir, dirs_exist_ok=True)
 
-        # Replace placeholders with actual paths
-        for pattern in ("*.json", "*.txt", "*.yaml", "*.yml"):
-            for file in output_dir.rglob(pattern):
-                content = file.read_text()
-                content = content.replace("<OUTPUT_DIR>", str(output_dir))
-                content = content.replace("<TEST_DATA_DIR>", str(self.test_data_dir))
-                file.write_text(content)
+        from_placeholders(output_dir, output_dir=output_dir, test_data_dir=self.test_data_dir)
 
-        # Load datasets from catalog
         datasets: ExecutionDatasetCollection = load_datasets_from_yaml(catalog_path)
 
         return ExecutionDefinition(

--- a/packages/climate-ref-core/tests/unit/test_output_files.py
+++ b/packages/climate-ref-core/tests/unit/test_output_files.py
@@ -1,0 +1,133 @@
+"""Unit tests for :mod:`climate_ref_core.output_files`."""
+
+import pytest
+
+from climate_ref_core.logging import EXECUTION_LOG_FILENAME
+from climate_ref_core.output_files import (
+    PLACEHOLDER_OUTPUT_DIR,
+    PLACEHOLDER_TEST_DATA_DIR,
+    copy_execution_outputs,
+    copy_output_file,
+    from_placeholders,
+    to_placeholders,
+)
+
+
+def test_sanitise_and_expand_round_trip(tmp_path):
+    output_dir = tmp_path / "scratch" / "output"
+    test_data_dir = tmp_path / "test-data"
+    directory = tmp_path / "regression"
+    directory.mkdir()
+
+    original = f"path={output_dir}\ndata={test_data_dir}\n"
+    (directory / "diagnostic.json").write_text(original)
+
+    to_placeholders(directory, output_dir=output_dir, test_data_dir=test_data_dir)
+    sanitised = (directory / "diagnostic.json").read_text()
+    assert str(output_dir) not in sanitised
+    assert str(test_data_dir) not in sanitised
+    assert PLACEHOLDER_OUTPUT_DIR in sanitised
+    assert PLACEHOLDER_TEST_DATA_DIR in sanitised
+
+    from_placeholders(directory, output_dir=output_dir, test_data_dir=test_data_dir)
+    assert (directory / "diagnostic.json").read_text() == original
+
+
+def test_sanitise_only_touches_text_globs(tmp_path):
+    output_dir = tmp_path / "output"
+    test_data_dir = tmp_path / "test-data"
+    directory = tmp_path / "regression"
+    directory.mkdir()
+
+    binary = f"{output_dir}".encode()
+    (directory / "data.nc").write_bytes(binary)
+    (directory / "meta.json").write_text(str(output_dir))
+
+    to_placeholders(directory, output_dir=output_dir, test_data_dir=test_data_dir)
+
+    # Binary file is untouched; JSON is rewritten.
+    assert (directory / "data.nc").read_bytes() == binary
+    assert (directory / "meta.json").read_text() == PLACEHOLDER_OUTPUT_DIR
+
+
+def test_sanitise_longest_match_first(tmp_path):
+    # test_data_dir is a prefix of output_dir; the longer path must win.
+    test_data_dir = tmp_path / "base"
+    output_dir = tmp_path / "base" / "scratch"
+    directory = tmp_path / "regression"
+    directory.mkdir()
+    (directory / "a.json").write_text(str(output_dir))
+
+    to_placeholders(directory, output_dir=output_dir, test_data_dir=test_data_dir)
+
+    assert (directory / "a.json").read_text() == PLACEHOLDER_OUTPUT_DIR
+
+
+@pytest.mark.parametrize("filename", ("bundle.zip", "nested/bundle.zip"))
+def test_copy_output_file_returns_relpath(filename, tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    src = scratch / fragment / filename
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.touch()
+
+    rel = copy_output_file(scratch, results, fragment, filename)
+
+    assert (results / fragment / filename).exists()
+    assert rel.as_posix() == filename
+
+
+def test_copy_output_file_missing_raises(tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    with pytest.raises(FileNotFoundError, match=r"Could not find missing\.json"):
+        copy_output_file(scratch, results, "frag", "missing.json")
+
+
+class _FakeResult:
+    def __init__(self, metric_bundle_filename, output_bundle_filename=None, series_filename=None):
+        self.metric_bundle_filename = metric_bundle_filename
+        self.output_bundle_filename = output_bundle_filename
+        self.series_filename = series_filename
+
+
+def _seed(scratch, fragment, *names):
+    for name in names:
+        path = scratch / fragment / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+
+
+def test_copy_execution_outputs_curated_set(tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    _seed(scratch, fragment, EXECUTION_LOG_FILENAME, "bundle.json", "series.json")
+
+    result = _FakeResult(metric_bundle_filename="bundle.json", series_filename="series.json")
+    copied = copy_execution_outputs(scratch, results, fragment, result, include_log=True)
+
+    names = {p.as_posix() for p in copied}
+    assert names == {EXECUTION_LOG_FILENAME, "bundle.json", "series.json"}
+    for name in names:
+        assert (results / fragment / name).exists()
+
+
+def test_copy_execution_outputs_excludes_log_by_default(tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    _seed(scratch, fragment, "bundle.json")
+
+    result = _FakeResult(metric_bundle_filename="bundle.json")
+    copied = copy_execution_outputs(scratch, results, fragment, result)
+
+    assert [p.as_posix() for p in copied] == ["bundle.json"]
+    assert not (results / fragment / EXECUTION_LOG_FILENAME).exists()
+
+
+def test_copy_execution_outputs_requires_metric_bundle(tmp_path):
+    result = _FakeResult(metric_bundle_filename=None)
+    with pytest.raises(ValueError, match="without a metric bundle"):
+        copy_execution_outputs(tmp_path / "scratch", tmp_path / "results", "frag", result)

--- a/packages/climate-ref-core/tests/unit/test_output_files.py
+++ b/packages/climate-ref-core/tests/unit/test_output_files.py
@@ -11,6 +11,7 @@ from climate_ref_core.output_files import (
     from_placeholders,
     to_placeholders,
 )
+from climate_ref_core.pycmec.output import CMECOutput
 
 
 def test_sanitise_and_expand_round_trip(tmp_path):
@@ -63,6 +64,57 @@ def test_sanitise_longest_match_first(tmp_path):
     assert (directory / "a.json").read_text() == PLACEHOLDER_OUTPUT_DIR
 
 
+@pytest.mark.parametrize("suffix", ("json", "txt", "yaml", "yml", "html", "xml"))
+def test_sanitise_covers_all_text_globs(suffix, tmp_path):
+    output_dir = tmp_path / "output"
+    test_data_dir = tmp_path / "test-data"
+    directory = tmp_path / "regression"
+    directory.mkdir()
+    (directory / f"artefact.{suffix}").write_text(str(output_dir))
+
+    to_placeholders(directory, output_dir=output_dir, test_data_dir=test_data_dir)
+
+    assert (directory / f"artefact.{suffix}").read_text() == PLACEHOLDER_OUTPUT_DIR
+
+
+def test_sanitise_respects_custom_globs(tmp_path):
+    output_dir = tmp_path / "output"
+    test_data_dir = tmp_path / "test-data"
+    directory = tmp_path / "regression"
+    directory.mkdir()
+    (directory / "config.cfg").write_text(str(output_dir))
+    (directory / "skip.json").write_text(str(output_dir))
+
+    to_placeholders(
+        directory,
+        output_dir=output_dir,
+        test_data_dir=test_data_dir,
+        globs=("*.cfg",),
+    )
+
+    # Only the custom glob is rewritten; the default JSON glob is left untouched.
+    assert (directory / "config.cfg").read_text() == PLACEHOLDER_OUTPUT_DIR
+    assert (directory / "skip.json").read_text() == str(output_dir)
+
+
+def test_sanitise_leaves_unmatched_content_untouched(tmp_path):
+    # A text file that contains neither path must be left byte-for-byte identical
+    # (exercises the "no rewrite" branch that skips the write).
+    output_dir = tmp_path / "output"
+    test_data_dir = tmp_path / "test-data"
+    directory = tmp_path / "regression"
+    directory.mkdir()
+    original = "nothing to replace here\n"
+    target = directory / "untouched.json"
+    target.write_text(original)
+    before = target.stat().st_mtime_ns
+
+    to_placeholders(directory, output_dir=output_dir, test_data_dir=test_data_dir)
+
+    assert target.read_text() == original
+    assert target.stat().st_mtime_ns == before
+
+
 @pytest.mark.parametrize("filename", ("bundle.zip", "nested/bundle.zip"))
 def test_copy_output_file_returns_relpath(filename, tmp_path):
     scratch = (tmp_path / "scratch").resolve()
@@ -83,6 +135,27 @@ def test_copy_output_file_missing_raises(tmp_path):
     results = (tmp_path / "results").resolve()
     with pytest.raises(FileNotFoundError, match=r"Could not find missing\.json"):
         copy_output_file(scratch, results, "frag", "missing.json")
+
+
+def test_copy_output_file_accepts_absolute_filename(tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    src = scratch / fragment / "bundle.json"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.touch()
+
+    # An absolute path under scratch/fragment is normalised back to a relative path.
+    rel = copy_output_file(scratch, results, fragment, src)
+
+    assert rel.as_posix() == "bundle.json"
+    assert (results / fragment / "bundle.json").exists()
+
+
+def test_copy_output_file_rejects_identical_directories(tmp_path):
+    same = (tmp_path / "shared").resolve()
+    with pytest.raises(ValueError, match="must differ"):
+        copy_output_file(same, same, "frag", "bundle.json")
 
 
 class _FakeResult:
@@ -131,3 +204,82 @@ def test_copy_execution_outputs_requires_metric_bundle(tmp_path):
     result = _FakeResult(metric_bundle_filename=None)
     with pytest.raises(ValueError, match="without a metric bundle"):
         copy_execution_outputs(tmp_path / "scratch", tmp_path / "results", "frag", result)
+
+
+def _write_output_bundle(scratch, fragment, bundle_filename, referenced):
+    """Seed a CMEC output bundle plus the plots/data/html files it references."""
+    cmec_output = CMECOutput(**CMECOutput.create_template())
+    for attr, short_name, filename in referenced:
+        cmec_output.update(
+            attr,
+            short_name=short_name,
+            dict_content={"long_name": short_name, "filename": filename, "description": ""},
+        )
+        _seed(scratch, fragment, filename)
+    cmec_output.dump_to_json(scratch / fragment / bundle_filename)
+
+
+def test_copy_execution_outputs_includes_output_bundle_and_referenced_files(tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    _seed(scratch, fragment, "bundle.json")
+    _write_output_bundle(
+        scratch,
+        fragment,
+        "output.json",
+        referenced=[
+            ("plots", "fig1", "fig_1.png"),
+            ("plots", "fig2", "nested/fig_2.png"),
+            ("html", "index", "index.html"),
+        ],
+    )
+
+    result = _FakeResult(metric_bundle_filename="bundle.json", output_bundle_filename="output.json")
+    copied = copy_execution_outputs(scratch, results, fragment, result)
+
+    names = {p.as_posix() for p in copied}
+    assert names == {"bundle.json", "output.json", "fig_1.png", "nested/fig_2.png", "index.html"}
+    for name in names:
+        assert (results / fragment / name).exists()
+
+
+def test_copy_execution_outputs_full_curated_set(tmp_path):
+    # Exercises every branch together: log + metric + output bundle (+ referenced) + series.
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    _seed(scratch, fragment, EXECUTION_LOG_FILENAME, "bundle.json", "series.json")
+    _write_output_bundle(scratch, fragment, "output.json", referenced=[("data", "d1", "data_1.nc")])
+
+    result = _FakeResult(
+        metric_bundle_filename="bundle.json",
+        output_bundle_filename="output.json",
+        series_filename="series.json",
+    )
+    copied = copy_execution_outputs(scratch, results, fragment, result, include_log=True)
+
+    names = {p.as_posix() for p in copied}
+    assert names == {
+        EXECUTION_LOG_FILENAME,
+        "bundle.json",
+        "output.json",
+        "data_1.nc",
+        "series.json",
+    }
+    for name in names:
+        assert (results / fragment / name).exists()
+
+
+def test_copy_execution_outputs_empty_output_bundle(tmp_path):
+    # An output bundle that references no files still copies the bundle itself.
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    _seed(scratch, fragment, "bundle.json")
+    _write_output_bundle(scratch, fragment, "output.json", referenced=[])
+
+    result = _FakeResult(metric_bundle_filename="bundle.json", output_bundle_filename="output.json")
+    copied = copy_execution_outputs(scratch, results, fragment, result)
+
+    assert {p.as_posix() for p in copied} == {"bundle.json", "output.json"}

--- a/packages/climate-ref/src/climate_ref/cli/test_cases.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases.py
@@ -25,6 +25,7 @@ from climate_ref_core.exceptions import (
     NoTestDataSpecError,
     TestCaseNotFoundError,
 )
+from climate_ref_core.output_files import to_placeholders
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -578,15 +579,13 @@ def _run_single_test_case(  # noqa: PLR0911, PLR0912, PLR0915
         paths.regression.mkdir(parents=True, exist_ok=True)
         shutil.copytree(result.definition.output_directory, paths.regression, dirs_exist_ok=True)
 
-        # Replace absolute paths with placeholders for portability
-        # We don't touch binary files, only text-based ones
+        # Replace absolute paths with placeholders for portability (text files only).
         # TODO: Symlink regression datasets instead of any paths on users' systems
-        for glob_pattern in ("*.json", "*.txt", "*.yaml", "*.yml"):
-            for file in paths.regression.rglob(glob_pattern):
-                content = file.read_text()
-                content = content.replace(str(result.definition.output_directory), "<OUTPUT_DIR>")
-                content = content.replace(str(paths.test_data_dir), "<TEST_DATA_DIR>")
-                file.write_text(content)
+        to_placeholders(
+            paths.regression,
+            output_dir=result.definition.output_directory,
+            test_data_dir=paths.test_data_dir,
+        )
 
         # Store catalog hash for change detection
         catalog_hash = get_catalog_hash(paths.catalog)

--- a/packages/climate-ref/src/climate_ref/cli/test_cases.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases.py
@@ -579,7 +579,7 @@ def _run_single_test_case(  # noqa: PLR0911, PLR0912, PLR0915
         paths.regression.mkdir(parents=True, exist_ok=True)
         shutil.copytree(result.definition.output_directory, paths.regression, dirs_exist_ok=True)
 
-        # Replace absolute paths with placeholders for portability (text files only).
+        # Replace absolute paths with placeholders for portability
         # TODO: Symlink regression datasets instead of any paths on users' systems
         to_placeholders(
             paths.regression,

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -61,6 +61,7 @@ from climate_ref_core.datasets import DatasetCollection, ExecutionDatasetCollect
 from climate_ref_core.diagnostics import DataRequirement, Diagnostic, ExecutionDefinition, ExecutionResult
 from climate_ref_core.exceptions import TestCaseError
 from climate_ref_core.logging import add_log_handler, remove_log_handler
+from climate_ref_core.output_files import SANITISED_FILE_GLOBS, rewrite_tree
 from climate_ref_core.providers import DiagnosticProvider
 from climate_ref_core.testing import validate_series_regression
 
@@ -432,38 +433,17 @@ class ExecutionRegression:
     request: pytest.FixtureRequest
     replacements: dict[str, str]
 
-    sanitised_file_globs: tuple[str, ...] = (
-        "*.json",
-        "*.txt",
-        "*.yaml",
-        "*.yml",
-        "*.html",
-        "*.xml",
-    )
-
-    def _replace_file(self, file: Path, replacements: dict[str, str]) -> None:
-        with open(file, encoding="utf-8") as f:
-            content = f.read()
-            for key, value in replacements.items():
-                content = content.replace(key, value)
-        with open(file, "w") as f:
-            f.write(content)
-
     def path(self, key: str) -> Path:
         """Return the regression data path for the given key."""
         return self.regression_data_dir / self.diagnostic.provider.slug / self.diagnostic.slug / key
 
     def replace_references(self, output_dir: Path, replacements: dict[str, str]) -> None:
         """Replace any references to local directories with a placeholder."""
-        for glob in self.sanitised_file_globs:
-            for file in output_dir.rglob(glob):
-                self._replace_file(file, replacements)
+        rewrite_tree(output_dir, replacements, SANITISED_FILE_GLOBS)
 
     def hydrate_output_directory(self, output_dir: Path, replacements: dict[str, str]) -> None:
         """Replace any references to the placeholder with the actual output directory."""
-        for glob in self.sanitised_file_globs:
-            for file in output_dir.rglob(glob):
-                self._replace_file(file, replacements)
+        rewrite_tree(output_dir, replacements, SANITISED_FILE_GLOBS)
 
     def output_replacements(self, output_directory: Path) -> dict[str, str]:
         """Map real paths to regression placeholders for a given output directory."""

--- a/packages/climate-ref/src/climate_ref/executor/result_handling.py
+++ b/packages/climate-ref/src/climate_ref/executor/result_handling.py
@@ -10,7 +10,6 @@ This is useful for local testing and debugging.
 """
 
 import pathlib
-import shutil
 from concurrent.futures import Future
 from typing import TYPE_CHECKING
 
@@ -25,6 +24,7 @@ from climate_ref_core.diagnostics import ExecutionDefinition, ExecutionResult, e
 from climate_ref_core.exceptions import ResultValidationError
 from climate_ref_core.logging import EXECUTION_LOG_FILENAME
 from climate_ref_core.metric_values import SeriesMetricValue as TSeries
+from climate_ref_core.output_files import copy_execution_outputs, copy_output_file
 from climate_ref_core.pycmec.controlled_vocabulary import CV
 from climate_ref_core.pycmec.metric import CMECMetric
 from climate_ref_core.pycmec.output import CMECOutput, OutputDict
@@ -85,41 +85,6 @@ def mark_execution_failed(
             process_result(config, database, failure_result, execution)
     except Exception:
         logger.exception(f"Failed to record failure for {definition.execution_slug()!r}")
-
-
-def _copy_file_to_results(
-    scratch_directory: pathlib.Path,
-    results_directory: pathlib.Path,
-    fragment: pathlib.Path | str,
-    filename: pathlib.Path | str,
-) -> None:
-    """
-    Copy a file from the scratch directory to the executions directory
-
-    Parameters
-    ----------
-    scratch_directory
-        The directory where the file is currently located
-    results_directory
-        The directory where the file should be copied to
-    fragment
-        The fragment of the executions directory where the file should be copied
-    filename
-        The name of the file to be copied
-    """
-    assert results_directory != scratch_directory
-    input_directory = scratch_directory / fragment
-    output_directory = results_directory / fragment
-
-    filename = ensure_relative_path(filename, input_directory)
-
-    if not (input_directory / filename).exists():
-        raise FileNotFoundError(f"Could not find {filename} in {input_directory}")
-
-    output_filename = output_directory / filename
-    output_filename.parent.mkdir(parents=True, exist_ok=True)
-
-    shutil.copy(input_directory / filename, output_filename)
 
 
 def ingest_scalar_values(
@@ -372,7 +337,7 @@ def handle_execution_result(
     """
     # Always copy log data to the results directory
     try:
-        _copy_file_to_results(
+        copy_output_file(
             config.paths.scratch,
             config.paths.results,
             execution.output_fragment,
@@ -401,33 +366,15 @@ def handle_execution_result(
 
     logger.info(f"{execution} successful")
 
-    _copy_file_to_results(
+    # Copy the curated persisted output subset (metric bundle, output bundle and the
+    # files it references, series) from scratch to results. This is the same code path
+    # regression capture reuses, so the captured set cannot diverge from production.
+    copy_execution_outputs(
         config.paths.scratch,
         config.paths.results,
         execution.output_fragment,
-        result.metric_bundle_filename,
+        result,
     )
-
-    if result.output_bundle_filename:
-        _copy_file_to_results(
-            config.paths.scratch,
-            config.paths.results,
-            execution.output_fragment,
-            result.output_bundle_filename,
-        )
-        _copy_output_bundle_files(
-            config,
-            execution,
-            result.to_output_path(result.output_bundle_filename),
-        )
-
-    if result.series_filename:
-        _copy_file_to_results(
-            config.paths.scratch,
-            config.paths.results,
-            execution.output_fragment,
-            result.series_filename,
-        )
 
     # Ingest outputs and metrics into the database via the shared ingestion path
     cv = CV.load_from_file(config.paths.dimensions_cv)
@@ -451,23 +398,3 @@ def handle_execution_result(
 
     # Finally, mark the execution as successful
     execution.mark_successful(result.as_relative_path(result.metric_bundle_filename))
-
-
-def _copy_output_bundle_files(
-    config: "Config",
-    execution: Execution,
-    cmec_output_bundle_filename: pathlib.Path,
-) -> None:
-    """Copy output bundle referenced files (plots, data, html) from scratch to results."""
-    cmec_output_bundle = CMECOutput.load_from_json(cmec_output_bundle_filename)
-    scratch_base = config.paths.scratch / execution.output_fragment
-
-    for attr in ("plots", "data", "html"):
-        for output_info in (getattr(cmec_output_bundle, attr) or {}).values():
-            filename = ensure_relative_path(output_info.filename, scratch_base)
-            _copy_file_to_results(
-                config.paths.scratch,
-                config.paths.results,
-                execution.output_fragment,
-                filename,
-            )

--- a/packages/climate-ref/src/climate_ref/executor/result_handling.py
+++ b/packages/climate-ref/src/climate_ref/executor/result_handling.py
@@ -366,9 +366,13 @@ def handle_execution_result(
 
     logger.info(f"{execution} successful")
 
-    # Copy the curated persisted output subset (metric bundle, output bundle and the
-    # files it references, series) from scratch to results. This is the same code path
-    # regression capture reuses, so the captured set cannot diverge from production.
+    # Copy the curated subset of outputs that REF persists for a successful execution
+    # (metric bundle, output bundle and the files it references, series)
+    # from scratch to results.
+    # Only the files in results are served by the API.
+    #
+    # Regression capture currently snapshots the whole output directory rather than this curated subset,
+    # so the committed baseline is a superset of what production persists.
     copy_execution_outputs(
         config.paths.scratch,
         config.paths.results,

--- a/packages/climate-ref/tests/unit/executor/test_result_handling.py
+++ b/packages/climate-ref/tests/unit/executor/test_result_handling.py
@@ -128,8 +128,7 @@ def test_handle_execution_result_with_series(
 
     handle_execution_result(config, db, mock_execution_result, result)
 
-    # The log is copied directly (health check); the curated set (metric, series, ...)
-    # is delegated to copy_execution_outputs.
+    # The log is copied directly
     mock_copy.assert_called_once_with(
         config.paths.scratch,
         config.paths.results,

--- a/packages/climate-ref/tests/unit/executor/test_result_handling.py
+++ b/packages/climate-ref/tests/unit/executor/test_result_handling.py
@@ -7,7 +7,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from climate_ref.executor.result_handling import (
-    _copy_file_to_results,
     handle_execution_result,
     ingest_execution_result,
     ingest_scalar_values,
@@ -27,6 +26,7 @@ from climate_ref.models.provider import Provider as ProviderModel
 from climate_ref_core.diagnostics import ExecutionResult
 from climate_ref_core.logging import EXECUTION_LOG_FILENAME
 from climate_ref_core.metric_values import SeriesMetricValue as TSeries
+from climate_ref_core.output_files import copy_output_file
 from climate_ref_core.pycmec.controlled_vocabulary import CV
 from climate_ref_core.pycmec.metric import CMECMetric
 from climate_ref_core.pycmec.output import CMECOutput
@@ -67,21 +67,24 @@ def test_handle_execution_result_successful(
         mock_definition.to_output_path(metric_bundle_filename),
     )
 
-    mock_copy = mocker.patch("climate_ref.executor.result_handling._copy_file_to_results")
+    mock_copy = mocker.patch("climate_ref.executor.result_handling.copy_output_file")
+    mock_curate = mocker.patch("climate_ref.executor.result_handling.copy_execution_outputs")
 
     handle_execution_result(config, db, mock_execution_result, result)
 
-    mock_copy.assert_any_call(
+    # The log is copied directly (health check); the curated output set is delegated
+    # to copy_execution_outputs (which file lands where is covered by test_output_files).
+    mock_copy.assert_called_once_with(
         config.paths.scratch,
         config.paths.results,
         mock_execution_result.output_fragment,
         EXECUTION_LOG_FILENAME,
     )
-    mock_copy.assert_called_with(
+    mock_curate.assert_called_once_with(
         config.paths.scratch,
         config.paths.results,
         mock_execution_result.output_fragment,
-        metric_bundle_filename,
+        result,
     )
     mock_execution_result.mark_successful.assert_called_once_with(metric_bundle_filename)
     assert not mock_execution_result.execution_group.dirty
@@ -120,27 +123,24 @@ def test_handle_execution_result_with_series(
     ]
     TSeries.dump_to_json(mock_definition.to_output_path(series_filename), series_data)
 
-    mock_copy = mocker.patch("climate_ref.executor.result_handling._copy_file_to_results")
+    mock_copy = mocker.patch("climate_ref.executor.result_handling.copy_output_file")
+    mock_curate = mocker.patch("climate_ref.executor.result_handling.copy_execution_outputs")
 
     handle_execution_result(config, db, mock_execution_result, result)
 
-    mock_copy.assert_any_call(
+    # The log is copied directly (health check); the curated set (metric, series, ...)
+    # is delegated to copy_execution_outputs.
+    mock_copy.assert_called_once_with(
         config.paths.scratch,
         config.paths.results,
         mock_execution_result.output_fragment,
         EXECUTION_LOG_FILENAME,
     )
-    mock_copy.assert_any_call(
+    mock_curate.assert_called_once_with(
         config.paths.scratch,
         config.paths.results,
         mock_execution_result.output_fragment,
-        metric_bundle_filename,
-    )
-    mock_copy.assert_called_with(
-        config.paths.scratch,
-        config.paths.results,
-        mock_execution_result.output_fragment,
-        series_filename,
+        result,
     )
     mock_execution_result.mark_successful.assert_called_once_with(metric_bundle_filename)
     assert not mock_execution_result.execution_group.dirty
@@ -289,9 +289,9 @@ def test_copy_file_to_results_success(filename, is_relative, tmp_path):
     scratch_filename.touch()
 
     if is_relative:
-        _copy_file_to_results(scratch_directory, results_directory, fragment, filename)
+        copy_output_file(scratch_directory, results_directory, fragment, filename)
     else:
-        _copy_file_to_results(
+        copy_output_file(
             scratch_directory, results_directory, fragment, scratch_directory / fragment / filename
         )
 
@@ -309,7 +309,7 @@ def test_copy_file_to_results_file_not_found(mocker):
     with pytest.raises(
         FileNotFoundError, match=f"Could not find {filename} in {scratch_directory / fragment}"
     ):
-        _copy_file_to_results(scratch_directory, results_directory, fragment, filename)
+        copy_output_file(scratch_directory, results_directory, fragment, filename)
 
 
 SAMPLE_SERIES = [


### PR DESCRIPTION
## Description

Extract the curated scratch->results output copy out of `handle_execution_result` into a pure, reusable function, and implement forwards/backwards path-sanitisationin in a new `climate_ref_core.output_files` module.


## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
