### PR TITLE
feat(core): native regression-baseline primitives

### DIFF
--- a/changelog/720.trivial.md
+++ b/changelog/720.trivial.md
@@ -1,0 +1,1 @@
+Added the `climate_ref_core.regression` package — the internal building blocks (manifest, content-addressed native store, tolerant bundle comparison, and execution capture) for the upcoming object-store-backed regression baselines. Not yet wired into any user-facing command.

--- a/packages/climate-ref-core/src/climate_ref_core/output_files.py
+++ b/packages/climate-ref-core/src/climate_ref_core/output_files.py
@@ -52,6 +52,25 @@ Binary outputs (``.nc``, ``.png``, ...) are never rewritten.
 """
 
 
+def ordered_replacements(replacements: dict[str, str]) -> list[tuple[str, str]]:
+    """Order ``replacements`` longest-key-first.
+
+    This is the canonical replacement ordering for all sanitisation:
+    an overlapping shorter key cannot partially shadow a longer one.
+
+    Parameters
+    ----------
+    replacements
+        Mapping of substring to replacement.
+
+    Returns
+    -------
+    :
+        The ``(old, new)`` pairs ordered longest-``old``-first.
+    """
+    return sorted(replacements.items(), key=lambda kv: len(kv[0]), reverse=True)
+
+
 def rewrite_tree(
     directory: Path,
     replacements: dict[str, str],
@@ -72,7 +91,7 @@ def rewrite_tree(
     globs
         File globs whose contents are rewritten.
     """
-    ordered = sorted(replacements.items(), key=lambda kv: len(kv[0]), reverse=True)
+    ordered = ordered_replacements(replacements)
     for glob in globs:
         for file in sorted(directory.rglob(glob)):
             text = file.read_text(encoding="utf-8")

--- a/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
@@ -1,20 +1,14 @@
 """
-Regression-baseline primitives for diagnostic test cases (RFC 0005).
+Regression-baseline primitives for diagnostic test cases.
 
-This package holds the building blocks for the two-bundle regression model:
+This package holds the building blocks for the two-bundle regression model,
+where we capture and commit a small, sanitised **committed bundle** of artefacts for a test case.
+These committed bundles are tracked in git and form the regression baseline for the test case.
 
-- :mod:`~climate_ref_core.regression.manifest` — the ``manifest.json`` model and
-  sha256 digest helpers coupling a committed bundle to its native outputs.
-- :mod:`~climate_ref_core.regression.store` — the content-addressed ``NativeStore``
-  Protocol and its local / public-read implementations.
-- :mod:`~climate_ref_core.regression.compare` — the tolerant JSON comparator used
-  to gate committed bundles.
-- :mod:`~climate_ref_core.regression.capture` — capture of a committed bundle and a
-  native snapshot, built on :func:`climate_ref_core.output_files.copy_execution_outputs`
-  so the captured set is exactly what production persists.
-
-These primitives are pure: they take plain paths and data, with no dependency on the
-application ``Config`` or database. The ``ref test-cases`` CLI wires them together.
+We also snapshot the native files persisted by the execution.
+These files are typically large and not always portable,
+so we keep them out of git and refer to them by their sha256 digest in the committed bundle.
+These data will be able to be fetched from an object store in CI and replayed locally for debugging.
 """
 
 from climate_ref_core.regression.capture import (

--- a/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
@@ -18,11 +18,9 @@ from climate_ref_core.regression.capture import (
     write_committed_bundle,
 )
 from climate_ref_core.regression.compare import (
-    DEFAULT_TOLERANCE,
     Tolerance,
     assert_bundle_regression,
     compare_json_content,
-    resolve_tolerance,
 )
 from climate_ref_core.regression.manifest import (
     SCHEMA_VERSION,
@@ -42,7 +40,6 @@ from climate_ref_core.regression.store import (
 )
 
 __all__ = [
-    "DEFAULT_TOLERANCE",
     "SCHEMA_VERSION",
     "LocalFilesystemStore",
     "Manifest",
@@ -58,7 +55,6 @@ __all__ = [
     "compare_json_content",
     "compute_committed_digests",
     "materialise_native",
-    "resolve_tolerance",
     "sha256_bytes",
     "sha256_file",
     "verify_committed_integrity",

--- a/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
@@ -1,0 +1,72 @@
+"""
+Regression-baseline primitives for diagnostic test cases (RFC 0005).
+
+This package holds the building blocks for the two-bundle regression model:
+
+- :mod:`~climate_ref_core.regression.manifest` — the ``manifest.json`` model and
+  sha256 digest helpers coupling a committed bundle to its native outputs.
+- :mod:`~climate_ref_core.regression.store` — the content-addressed ``NativeStore``
+  Protocol and its local / public-read implementations.
+- :mod:`~climate_ref_core.regression.compare` — the tolerant JSON comparator used
+  to gate committed bundles.
+- :mod:`~climate_ref_core.regression.capture` — capture of a committed bundle and a
+  native snapshot, built on :func:`climate_ref_core.output_files.copy_execution_outputs`
+  so the captured set is exactly what production persists.
+
+These primitives are pure: they take plain paths and data, with no dependency on the
+application ``Config`` or database. The ``ref test-cases`` CLI wires them together.
+"""
+
+from climate_ref_core.regression.capture import (
+    build_native_snapshot,
+    capture_execution,
+    materialise_native,
+    write_committed_bundle,
+)
+from climate_ref_core.regression.compare import (
+    DEFAULT_TOLERANCE,
+    Tolerance,
+    assert_bundle_regression,
+    compare_json_content,
+    resolve_tolerance,
+)
+from climate_ref_core.regression.manifest import (
+    SCHEMA_VERSION,
+    Manifest,
+    NativeEntry,
+    compute_committed_digests,
+    sha256_bytes,
+    sha256_file,
+    verify_committed_integrity,
+)
+from climate_ref_core.regression.store import (
+    LocalFilesystemStore,
+    NativeStore,
+    PoochReadStore,
+    R2WriteStore,
+    build_native_store,
+)
+
+__all__ = [
+    "DEFAULT_TOLERANCE",
+    "SCHEMA_VERSION",
+    "LocalFilesystemStore",
+    "Manifest",
+    "NativeEntry",
+    "NativeStore",
+    "PoochReadStore",
+    "R2WriteStore",
+    "Tolerance",
+    "assert_bundle_regression",
+    "build_native_snapshot",
+    "build_native_store",
+    "capture_execution",
+    "compare_json_content",
+    "compute_committed_digests",
+    "materialise_native",
+    "resolve_tolerance",
+    "sha256_bytes",
+    "sha256_file",
+    "verify_committed_integrity",
+    "write_committed_bundle",
+]

--- a/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
@@ -1,16 +1,19 @@
 """
 Capture of regression baselines from a diagnostic execution.
 
-Capture reuses :func:`climate_ref_core.output_files.copy_execution_outputs` — the
-exact code path production uses to persist a successful execution — so the captured
-native set is, by construction, identical to what REF actually persists (no drift,
-no separate "what counts as output" heuristic).
+Capture reuses :func:`climate_ref_core.output_files.copy_execution_outputs`,
+so the captured native set is identical to what REF actually persists when handling an execution.
+
+Note that this is not the raw output from an execution (the "scratch" directory),
+but the curated subset of files copied into the "results" directory for persistence and comparison.
+This avoids the need to maintain a separate ignore list for regression captures.
 
 It produces two things:
 
-- the small **committed bundle** (``series.json`` / ``diagnostic.json`` /
-  ``output.json``) written into the test case ``regression/`` directory, sanitised
-  text-only for portability and tracked in git, and
+- the small **committed bundle**
+  (``series.json`` / ``diagnostic.json`` / ``output.json``)
+  written into the test case ``regression/`` directory,
+  sanitised text-only for portability and tracked in git
 - a **native snapshot**: a ``{relpath: NativeEntry}`` map recording the sha256 digest
   and size of every persisted native file, for the manifest and the object store.
 """
@@ -23,6 +26,7 @@ from typing import TYPE_CHECKING
 
 from climate_ref_core.output_files import copy_execution_outputs, to_placeholders
 from climate_ref_core.regression.manifest import (
+    COMMITTED_BUNDLE_FILES,
     NativeEntry,
     compute_committed_digests,
     sha256_file,
@@ -31,9 +35,6 @@ from climate_ref_core.regression.manifest import (
 if TYPE_CHECKING:
     from climate_ref_core.diagnostics import ExecutionResult
     from climate_ref_core.regression.store import NativeStore
-
-COMMITTED_BUNDLE_FILES: tuple[str, ...] = ("series.json", "diagnostic.json", "output.json")
-"""The committed CMEC artefacts tracked in git (the human-reviewable diff signal)."""
 
 
 def write_committed_bundle(
@@ -48,8 +49,8 @@ def write_committed_bundle(
 
     Copies each committed artefact present in ``source_dir`` into ``regression_dir``,
     then rewrites absolute paths to portable placeholders in place
-    (:func:`~climate_ref_core.output_files.to_placeholders`). Missing source files
-    are skipped.
+    (:func:`~climate_ref_core.output_files.to_placeholders`).
+    Missing source files are skipped.
 
     Parameters
     ----------
@@ -113,15 +114,16 @@ def capture_execution(  # noqa: PLR0913
     regression_dir: Path,
     output_dir: Path,
     test_data_dir: Path,
-    include_log: bool = True,
+    # TODO: Unify the log handling
+    include_log: bool = False,
 ) -> tuple[dict[str, str], dict[str, NativeEntry]]:
     """
     Persist a successful execution and capture its committed bundle + native snapshot.
 
     Copies the curated output set from scratch to results via
-    :func:`~climate_ref_core.output_files.copy_execution_outputs` (the production
-    persistence path), then writes the committed bundle and snapshots every
-    persisted native file.
+    :func:`~climate_ref_core.output_files.copy_execution_outputs`
+    (the production persistence path),
+    then writes the committed bundle and snapshots every persisted native file.
 
     Parameters
     ----------
@@ -141,6 +143,9 @@ def capture_execution(  # noqa: PLR0913
         The absolute provider test-data directory, for path substitution.
     include_log
         If True, the execution log is included in the persisted/native set.
+
+        Defaults to False, matching the behaviour of
+        :func:`~climate_ref_core.output_files.copy_execution_outputs`.
 
     Returns
     -------

--- a/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
@@ -50,7 +50,8 @@ def write_committed_bundle(
     Copies each committed artefact present in ``source_dir`` into ``regression_dir``,
     then rewrites absolute paths to portable placeholders in place
     (:func:`~climate_ref_core.output_files.to_placeholders`).
-    Missing source files are skipped.
+    When a committed artefact is absent from ``source_dir``,
+    any stale copy left in ``regression_dir`` from a previous capture is removed so it is not re-digested.
 
     Parameters
     ----------
@@ -74,8 +75,12 @@ def write_committed_bundle(
 
     for filename in COMMITTED_BUNDLE_FILES:
         source = source_dir / filename
+        dest = regression_dir / filename
         if source.exists():
-            shutil.copy(source, regression_dir / filename)
+            shutil.copy(source, dest)
+        else:
+            # Drop a stale copy from a previous capture so it is not re-digested.
+            dest.unlink(missing_ok=True)
 
     to_placeholders(regression_dir, output_dir=output_dir, test_data_dir=test_data_dir)
     return compute_committed_digests(regression_dir)

--- a/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
@@ -1,0 +1,187 @@
+"""
+Capture of regression baselines from a diagnostic execution.
+
+Capture reuses :func:`climate_ref_core.output_files.copy_execution_outputs` — the
+exact code path production uses to persist a successful execution — so the captured
+native set is, by construction, identical to what REF actually persists (no drift,
+no separate "what counts as output" heuristic).
+
+It produces two things:
+
+- the small **committed bundle** (``series.json`` / ``diagnostic.json`` /
+  ``output.json``) written into the test case ``regression/`` directory, sanitised
+  text-only for portability and tracked in git, and
+- a **native snapshot**: a ``{relpath: NativeEntry}`` map recording the sha256 digest
+  and size of every persisted native file, for the manifest and the object store.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from climate_ref_core.output_files import copy_execution_outputs, to_placeholders
+from climate_ref_core.regression.manifest import (
+    NativeEntry,
+    compute_committed_digests,
+    sha256_file,
+)
+
+if TYPE_CHECKING:
+    from climate_ref_core.diagnostics import ExecutionResult
+    from climate_ref_core.regression.store import NativeStore
+
+COMMITTED_BUNDLE_FILES: tuple[str, ...] = ("series.json", "diagnostic.json", "output.json")
+"""The committed CMEC artefacts tracked in git (the human-reviewable diff signal)."""
+
+
+def write_committed_bundle(
+    source_dir: Path,
+    regression_dir: Path,
+    *,
+    output_dir: Path,
+    test_data_dir: Path,
+) -> dict[str, str]:
+    """
+    Write the sanitised committed CMEC bundle into ``regression_dir``.
+
+    Copies each committed artefact present in ``source_dir`` into ``regression_dir``,
+    then rewrites absolute paths to portable placeholders in place
+    (:func:`~climate_ref_core.output_files.to_placeholders`). Missing source files
+    are skipped.
+
+    Parameters
+    ----------
+    source_dir
+        Directory holding the freshly persisted CMEC artefacts (the per-execution
+        results directory).
+    regression_dir
+        The destination ``regression/`` directory (created if needed).
+    output_dir
+        The absolute execution output directory, for path substitution.
+    test_data_dir
+        The absolute provider test-data directory, for path substitution.
+
+    Returns
+    -------
+    :
+        The committed digests ``{filename: sha256}`` of the bytes just written,
+        suitable for :attr:`Manifest.committed`.
+    """
+    regression_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename in COMMITTED_BUNDLE_FILES:
+        source = source_dir / filename
+        if source.exists():
+            shutil.copy(source, regression_dir / filename)
+
+    to_placeholders(regression_dir, output_dir=output_dir, test_data_dir=test_data_dir)
+    return compute_committed_digests(regression_dir)
+
+
+def build_native_snapshot(base_dir: Path, relpaths: list[Path]) -> dict[str, NativeEntry]:
+    """
+    Record a sha256 + size snapshot of each persisted native file.
+
+    Parameters
+    ----------
+    base_dir
+        The per-execution results directory the relpaths are resolved against.
+    relpaths
+        The persisted files (relative to ``base_dir``), e.g. the return value of
+        :func:`~climate_ref_core.output_files.copy_execution_outputs`.
+
+    Returns
+    -------
+    :
+        Mapping of POSIX relpath -> :class:`NativeEntry` for every persisted file.
+    """
+    entries: dict[str, NativeEntry] = {}
+    for relpath in relpaths:
+        path = base_dir / relpath
+        entries[relpath.as_posix()] = NativeEntry(sha256=sha256_file(path), size=path.stat().st_size)
+    return entries
+
+
+def capture_execution(  # noqa: PLR0913
+    scratch_directory: Path,
+    results_directory: Path,
+    fragment: Path | str,
+    result: ExecutionResult,
+    *,
+    regression_dir: Path,
+    output_dir: Path,
+    test_data_dir: Path,
+    include_log: bool = True,
+) -> tuple[dict[str, str], dict[str, NativeEntry]]:
+    """
+    Persist a successful execution and capture its committed bundle + native snapshot.
+
+    Copies the curated output set from scratch to results via
+    :func:`~climate_ref_core.output_files.copy_execution_outputs` (the production
+    persistence path), then writes the committed bundle and snapshots every
+    persisted native file.
+
+    Parameters
+    ----------
+    scratch_directory
+        Base scratch directory the diagnostic wrote into.
+    results_directory
+        Base results directory to persist the curated subset into.
+    fragment
+        The per-execution fragment under both base directories.
+    result
+        The successful execution result (must carry a metric bundle filename).
+    regression_dir
+        The test case ``regression/`` directory for the committed bundle.
+    output_dir
+        The absolute execution output directory, for path substitution.
+    test_data_dir
+        The absolute provider test-data directory, for path substitution.
+    include_log
+        If True, the execution log is included in the persisted/native set.
+
+    Returns
+    -------
+    :
+        A ``(committed_digests, native_snapshot)`` tuple.
+    """
+    relpaths = copy_execution_outputs(
+        scratch_directory,
+        results_directory,
+        fragment,
+        result,
+        include_log=include_log,
+    )
+    base_dir = results_directory / fragment
+    committed = write_committed_bundle(
+        base_dir,
+        regression_dir,
+        output_dir=output_dir,
+        test_data_dir=test_data_dir,
+    )
+    native = build_native_snapshot(base_dir, relpaths)
+    return committed, native
+
+
+def materialise_native(native: dict[str, NativeEntry], store: NativeStore, dest: Path) -> None:
+    """
+    Materialise a native snapshot from a store into a destination directory.
+
+    For each ``(relpath, entry)`` the blob is fetched from ``store`` (keyed by its
+    sha256 digest) to ``dest / relpath``, creating parent directories as needed.
+
+    Parameters
+    ----------
+    native
+        Mapping of relpath -> :class:`NativeEntry` (from a manifest).
+    store
+        A content-addressed :class:`~climate_ref_core.regression.store.NativeStore`.
+    dest
+        The destination directory the snapshot is materialised into.
+    """
+    for relpath, entry in native.items():
+        target = dest / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        store.fetch(entry.sha256, target)

--- a/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
@@ -2,8 +2,6 @@
 Content comparison utilities for regression testing.
 """
 
-from __future__ import annotations
-
 import json
 import math
 from pathlib import Path

--- a/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
@@ -33,34 +33,6 @@ class Tolerance:
     atol: float = 0.0
 
 
-DEFAULT_TOLERANCE = Tolerance()
-"""Global default tolerance applied when no per-case override is configured."""
-
-
-def resolve_tolerance(diagnostic_slug: str, test_case: str | None = None) -> Tolerance:
-    """
-    Resolve the effective float tolerance for a diagnostic / test-case pair.
-
-    Currently returns :data:`DEFAULT_TOLERANCE` for all inputs.
-    Per-case overrides may be wired in future by consulting a ``TestCase.tolerances``
-    mapping (see the plan's "Tolerance config surface" note); this function is the
-    single call-site to update when that happens.
-
-    Parameters
-    ----------
-    diagnostic_slug
-        The diagnostic slug (e.g. ``"global-mean-timeseries"``).
-    test_case
-        Optional test-case name for per-case overrides.
-
-    Returns
-    -------
-    :
-        The resolved :class:`Tolerance` to use for comparisons.
-    """
-    return DEFAULT_TOLERANCE
-
-
 def _rewrite_keys_and_values(obj: Any, replacements: list[tuple[str, str]]) -> Any:
     """
     Recursively rewrite both dict *keys* and leaf string *values* in ``obj``.
@@ -230,7 +202,7 @@ def assert_bundle_regression(
     actual_path: Path,
     *,
     slug: str,
-    tol: Tolerance,
+    tol: Tolerance = Tolerance(),
     replacements: dict[str, str],
 ) -> None:
     """

--- a/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
@@ -160,7 +160,8 @@ def _compare_recursive(
             out.append(f"{label}: missing keys {sorted(missing)!r}")
         if extra:
             out.append(f"{label}: unexpected extra keys {sorted(extra)!r}")
-        for key in expected_keys & actual_keys:
+        # Sort shared keys for deterministic mismatch ordering across runs.
+        for key in sorted(expected_keys & actual_keys):
             child_path = f"{path}.{key}" if path else str(key)
             _compare_recursive(expected[key], actual[key], tol=tol, path=child_path, out=out)
 
@@ -247,8 +248,11 @@ def assert_bundle_regression(
     ------
     AssertionError
         If the bundles differ beyond tolerance after sanitisation.
-    FileNotFoundError
-        If ``expected_path`` does not exist (legacy regression without committed bundle).
+
+    Notes
+    -----
+    If ``expected_path`` does not exist (a legacy regression without a committed bundle),
+    the comparison is skipped silently and the function returns.
     """
     if not expected_path.exists():
         # Legacy regression data without this bundle file — skip silently

--- a/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
@@ -1,17 +1,5 @@
 """
-Tolerant content comparator for committed regression bundles.
-
-Key design points:
-
-- ``compare_json_content`` recurses through parsed JSON,
-  comparing floats with relative/absolute tolerance and all other scalars exactly.
-  It returns a *list* of human-readable mismatch descriptions with JSON-path
-  precision so failures are immediately actionable.
-- ``assert_bundle_regression`` handles the byte-equal fast path,
-  placeholder sanitisation of both dict *keys* and leaf string *values*,
-  and raises ``AssertionError`` with the mismatch list on divergence.
-- ``resolve_tolerance`` merges the global default with any per-case override
-  stored in a ``TestCase.tolerances`` mapping.
+Content comparison utilities for regression testing.
 """
 
 from __future__ import annotations
@@ -22,6 +10,8 @@ from pathlib import Path
 from typing import Any
 
 from attrs import frozen
+
+from climate_ref_core.output_files import ordered_replacements
 
 
 @frozen
@@ -158,7 +148,7 @@ def compare_json_content(
         An empty list means the values are equivalent within tolerance.
     """
     mismatches: list[str] = []
-    _compare_recursive(expected, actual, tol=tol, path=path or "<root>", out=mismatches)
+    _compare_recursive(expected, actual, tol=tol, path=path, out=mismatches)
     return mismatches
 
 
@@ -170,20 +160,26 @@ def _compare_recursive(
     path: str,
     out: list[str],
 ) -> None:
-    """Recursive helper; appends to ``out``."""
+    """Recursive helper; appends to ``out``.
+
+    ``path`` is empty at the top level; ``label`` substitutes ``<root>`` in messages
+    so top-level keys render bare (``key``) while a root-level scalar/type mismatch
+    is still identifiable.
+    """
+    label = path or "<root>"
     # Type mismatch (treat int/float as numeric together)
     if type(expected) is not type(actual):
         if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
-            _compare_numeric(float(expected), float(actual), tol=tol, path=path, out=out)
+            _compare_numeric(float(expected), float(actual), tol=tol, path=label, out=out)
             return
         out.append(
-            f"{path}: type mismatch — expected {type(expected).__name__} ({expected!r}), "
+            f"{label}: type mismatch — expected {type(expected).__name__} ({expected!r}), "
             f"got {type(actual).__name__} ({actual!r})"
         )
         return
 
     if isinstance(expected, float):
-        _compare_numeric(expected, actual, tol=tol, path=path, out=out)
+        _compare_numeric(expected, actual, tol=tol, path=label, out=out)
 
     elif isinstance(expected, dict):
         expected_keys = set(expected.keys())
@@ -191,23 +187,23 @@ def _compare_recursive(
         missing = expected_keys - actual_keys
         extra = actual_keys - expected_keys
         if missing:
-            out.append(f"{path}: missing keys {sorted(missing)!r}")
+            out.append(f"{label}: missing keys {sorted(missing)!r}")
         if extra:
-            out.append(f"{path}: unexpected extra keys {sorted(extra)!r}")
+            out.append(f"{label}: unexpected extra keys {sorted(extra)!r}")
         for key in expected_keys & actual_keys:
             child_path = f"{path}.{key}" if path else str(key)
             _compare_recursive(expected[key], actual[key], tol=tol, path=child_path, out=out)
 
     elif isinstance(expected, list):
         if len(expected) != len(actual):
-            out.append(f"{path}: length mismatch — expected {len(expected)}, got {len(actual)}")
+            out.append(f"{label}: length mismatch — expected {len(expected)}, got {len(actual)}")
         # Compare the common prefix so partial mismatches are visible.
         for i, (e, a) in enumerate(zip(expected, actual)):
             _compare_recursive(e, a, tol=tol, path=f"{path}[{i}]", out=out)
 
     # int, bool, str, None — exact equality
     elif expected != actual:
-        out.append(f"{path}: expected {expected!r}, got {actual!r}")
+        out.append(f"{label}: expected {expected!r}, got {actual!r}")
 
 
 def _compare_numeric(
@@ -255,6 +251,11 @@ def assert_bundle_regression(
     infrastructure: keys are real runtime values (absolute paths, recipe-dir
     timestamps), values are the committed-bundle placeholders (e.g.
     ``"<OUTPUT_DIR>"``, ``"<TEST_DATA_DIR>"``, ``"<RECIPE_RUN>"``).
+    Only the *actual* document is rewritten: the committed *expected* file is
+    assumed to already contain placeholders, which
+    :func:`~climate_ref_core.regression.capture.write_committed_bundle` guarantees
+    at capture time. A hand-edited baseline with raw paths will surface as ordinary
+    value mismatches.
 
     Both ``<OUTPUT_DIR>`` and ``<RECIPE_RUN>`` participate in dict-KEY rewriting
     because ESMValTool's ``output.json`` embeds absolute paths as object keys.
@@ -280,8 +281,7 @@ def assert_bundle_regression(
         If ``expected_path`` does not exist (legacy regression without committed bundle).
     """
     if not expected_path.exists():
-        # Legacy regression data without this bundle file — skip silently,
-        # matching the behaviour of validate_series_regression.
+        # Legacy regression data without this bundle file — skip silently
         return
 
     expected_bytes = expected_path.read_bytes()
@@ -294,11 +294,8 @@ def assert_bundle_regression(
     expected_obj = json.loads(expected_bytes.decode("utf-8"))
     actual_obj = json.loads(actual_bytes.decode("utf-8"))
 
-    # Build ordered replacement list: longest real-value string first.
-    ordered = sorted(replacements.items(), key=lambda kv: len(kv[0]), reverse=True)
-
     # Rewrite actual — both keys and leaf values — before comparison.
-    actual_sanitised = _rewrite_keys_and_values(actual_obj, ordered)
+    actual_sanitised = _rewrite_keys_and_values(actual_obj, ordered_replacements(replacements))
 
     mismatches = compare_json_content(expected_obj, actual_sanitised, tol=tol)
     if mismatches:

--- a/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/compare.py
@@ -1,0 +1,313 @@
+"""
+Tolerant content comparator for committed regression bundles.
+
+Key design points:
+
+- ``compare_json_content`` recurses through parsed JSON,
+  comparing floats with relative/absolute tolerance and all other scalars exactly.
+  It returns a *list* of human-readable mismatch descriptions with JSON-path
+  precision so failures are immediately actionable.
+- ``assert_bundle_regression`` handles the byte-equal fast path,
+  placeholder sanitisation of both dict *keys* and leaf string *values*,
+  and raises ``AssertionError`` with the mismatch list on divergence.
+- ``resolve_tolerance`` merges the global default with any per-case override
+  stored in a ``TestCase.tolerances`` mapping.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from attrs import frozen
+
+
+@frozen
+class Tolerance:
+    """
+    Float comparison tolerance for bundle regression checks.
+
+    Parameters
+    ----------
+    rtol
+        Relative tolerance — the allowed proportional difference between expected
+        and actual float values (default ``1e-6``).
+    atol
+        Absolute tolerance — the minimum absolute difference that can ever be
+        flagged, regardless of magnitude (default ``0.0``).
+    """
+
+    rtol: float = 1e-6
+    atol: float = 0.0
+
+
+DEFAULT_TOLERANCE = Tolerance()
+"""Global default tolerance applied when no per-case override is configured."""
+
+
+def resolve_tolerance(diagnostic_slug: str, test_case: str | None = None) -> Tolerance:
+    """
+    Resolve the effective float tolerance for a diagnostic / test-case pair.
+
+    Currently returns :data:`DEFAULT_TOLERANCE` for all inputs.
+    Per-case overrides may be wired in future by consulting a ``TestCase.tolerances``
+    mapping (see the plan's "Tolerance config surface" note); this function is the
+    single call-site to update when that happens.
+
+    Parameters
+    ----------
+    diagnostic_slug
+        The diagnostic slug (e.g. ``"global-mean-timeseries"``).
+    test_case
+        Optional test-case name for per-case overrides.
+
+    Returns
+    -------
+    :
+        The resolved :class:`Tolerance` to use for comparisons.
+    """
+    return DEFAULT_TOLERANCE
+
+
+def _rewrite_keys_and_values(obj: Any, replacements: list[tuple[str, str]]) -> Any:
+    """
+    Recursively rewrite both dict *keys* and leaf string *values* in ``obj``.
+
+    Replacements are applied in the order supplied
+    (caller is responsible for longest-key-first ordering).
+
+    Parameters
+    ----------
+    obj
+        The parsed JSON object to rewrite (dict, list, or scalar).
+    replacements
+        Ordered list of ``(real, placeholder)`` pairs to apply.
+
+    Returns
+    -------
+    :
+        A new object with all matching substrings replaced.
+    """
+    if isinstance(obj, dict):
+        return {
+            _apply_replacements(k, replacements): _rewrite_keys_and_values(v, replacements)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_rewrite_keys_and_values(item, replacements) for item in obj]
+    if isinstance(obj, str):
+        return _apply_replacements(obj, replacements)
+    return obj
+
+
+def _apply_replacements(text: str, replacements: list[tuple[str, str]]) -> str:
+    """
+    Apply a sequence of ``(real, placeholder)`` string substitutions to ``text``.
+
+    Parameters
+    ----------
+    text
+        The input string.
+    replacements
+        Ordered list of ``(real, placeholder)`` pairs.
+
+    Returns
+    -------
+    :
+        The rewritten string.
+    """
+    for real, placeholder in replacements:
+        text = text.replace(real, placeholder)
+    return text
+
+
+def compare_json_content(
+    expected: Any,
+    actual: Any,
+    *,
+    tol: Tolerance,
+    path: str = "",
+) -> list[str]:
+    """
+    Recursively compare two parsed JSON values with float tolerance.
+
+    Rules:
+    - **Floats**: compared with relative tolerance ``tol.rtol``
+      and absolute tolerance ``tol.atol``.
+    - **Ints, strings, bools, ``None``**: exact equality.
+    - **Lists**: element-by-element, same length required.
+    - **Dicts**: key sets must match; values compared recursively.
+
+    Parameters
+    ----------
+    expected
+        The reference (committed) parsed JSON value.
+    actual
+        The regenerated parsed JSON value.
+    tol
+        Float comparison tolerance.
+    path
+        Dot-/bracket-notation path prefix for error messages (empty at top level).
+
+    Returns
+    -------
+    :
+        A list of human-readable mismatch descriptions.
+        An empty list means the values are equivalent within tolerance.
+    """
+    mismatches: list[str] = []
+    _compare_recursive(expected, actual, tol=tol, path=path or "<root>", out=mismatches)
+    return mismatches
+
+
+def _compare_recursive(
+    expected: Any,
+    actual: Any,
+    *,
+    tol: Tolerance,
+    path: str,
+    out: list[str],
+) -> None:
+    """Recursive helper; appends to ``out``."""
+    # Type mismatch (treat int/float as numeric together)
+    if type(expected) is not type(actual):
+        if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+            _compare_numeric(float(expected), float(actual), tol=tol, path=path, out=out)
+            return
+        out.append(
+            f"{path}: type mismatch — expected {type(expected).__name__} ({expected!r}), "
+            f"got {type(actual).__name__} ({actual!r})"
+        )
+        return
+
+    if isinstance(expected, float):
+        _compare_numeric(expected, actual, tol=tol, path=path, out=out)
+
+    elif isinstance(expected, dict):
+        expected_keys = set(expected.keys())
+        actual_keys = set(actual.keys())
+        missing = expected_keys - actual_keys
+        extra = actual_keys - expected_keys
+        if missing:
+            out.append(f"{path}: missing keys {sorted(missing)!r}")
+        if extra:
+            out.append(f"{path}: unexpected extra keys {sorted(extra)!r}")
+        for key in expected_keys & actual_keys:
+            child_path = f"{path}.{key}" if path else str(key)
+            _compare_recursive(expected[key], actual[key], tol=tol, path=child_path, out=out)
+
+    elif isinstance(expected, list):
+        if len(expected) != len(actual):
+            out.append(f"{path}: length mismatch — expected {len(expected)}, got {len(actual)}")
+        # Compare the common prefix so partial mismatches are visible.
+        for i, (e, a) in enumerate(zip(expected, actual)):
+            _compare_recursive(e, a, tol=tol, path=f"{path}[{i}]", out=out)
+
+    # int, bool, str, None — exact equality
+    elif expected != actual:
+        out.append(f"{path}: expected {expected!r}, got {actual!r}")
+
+
+def _compare_numeric(
+    expected: float,
+    actual: float,
+    *,
+    tol: Tolerance,
+    path: str,
+    out: list[str],
+) -> None:
+    """Compare two numeric values with tolerance; append to ``out`` on failure."""
+    # Both NaN is considered equal
+    if math.isnan(expected) and math.isnan(actual):
+        return
+    if not math.isclose(expected, actual, rel_tol=tol.rtol, abs_tol=tol.atol):
+        out.append(
+            f"{path}: float mismatch — expected {expected!r}, got {actual!r} "
+            f"(rtol={tol.rtol}, atol={tol.atol})"
+        )
+
+
+def assert_bundle_regression(
+    expected_path: Path,
+    actual_path: Path,
+    *,
+    slug: str,
+    tol: Tolerance,
+    replacements: dict[str, str],
+) -> None:
+    """
+    Assert that a regenerated committed-bundle JSON file matches the committed copy.
+
+    Algorithm:
+
+    1. **Byte-equal fast path** — if the raw bytes of both files are identical, return immediately.
+    2. Parse both files as JSON.
+    3. Rewrite both dict *keys* and leaf string *values* in the regenerated
+       (``actual``) document using ``replacements``, applied **longest-key-first**
+       so that a shorter placeholder cannot pre-empt a longer overlapping one.
+    4. Call :func:`compare_json_content` with the given tolerance.
+    5. Raise ``AssertionError`` with the full mismatch list and a remediation hint
+       if any mismatches are found.
+
+    The replacements map follows the convention used throughout the testing
+    infrastructure: keys are real runtime values (absolute paths, recipe-dir
+    timestamps), values are the committed-bundle placeholders (e.g.
+    ``"<OUTPUT_DIR>"``, ``"<TEST_DATA_DIR>"``, ``"<RECIPE_RUN>"``).
+
+    Both ``<OUTPUT_DIR>`` and ``<RECIPE_RUN>`` participate in dict-KEY rewriting
+    because ESMValTool's ``output.json`` embeds absolute paths as object keys.
+
+    Parameters
+    ----------
+    expected_path
+        Path to the committed (on-disk) bundle file containing placeholders.
+    actual_path
+        Path to the regenerated bundle file containing real runtime paths.
+    slug
+        Diagnostic slug used in error messages.
+    tol
+        Float comparison tolerance.
+    replacements
+        Mapping of ``{real_value: placeholder}`` applied to the actual document.
+
+    Raises
+    ------
+    AssertionError
+        If the bundles differ beyond tolerance after sanitisation.
+    FileNotFoundError
+        If ``expected_path`` does not exist (legacy regression without committed bundle).
+    """
+    if not expected_path.exists():
+        # Legacy regression data without this bundle file — skip silently,
+        # matching the behaviour of validate_series_regression.
+        return
+
+    expected_bytes = expected_path.read_bytes()
+    actual_bytes = actual_path.read_bytes()
+
+    # Fast path: byte-identical means no difference.
+    if expected_bytes == actual_bytes:
+        return
+
+    expected_obj = json.loads(expected_bytes.decode("utf-8"))
+    actual_obj = json.loads(actual_bytes.decode("utf-8"))
+
+    # Build ordered replacement list: longest real-value string first.
+    ordered = sorted(replacements.items(), key=lambda kv: len(kv[0]), reverse=True)
+
+    # Rewrite actual — both keys and leaf values — before comparison.
+    actual_sanitised = _rewrite_keys_and_values(actual_obj, ordered)
+
+    mismatches = compare_json_content(expected_obj, actual_sanitised, tol=tol)
+    if mismatches:
+        mismatch_detail = "\n  ".join(mismatches)
+        msg = (
+            f"Diagnostic {slug!r}: committed bundle {expected_path.name!r} "
+            f"differs from regenerated output after sanitisation.\n"
+            f"Mismatches ({len(mismatches)}):\n  {mismatch_detail}\n\n"
+            f"Remediation: if the change is intentional, bump the diagnostic's "
+            f"test_case_version and regenerate with `ref test-cases run --force-regen`."
+        )
+        raise AssertionError(msg)

--- a/packages/climate-ref-core/src/climate_ref_core/regression/manifest.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/manifest.py
@@ -27,8 +27,11 @@ from attrs import asdict, frozen
 SCHEMA_VERSION: int = 1
 """Current manifest schema version."""
 
-# The committed regression artefacts whose digests are tracked in ``manifest.committed``.
-_COMMITTED_FILES: tuple[str, ...] = ("series.json", "diagnostic.json", "output.json")
+COMMITTED_BUNDLE_FILES: tuple[str, ...] = ("series.json", "diagnostic.json", "output.json")
+"""The committed CMEC artefacts tracked in git.
+
+Their digests are tracked in :attr:`Manifest.committed`.
+"""
 
 
 def sha256_file(path: Path) -> str:
@@ -113,12 +116,31 @@ class Manifest:
         -------
         :
             The parsed manifest.
+
+        Raises
+        ------
+        ValueError
+            If the manifest is missing required keys or has malformed native entries
+            (e.g. hand-edited or written by an incompatible version).
         """
         data = json.loads(path.read_text(encoding="utf-8"))
-        native = {
-            relpath: NativeEntry(sha256=entry["sha256"], size=entry["size"])
-            for relpath, entry in data["native"].items()
-        }
+        missing = [key for key in ("schema", "test_case_version", "committed", "native") if key not in data]
+        if missing:
+            raise ValueError(
+                f"Invalid manifest {path}: missing required keys {missing}. "
+                "The manifest may be corrupted or written by an incompatible version; "
+                "regenerate it with `ref test-cases run --force-regen`."
+            )
+        try:
+            native = {
+                relpath: NativeEntry(sha256=entry["sha256"], size=entry["size"])
+                for relpath, entry in data["native"].items()
+            }
+        except (KeyError, TypeError, AttributeError) as exc:
+            raise ValueError(
+                f"Invalid manifest {path}: malformed 'native' entry ({exc!r}). "
+                "Each entry must be a mapping with 'sha256' and 'size' keys."
+            ) from exc
         return cls(
             schema=data["schema"],
             test_case_version=data["test_case_version"],
@@ -141,7 +163,7 @@ class Manifest:
         payload = {
             "schema": self.schema,
             "test_case_version": self.test_case_version,
-            "committed": dict(self.committed),
+            "committed": self.committed,
             "native": {relpath: asdict(entry) for relpath, entry in self.native.items()},
         }
         text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
@@ -188,7 +210,7 @@ def compute_committed_digests(regression_dir: Path) -> dict[str, str]:
         Mapping of ``{relpath: sha256}`` for each present committed artefact.
     """
     digests: dict[str, str] = {}
-    for relpath in _COMMITTED_FILES:
+    for relpath in COMMITTED_BUNDLE_FILES:
         candidate = regression_dir / relpath
         if candidate.exists():
             digests[relpath] = sha256_file(candidate)

--- a/packages/climate-ref-core/src/climate_ref_core/regression/manifest.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/manifest.py
@@ -1,0 +1,225 @@
+"""
+Manifest model and digest utilities for test case regression bundles.
+
+The manifest (``manifest.json``) lives alongside a test case's regression data.
+It records:
+- ``schema``: the manifest schema version (``SCHEMA_VERSION``).
+- ``test_case_version``: a monotonic, author-bumped integer coupling the committed
+  bundle to its native outputs.
+- ``committed``: sha256 digests of the committed regression JSON artefacts,
+  computed over the exact placeholder-substituted bytes as they sit on disk,
+  so that a CI recompute is deterministic.
+- ``native``: digests of the curated native output files, authored ONLY by ``mint``.
+
+Digests use sha256 throughout, reusing pooch's hashing helper
+so that file digests agree with the rest of the codebase.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pooch.hashes
+from attrs import asdict, frozen
+
+SCHEMA_VERSION: int = 1
+"""Current manifest schema version."""
+
+# The committed regression artefacts whose digests are tracked in ``manifest.committed``.
+_COMMITTED_FILES: tuple[str, ...] = ("series.json", "diagnostic.json", "output.json")
+
+
+def sha256_file(path: Path) -> str:
+    """
+    Compute the sha256 digest of a file.
+
+    Reuses :func:`pooch.hashes.file_hash` so the digest agrees with pooch elsewhere.
+
+    Parameters
+    ----------
+    path
+        Path to the file to hash.
+
+    Returns
+    -------
+    :
+        The hex-encoded sha256 digest.
+    """
+    return pooch.hashes.file_hash(str(path), alg="sha256")
+
+
+def sha256_bytes(data: bytes) -> str:
+    """
+    Compute the sha256 digest of an in-memory byte string.
+
+    Parameters
+    ----------
+    data
+        The bytes to hash.
+
+    Returns
+    -------
+    :
+        The hex-encoded sha256 digest.
+    """
+    return hashlib.sha256(data).hexdigest()
+
+
+@frozen
+class NativeEntry:
+    """A single curated native output file recorded in the manifest."""
+
+    sha256: str
+    """Hex-encoded sha256 digest of the curated file."""
+
+    size: int
+    """Size of the curated file in bytes."""
+
+
+@frozen
+class Manifest:
+    """
+    The on-disk manifest for a test case regression bundle.
+
+    Serialised as ``manifest.json`` with stable key ordering and a trailing newline,
+    so repeated dumps are byte-identical.
+    """
+
+    schema: int
+    """Manifest schema version; equals :data:`SCHEMA_VERSION` for current manifests."""
+
+    test_case_version: int
+    """Monotonic, author-bumped version coupling the bundle to its native outputs."""
+
+    committed: dict[str, str]
+    """Digests of committed regression JSON artefacts: ``{relpath: sha256}``."""
+
+    native: dict[str, NativeEntry]
+    """Digests of curated native output files: ``{relpath: NativeEntry}``."""
+
+    @classmethod
+    def load(cls, path: Path) -> Manifest:
+        """
+        Load a manifest from ``manifest.json``.
+
+        Parameters
+        ----------
+        path
+            Path to the manifest file.
+
+        Returns
+        -------
+        :
+            The parsed manifest.
+        """
+        data = json.loads(path.read_text(encoding="utf-8"))
+        native = {
+            relpath: NativeEntry(sha256=entry["sha256"], size=entry["size"])
+            for relpath, entry in data["native"].items()
+        }
+        return cls(
+            schema=data["schema"],
+            test_case_version=data["test_case_version"],
+            committed=dict(data["committed"]),
+            native=native,
+        )
+
+    def dump(self, path: Path) -> None:
+        """
+        Write the manifest to ``manifest.json``.
+
+        Keys are stably ordered (``sort_keys=True``) and a trailing newline is added,
+        so ``dump`` followed by ``load`` round-trips byte-identically.
+
+        Parameters
+        ----------
+        path
+            Path to write the manifest to.
+        """
+        payload = {
+            "schema": self.schema,
+            "test_case_version": self.test_case_version,
+            "committed": dict(self.committed),
+            "native": {relpath: asdict(entry) for relpath, entry in self.native.items()},
+        }
+        text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        path.write_text(text, encoding="utf-8")
+
+    @classmethod
+    def seed_v1(cls, committed_digests: dict[str, str]) -> Manifest:
+        """
+        Create an initial manifest at ``test_case_version == 1`` with no native outputs.
+
+        Parameters
+        ----------
+        committed_digests
+            Digests of the committed regression JSON artefacts.
+
+        Returns
+        -------
+        :
+            A fresh manifest with ``test_case_version=1`` and ``native={}``.
+        """
+        return cls(
+            schema=SCHEMA_VERSION,
+            test_case_version=1,
+            committed=dict(committed_digests),
+            native={},
+        )
+
+
+def compute_committed_digests(regression_dir: Path) -> dict[str, str]:
+    """
+    Compute sha256 digests of the committed regression JSON artefacts.
+
+    The digests are taken over the bytes exactly as they sit on disk (placeholder text included),
+    so a CI recompute is deterministic. Only files that exist are included.
+
+    Parameters
+    ----------
+    regression_dir
+        The test case ``regression/`` directory.
+
+    Returns
+    -------
+    :
+        Mapping of ``{relpath: sha256}`` for each present committed artefact.
+    """
+    digests: dict[str, str] = {}
+    for relpath in _COMMITTED_FILES:
+        candidate = regression_dir / relpath
+        if candidate.exists():
+            digests[relpath] = sha256_file(candidate)
+    return digests
+
+
+def verify_committed_integrity(manifest: Manifest, regression_dir: Path) -> list[str]:
+    """
+    Check that the committed regression artefacts match the manifest digests.
+
+    Used by the CI integrity gate. An empty return value means the bundle is intact.
+
+    Parameters
+    ----------
+    manifest
+        The manifest holding the expected committed digests.
+    regression_dir
+        The test case ``regression/`` directory to verify against.
+
+    Returns
+    -------
+    :
+        A list of human-readable mismatch descriptions; empty when everything matches.
+    """
+    mismatches: list[str] = []
+    for relpath, expected in manifest.committed.items():
+        candidate = regression_dir / relpath
+        if not candidate.exists():
+            mismatches.append(f"{relpath}: missing on disk (expected sha256 {expected})")
+            continue
+        actual = sha256_file(candidate)
+        if actual != expected:
+            mismatches.append(f"{relpath}: sha256 mismatch (expected {expected}, got {actual})")
+    return mismatches

--- a/packages/climate-ref-core/src/climate_ref_core/regression/store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/store.py
@@ -23,7 +23,7 @@ The :class:`LocalFilesystemStore` uses a two-level directory layout
 import shutil
 from pathlib import Path
 from typing import Protocol, runtime_checkable
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 import pooch
 from attrs import frozen
@@ -385,7 +385,8 @@ def build_native_store(config: _NativeStoreConfigProtocol, *, writable: bool) ->
                     f"Unsupported file URL {url!r}: a host component ({parts.netloc!r}) is not "
                     "supported. Use the file:///absolute/path form (three slashes)."
                 )
-            local_root = Path(parts.path)
+            # Percent-decode the path so escaped characters (e.g. %20) resolve to the real on-disk directory.
+            local_root = Path(unquote(parts.path))
         else:
             # A bare filesystem path.
             local_root = Path(url)

--- a/packages/climate-ref-core/src/climate_ref_core/regression/store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/store.py
@@ -20,8 +20,6 @@ The :class:`LocalFilesystemStore` uses a two-level directory layout
 ``<root>/<digest[:2]>/<digest>`` similar to git's object storage.
 """
 
-from __future__ import annotations
-
 import shutil
 from pathlib import Path
 from typing import Protocol, runtime_checkable

--- a/packages/climate-ref-core/src/climate_ref_core/regression/store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/store.py
@@ -17,7 +17,7 @@ based on the application :class:`~climate_ref.config.Config` and the ``writable`
 
 Blobs are keyed by their **sha256 hex digest**.
 The :class:`LocalFilesystemStore` uses a two-level directory layout
-``<root>/<digest[:2]>/<digest>`` (content-addressed, mirrors common git-object conventions).
+``<root>/<digest[:2]>/<digest>`` similar to git's object storage.
 """
 
 from __future__ import annotations
@@ -25,13 +25,14 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 from typing import Protocol, runtime_checkable
+from urllib.parse import urlsplit
 
 import pooch
-import pooch.hashes
 from attrs import frozen
 from loguru import logger
 
 from climate_ref_core.dataset_registry import _verify_hash_matches
+from climate_ref_core.regression.manifest import sha256_file
 
 
 @runtime_checkable
@@ -41,8 +42,7 @@ class NativeStore(Protocol):
 
     Blobs are keyed by their sha256 hex digest.
     Read operations (``has``, ``fetch``) are anonymous and credential-free.
-    ``put`` requires write credentials and raises :class:`NotImplementedError`
-    on read-only implementations.
+    ``put`` requires write credentials and raises :class:`NotImplementedError` on read-only implementations.
     """
 
     def has(self, digest: str) -> bool:
@@ -174,8 +174,7 @@ class LocalFilesystemStore:
         """
         Store the file at ``path`` in the content-addressed store.
 
-        Computes the sha256 digest, copies the file to its canonical location,
-        and returns the digest.
+        Computes the sha256 digest, copies the file to its canonical location, and returns the digest.
         If a blob with the same digest already exists, the copy is skipped.
 
         Parameters
@@ -188,7 +187,7 @@ class LocalFilesystemStore:
         :
             The sha256 hex digest of the stored blob.
         """
-        digest = pooch.hashes.file_hash(str(path), alg="sha256")
+        digest = sha256_file(path)
         blob = self._blob_path(digest)
         if not blob.exists():
             blob.parent.mkdir(parents=True, exist_ok=True)
@@ -332,6 +331,9 @@ class _NativeStoreConfigProtocol(Protocol):
 
     Both :class:`climate_ref.config.NativeStoreConfig` and test doubles satisfy
     this interface without an import dependency on the app package.
+
+    This keeps ``climate_ref_core`` free of any import dependency on ``climate_ref``.
+
     """
 
     @property
@@ -348,7 +350,6 @@ def build_native_store(config: _NativeStoreConfigProtocol, *, writable: bool) ->
     Accepts any object that exposes ``url: str`` and ``cache_dir: Path``
     (satisfying :class:`_NativeStoreConfigProtocol`), so callers pass
     ``config.native_store`` rather than the full :class:`~climate_ref.config.Config`.
-    This keeps ``climate_ref_core`` free of any import dependency on ``climate_ref``.
 
     With ``writable=False`` the returned store is always anonymous and
     credential-free (suitable for CI read/replay paths).
@@ -374,12 +375,22 @@ def build_native_store(config: _NativeStoreConfigProtocol, *, writable: bool) ->
     url: str = config.url
     cache_dir: Path = config.cache_dir
 
-    # Determine whether the URL refers to a local path (file:// or bare path).
-    is_local = url.startswith("file://") or not url.startswith(("http://", "https://"))
+    parts = urlsplit(url)
+    is_local = parts.scheme not in ("http", "https")
 
     if is_local:
-        # Strip file:// prefix if present to get the directory path.
-        local_root = Path(url[len("file://") :]) if url.startswith("file://") else Path(url)
+        if parts.scheme == "file":
+            # Parse properly so malformed variants fail loudly instead of
+            # silently producing a wrong (e.g. relative) path.
+            if parts.netloc not in ("", "localhost"):
+                raise ValueError(
+                    f"Unsupported file URL {url!r}: a host component ({parts.netloc!r}) is not "
+                    "supported. Use the file:///absolute/path form (three slashes)."
+                )
+            local_root = Path(parts.path)
+        else:
+            # A bare filesystem path.
+            local_root = Path(url)
         return LocalFilesystemStore(root=local_root)
     elif writable:
         # Remote writable store — R2 backend is deferred.

--- a/packages/climate-ref-core/src/climate_ref_core/regression/store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/store.py
@@ -1,0 +1,389 @@
+"""
+Data store for native bundles.
+
+This module provides the :class:`NativeStore` Protocol and three implementations:
+
+- :class:`LocalFilesystemStore`: local filesystem store for tests and development.
+  Supports both read and write.
+- :class:`PoochReadStore`: anonymous public-read store backed by a URL,
+  using :mod:`pooch` for caching, retry, and hash verification.
+  Write is intentionally unsupported (``put`` raises :class:`NotImplementedError`).
+- :class:`R2WriteStore`: stub for the future Cloudflare R2 write backend.
+  Construction raises :class:`NotImplementedError` until implemented.
+
+The factory :func:`build_native_store` selects the appropriate implementation
+based on the application :class:`~climate_ref.config.Config` and the ``writable`` flag.
+``writable=False`` never requires credentials.
+
+Blobs are keyed by their **sha256 hex digest**.
+The :class:`LocalFilesystemStore` uses a two-level directory layout
+``<root>/<digest[:2]>/<digest>`` (content-addressed, mirrors common git-object conventions).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import pooch
+import pooch.hashes
+from attrs import frozen
+from loguru import logger
+
+from climate_ref_core.dataset_registry import _verify_hash_matches
+
+
+@runtime_checkable
+class NativeStore(Protocol):
+    """
+    Protocol for a content-addressed native-bundle blob store.
+
+    Blobs are keyed by their sha256 hex digest.
+    Read operations (``has``, ``fetch``) are anonymous and credential-free.
+    ``put`` requires write credentials and raises :class:`NotImplementedError`
+    on read-only implementations.
+    """
+
+    def has(self, digest: str) -> bool:
+        """
+        Return ``True`` if the blob identified by ``digest`` is available in the store.
+
+        Parameters
+        ----------
+        digest
+            The sha256 hex digest of the blob.
+
+        Returns
+        -------
+        :
+            ``True`` when the blob is present, ``False`` when it is not.
+        """
+        ...
+
+    def fetch(self, digest: str, dest: Path) -> None:
+        """
+        Fetch the blob identified by ``digest`` and write it to ``dest``.
+
+        The sha256 of the written file is verified to equal ``digest``.
+        Raises :class:`ValueError` on hash mismatch and
+        :class:`FileNotFoundError` if the blob is not found.
+
+        Parameters
+        ----------
+        digest
+            The sha256 hex digest of the blob to fetch.
+        dest
+            Destination path to write the blob to.
+            Parent directories are created if they do not exist.
+        """
+        ...
+
+    def put(self, path: Path) -> str:
+        """
+        Store the file at ``path`` and return its sha256 hex digest.
+
+        Requires write credentials.
+        Read-only implementations raise :class:`NotImplementedError`.
+
+        Parameters
+        ----------
+        path
+            Path to the file to store.
+
+        Returns
+        -------
+        :
+            The sha256 hex digest of the stored blob.
+        """
+        ...
+
+
+@frozen
+class LocalFilesystemStore:
+    """
+    Content-addressed blob store backed by a local filesystem directory.
+
+    Intended for tests and development.
+    Supports both read and write without credentials.
+
+    Blobs are stored under ``root`` using a two-level layout::
+
+        <root>/<digest[:2]>/<digest>
+
+    This mirrors the git object-store convention,
+    keeping individual subdirectories manageable for large collections.
+
+    Parameters
+    ----------
+    root
+        Root directory for the content-addressed store.
+        Created on first write if it does not exist.
+    """
+
+    root: Path
+
+    def _blob_path(self, digest: str) -> Path:
+        """Return the canonical on-disk path for a blob with the given digest."""
+        return self.root / digest[:2] / digest
+
+    def has(self, digest: str) -> bool:
+        """
+        Return ``True`` if the blob is present on disk.
+
+        Parameters
+        ----------
+        digest
+            The sha256 hex digest of the blob.
+
+        Returns
+        -------
+        :
+            ``True`` when the blob file exists at its canonical path.
+        """
+        return self._blob_path(digest).exists()
+
+    def fetch(self, digest: str, dest: Path) -> None:
+        """
+        Copy the blob to ``dest`` and verify its sha256 matches ``digest``.
+
+        Parameters
+        ----------
+        digest
+            The sha256 hex digest of the blob to fetch.
+        dest
+            Destination path to write the blob to.
+            Parent directories are created if they do not exist.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the blob is not present in the store.
+        ValueError
+            If the blob's sha256 does not match ``digest``.
+        """
+        blob = self._blob_path(digest)
+        if not blob.exists():
+            raise FileNotFoundError(f"Blob {digest!r} not found in local store at {self.root}")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(blob), str(dest))
+        _verify_hash_matches(dest, digest)
+        logger.debug(f"LocalFilesystemStore.fetch: {digest} -> {dest}")
+
+    def put(self, path: Path) -> str:
+        """
+        Store the file at ``path`` in the content-addressed store.
+
+        Computes the sha256 digest, copies the file to its canonical location,
+        and returns the digest.
+        If a blob with the same digest already exists, the copy is skipped.
+
+        Parameters
+        ----------
+        path
+            Path to the file to store.
+
+        Returns
+        -------
+        :
+            The sha256 hex digest of the stored blob.
+        """
+        digest = pooch.hashes.file_hash(str(path), alg="sha256")
+        blob = self._blob_path(digest)
+        if not blob.exists():
+            blob.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(path), str(blob))
+            logger.debug(f"LocalFilesystemStore.put: {path} -> {blob}")
+        else:
+            logger.debug(f"LocalFilesystemStore.put: {digest} already present, skipping copy")
+        return digest
+
+
+@frozen
+class PoochReadStore:
+    """
+    Anonymous public-read blob store backed by a remote URL.
+
+    Uses :mod:`pooch` for caching, retry, and hash verification,
+    mirroring the pattern in :mod:`climate_ref_core.dataset_registry`.
+
+    Blobs are fetched from ``{base_url}/{digest}`` and cached under ``cache_dir``.
+    ``put`` is intentionally unsupported; minting uses the write backend.
+
+    Parameters
+    ----------
+    base_url
+        Base URL from which blobs are served (no trailing slash).
+        Example: ``https://baselines.climate-ref.org``.
+    cache_dir
+        Local directory used by pooch to cache downloaded blobs.
+    """
+
+    base_url: str
+    cache_dir: Path
+
+    def _cached_blob_path(self, digest: str) -> Path:
+        """Return the pooch cache path for a blob."""
+        return self.cache_dir / digest
+
+    def has(self, digest: str) -> bool:
+        """
+        Return ``True`` if the blob is already in the local pooch cache.
+
+        Parameters
+        ----------
+        digest
+            The sha256 hex digest of the blob.
+
+        Returns
+        -------
+        :
+            ``True`` when the cached file exists.
+        """
+        return self._cached_blob_path(digest).exists()
+
+    def fetch(self, digest: str, dest: Path) -> None:
+        """
+        Download the blob from ``{base_url}/{digest}`` and write it to ``dest``.
+
+        Uses pooch for caching and retry.
+        Verifies the sha256 of the downloaded file against ``digest``.
+
+        Parameters
+        ----------
+        digest
+            The sha256 hex digest of the blob to fetch.
+        dest
+            Destination path to write the blob to.
+            Parent directories are created if they do not exist.
+
+        Raises
+        ------
+        ValueError
+            If the downloaded blob's sha256 does not match ``digest``.
+        """
+        # Build a single-file pooch registry: the URL path component is the digest
+        # and the expected hash IS the digest (content-addressed).
+        registry = pooch.create(
+            path=self.cache_dir,
+            base_url=self.base_url + "/",
+            retry_if_failed=10,
+        )
+        registry.registry[digest] = digest  # content-addressed: hash == name
+
+        cached = registry.fetch(digest)
+        # Verify the cached copy against the expected digest.
+        _verify_hash_matches(cached, digest)
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(cached, str(dest))
+        logger.debug(f"PoochReadStore.fetch: {digest} -> {dest}")
+
+    def put(self, path: Path) -> str:
+        """
+        Not supported on this read-only store.
+
+        Raises
+        ------
+        NotImplementedError
+            Always; minting uses the write backend, not the read store.
+        """
+        raise NotImplementedError(
+            "PoochReadStore is a public-read store; put() is not supported. "
+            "Use a writable store (LocalFilesystemStore or R2WriteStore) for minting."
+        )
+
+
+@frozen
+class R2WriteStore:
+    """
+    Stub for the future Cloudflare R2 write backend.
+
+    This class documents the seam for the credentialed write backend
+    and will be implemented in a follow-up once the R2 credentials and
+    bucket lifecycle policy are in place.
+
+    Construction raises :class:`NotImplementedError` with a deferral message.
+    """
+
+    def __attrs_post_init__(self) -> None:
+        raise NotImplementedError(
+            "Remote writable native store (R2 backend) is deferred to a follow-up PR. "
+            "Anonymous public-read URL + credentialed S3-compatible PUT will be wired here. "
+            "Use a local store URL (file:// or a filesystem path) for minting in the meantime."
+        )
+
+    def has(self, digest: str) -> bool:  # pragma: no cover
+        """Not implemented — R2 backend deferred."""
+        raise NotImplementedError("R2 backend deferred")
+
+    def fetch(self, digest: str, dest: Path) -> None:  # pragma: no cover
+        """Not implemented — R2 backend deferred."""
+        raise NotImplementedError("R2 backend deferred")
+
+    def put(self, path: Path) -> str:  # pragma: no cover
+        """Not implemented — R2 backend deferred."""
+        raise NotImplementedError("R2 backend deferred")
+
+
+class _NativeStoreConfigProtocol(Protocol):
+    """
+    Structural protocol for the native-store config object expected by :func:`build_native_store`.
+
+    Both :class:`climate_ref.config.NativeStoreConfig` and test doubles satisfy
+    this interface without an import dependency on the app package.
+    """
+
+    @property
+    def url(self) -> str: ...
+
+    @property
+    def cache_dir(self) -> Path: ...
+
+
+def build_native_store(config: _NativeStoreConfigProtocol, *, writable: bool) -> NativeStore:
+    """
+    Build an appropriate :class:`NativeStore` from a native-store config object.
+
+    Accepts any object that exposes ``url: str`` and ``cache_dir: Path``
+    (satisfying :class:`_NativeStoreConfigProtocol`), so callers pass
+    ``config.native_store`` rather than the full :class:`~climate_ref.config.Config`.
+    This keeps ``climate_ref_core`` free of any import dependency on ``climate_ref``.
+
+    With ``writable=False`` the returned store is always anonymous and
+    credential-free (suitable for CI read/replay paths).
+    With ``writable=True`` and a local URL/path a :class:`LocalFilesystemStore`
+    or with a remote URL a :class:`R2WriteStore` is attempted
+    (currently deferred — raises :class:`NotImplementedError`).
+
+    Parameters
+    ----------
+    config
+        A config object providing ``url`` and ``cache_dir``.
+        Typically ``app_config.native_store``.
+    writable
+        When ``False``, return a read-only store (no credentials required).
+        When ``True``, return a writable store (``LocalFilesystemStore`` for local
+        paths, or a :class:`R2WriteStore` for remote URLs — deferred).
+
+    Returns
+    -------
+    :
+        A :class:`NativeStore` implementation appropriate for the configuration.
+    """
+    url: str = config.url
+    cache_dir: Path = config.cache_dir
+
+    # Determine whether the URL refers to a local path (file:// or bare path).
+    is_local = url.startswith("file://") or not url.startswith(("http://", "https://"))
+
+    if is_local:
+        # Strip file:// prefix if present to get the directory path.
+        local_root = Path(url[len("file://") :]) if url.startswith("file://") else Path(url)
+        return LocalFilesystemStore(root=local_root)
+    elif writable:
+        # Remote writable store — R2 backend is deferred.
+        # Construction raises NotImplementedError until the follow-up lands.
+        return R2WriteStore()
+    else:
+        return PoochReadStore(base_url=url.rstrip("/"), cache_dir=cache_dir)

--- a/packages/climate-ref-core/tests/unit/regression/test_capture.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_capture.py
@@ -1,0 +1,141 @@
+"""Unit tests for :mod:`climate_ref_core.regression.capture`."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from climate_ref_core.logging import EXECUTION_LOG_FILENAME
+from climate_ref_core.output_files import PLACEHOLDER_OUTPUT_DIR, PLACEHOLDER_TEST_DATA_DIR
+from climate_ref_core.pycmec.output import CMECOutput
+from climate_ref_core.regression.capture import (
+    build_native_snapshot,
+    capture_execution,
+    materialise_native,
+    write_committed_bundle,
+)
+from climate_ref_core.regression.manifest import sha256_file
+from climate_ref_core.regression.store import LocalFilesystemStore
+
+
+class _FakeResult:
+    def __init__(self, metric_bundle_filename, output_bundle_filename=None, series_filename=None):
+        self.metric_bundle_filename = metric_bundle_filename
+        self.output_bundle_filename = output_bundle_filename
+        self.series_filename = series_filename
+
+
+def _seed_execution(scratch, fragment, *, output_dir, test_data_dir):
+    """Write a minimal committed bundle + log into scratch/fragment."""
+    base = scratch / fragment
+    base.mkdir(parents=True, exist_ok=True)
+    (base / EXECUTION_LOG_FILENAME).write_text("ran ok\n")
+    # diagnostic.json (metric bundle) embeds an absolute path -> must be sanitised.
+    (base / "diagnostic.json").write_text(
+        json.dumps({"provenance": {"path": str(output_dir), "data": str(test_data_dir)}})
+    )
+    # output.json is a valid (empty) CMEC output bundle so copy can introspect it.
+    (base / "output.json").write_text(json.dumps(CMECOutput.create_template()))
+    (base / "series.json").write_text(json.dumps([{"v": str(output_dir)}]))
+    return base
+
+
+def test_write_committed_bundle_sanitises_and_digests(tmp_path):
+    output_dir = (tmp_path / "scratch" / "frag").resolve()
+    test_data_dir = (tmp_path / "test-data").resolve()
+    source = _seed_execution(tmp_path / "scratch", "frag", output_dir=output_dir, test_data_dir=test_data_dir)
+    regression_dir = tmp_path / "regression"
+
+    digests = write_committed_bundle(
+        source, regression_dir, output_dir=output_dir, test_data_dir=test_data_dir
+    )
+
+    assert set(digests) == {"series.json", "diagnostic.json", "output.json"}
+    written = (regression_dir / "diagnostic.json").read_text()
+    assert str(output_dir) not in written
+    assert PLACEHOLDER_OUTPUT_DIR in written
+    assert PLACEHOLDER_TEST_DATA_DIR in written
+    # Digest is over the sanitised bytes as they sit on disk.
+    assert digests["diagnostic.json"] == sha256_file(regression_dir / "diagnostic.json")
+
+
+def test_build_native_snapshot_digests_relpaths(tmp_path):
+    base = tmp_path / "results" / "frag"
+    base.mkdir(parents=True)
+    (base / "a.nc").write_bytes(b"data-a")
+    (base / "sub").mkdir()
+    (base / "sub" / "b.png").write_bytes(b"data-b")
+
+    snapshot = build_native_snapshot(base, [Path("a.nc"), Path("sub/b.png")])
+
+    assert set(snapshot) == {"a.nc", "sub/b.png"}
+    assert snapshot["a.nc"].size == len(b"data-a")
+    assert snapshot["a.nc"].sha256 == sha256_file(base / "a.nc")
+
+
+def test_capture_execution_end_to_end(tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    output_dir = (scratch / fragment).resolve()
+    test_data_dir = (tmp_path / "test-data").resolve()
+    _seed_execution(scratch, fragment, output_dir=output_dir, test_data_dir=test_data_dir)
+    regression_dir = tmp_path / "regression"
+
+    result = _FakeResult(
+        metric_bundle_filename="diagnostic.json",
+        output_bundle_filename="output.json",
+        series_filename="series.json",
+    )
+
+    committed, native = capture_execution(
+        scratch,
+        results,
+        fragment,
+        result,
+        regression_dir=regression_dir,
+        output_dir=output_dir,
+        test_data_dir=test_data_dir,
+    )
+
+    # Committed bundle is the three CMEC artefacts.
+    assert set(committed) == {"series.json", "diagnostic.json", "output.json"}
+    # Native snapshot is exactly what copy_execution_outputs persisted: log + 3 bundles.
+    assert set(native) == {EXECUTION_LOG_FILENAME, "diagnostic.json", "output.json", "series.json"}
+    # Persisted files actually landed in the results directory.
+    for relpath in native:
+        assert (results / fragment / relpath).exists()
+
+
+def test_capture_execution_requires_metric_bundle(tmp_path):
+    result = _FakeResult(metric_bundle_filename=None)
+    with pytest.raises(ValueError, match="without a metric bundle"):
+        capture_execution(
+            tmp_path / "scratch",
+            tmp_path / "results",
+            "frag",
+            result,
+            regression_dir=tmp_path / "regression",
+            output_dir=tmp_path / "out",
+            test_data_dir=tmp_path / "td",
+        )
+
+
+def test_materialise_native_round_trip(tmp_path):
+    # Put two blobs into a local store, snapshot them, then materialise.
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.nc").write_bytes(b"alpha")
+    (src / "b.png").write_bytes(b"beta")
+    store = LocalFilesystemStore(root=tmp_path / "store")
+
+    snapshot = build_native_snapshot(src, [Path("a.nc"), Path("b.png")])
+    for relpath, entry in snapshot.items():
+        digest = store.put(src / relpath)
+        assert digest == entry.sha256
+
+    dest = tmp_path / "dest"
+    materialise_native(snapshot, store, dest)
+
+    assert (dest / "a.nc").read_bytes() == b"alpha"
+    assert (dest / "b.png").read_bytes() == b"beta"

--- a/packages/climate-ref-core/tests/unit/regression/test_capture.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_capture.py
@@ -100,11 +100,40 @@ def test_capture_execution_end_to_end(tmp_path):
 
     # Committed bundle is the three CMEC artefacts.
     assert set(committed) == {"series.json", "diagnostic.json", "output.json"}
-    # Native snapshot is exactly what copy_execution_outputs persisted: log + 3 bundles.
-    assert set(native) == {EXECUTION_LOG_FILENAME, "diagnostic.json", "output.json", "series.json"}
+    # Native snapshot is exactly what copy_execution_outputs persists in production:
+    # the 3 bundles, without the execution log (the production default).
+    assert set(native) == {"diagnostic.json", "output.json", "series.json"}
     # Persisted files actually landed in the results directory.
     for relpath in native:
         assert (results / fragment / relpath).exists()
+
+
+def test_capture_execution_include_log(tmp_path):
+    scratch = (tmp_path / "scratch").resolve()
+    results = (tmp_path / "results").resolve()
+    fragment = "frag"
+    output_dir = (scratch / fragment).resolve()
+    test_data_dir = (tmp_path / "test-data").resolve()
+    _seed_execution(scratch, fragment, output_dir=output_dir, test_data_dir=test_data_dir)
+
+    result = _FakeResult(
+        metric_bundle_filename="diagnostic.json",
+        output_bundle_filename="output.json",
+        series_filename="series.json",
+    )
+
+    _, native = capture_execution(
+        scratch,
+        results,
+        fragment,
+        result,
+        regression_dir=tmp_path / "regression",
+        output_dir=output_dir,
+        test_data_dir=test_data_dir,
+        include_log=True,
+    )
+
+    assert set(native) == {EXECUTION_LOG_FILENAME, "diagnostic.json", "output.json", "series.json"}
 
 
 def test_capture_execution_requires_metric_bundle(tmp_path):

--- a/packages/climate-ref-core/tests/unit/regression/test_compare.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_compare.py
@@ -2,8 +2,6 @@
 Unit tests for :mod:`climate_ref_core.regression.compare`.
 """
 
-from __future__ import annotations
-
 import json
 import math
 from pathlib import Path
@@ -11,11 +9,9 @@ from pathlib import Path
 import pytest
 
 from climate_ref_core.regression.compare import (
-    DEFAULT_TOLERANCE,
     Tolerance,
     assert_bundle_regression,
     compare_json_content,
-    resolve_tolerance,
 )
 
 
@@ -23,7 +19,7 @@ def _write_json(path: Path, obj: object) -> None:
     path.write_text(json.dumps(obj, indent=2) + "\n", encoding="utf-8")
 
 
-TOL = DEFAULT_TOLERANCE
+TOL = Tolerance()
 
 
 class TestTolerance:
@@ -36,25 +32,6 @@ class TestTolerance:
         t = Tolerance(rtol=0.01, atol=1e-9)
         assert t.rtol == 0.01
         assert t.atol == 1e-9
-
-    def test_default_tolerance_singleton(self) -> None:
-        assert DEFAULT_TOLERANCE.rtol == 1e-6
-        assert DEFAULT_TOLERANCE.atol == 0.0
-
-
-class TestResolveTolerance:
-    def test_returns_default(self) -> None:
-        t = resolve_tolerance("some-diagnostic")
-        assert t == DEFAULT_TOLERANCE
-
-    def test_returns_default_with_test_case(self) -> None:
-        t = resolve_tolerance("some-diagnostic", test_case="default")
-        assert t == DEFAULT_TOLERANCE
-
-
-# ---------------------------------------------------------------------------
-# compare_json_content — scalars
-# ---------------------------------------------------------------------------
 
 
 class TestCompareJsonScalars:

--- a/packages/climate-ref-core/tests/unit/regression/test_compare.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_compare.py
@@ -171,6 +171,19 @@ class TestCompareJsonDicts:
         result = compare_json_content({"x": 1}, {"x": 2}, tol=TOL, path="parent")
         assert "parent" in result[0]
 
+    def test_top_level_key_path_is_bare(self) -> None:
+        """A mismatch under a top-level key renders as ``key``, not ``<root>.key``."""
+        result = compare_json_content({"x": 1}, {"x": 2}, tol=TOL)
+        assert result[0].startswith("x: ")
+
+    def test_root_scalar_mismatch_labelled_root(self) -> None:
+        result = compare_json_content(1, "1", tol=TOL)
+        assert result[0].startswith("<root>: ")
+
+    def test_root_missing_key_labelled_root(self) -> None:
+        result = compare_json_content({"a": 1}, {}, tol=TOL)
+        assert result[0].startswith("<root>: missing keys")
+
 
 class TestAssertBundleRegressionBasic:
     def test_byte_equal_fast_path_passes(self, tmp_path: Path) -> None:

--- a/packages/climate-ref-core/tests/unit/regression/test_compare.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_compare.py
@@ -1,0 +1,347 @@
+"""
+Unit tests for :mod:`climate_ref_core.regression.compare`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from climate_ref_core.regression.compare import (
+    DEFAULT_TOLERANCE,
+    Tolerance,
+    assert_bundle_regression,
+    compare_json_content,
+    resolve_tolerance,
+)
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.write_text(json.dumps(obj, indent=2) + "\n", encoding="utf-8")
+
+
+TOL = DEFAULT_TOLERANCE
+
+
+class TestTolerance:
+    def test_defaults(self) -> None:
+        t = Tolerance()
+        assert t.rtol == 1e-6
+        assert t.atol == 0.0
+
+    def test_custom_values(self) -> None:
+        t = Tolerance(rtol=0.01, atol=1e-9)
+        assert t.rtol == 0.01
+        assert t.atol == 1e-9
+
+    def test_default_tolerance_singleton(self) -> None:
+        assert DEFAULT_TOLERANCE.rtol == 1e-6
+        assert DEFAULT_TOLERANCE.atol == 0.0
+
+
+class TestResolveTolerance:
+    def test_returns_default(self) -> None:
+        t = resolve_tolerance("some-diagnostic")
+        assert t == DEFAULT_TOLERANCE
+
+    def test_returns_default_with_test_case(self) -> None:
+        t = resolve_tolerance("some-diagnostic", test_case="default")
+        assert t == DEFAULT_TOLERANCE
+
+
+# ---------------------------------------------------------------------------
+# compare_json_content — scalars
+# ---------------------------------------------------------------------------
+
+
+class TestCompareJsonScalars:
+    def test_equal_floats_pass(self) -> None:
+        assert compare_json_content(1.0, 1.0, tol=TOL) == []
+
+    def test_float_within_rtol_pass(self) -> None:
+        tol = Tolerance(rtol=0.01)
+        assert compare_json_content(1.0, 1.005, tol=tol) == []
+
+    def test_float_beyond_rtol_fail(self) -> None:
+        tol = Tolerance(rtol=0.01)
+        result = compare_json_content(1.0, 1.02, tol=tol)
+        assert len(result) == 1
+        assert "float mismatch" in result[0]
+        assert "rtol" in result[0]
+
+    def test_float_within_atol_pass(self) -> None:
+        tol = Tolerance(rtol=0.0, atol=0.1)
+        assert compare_json_content(0.0, 0.05, tol=tol) == []
+
+    def test_float_beyond_atol_fail(self) -> None:
+        tol = Tolerance(rtol=0.0, atol=0.01)
+        result = compare_json_content(0.0, 0.1, tol=tol)
+        assert len(result) == 1
+        assert "float mismatch" in result[0]
+
+    def test_nan_vs_nan_pass(self) -> None:
+        assert compare_json_content(math.nan, math.nan, tol=TOL) == []
+
+    def test_equal_ints_pass(self) -> None:
+        assert compare_json_content(42, 42, tol=TOL) == []
+
+    def test_different_ints_fail(self) -> None:
+        result = compare_json_content(1, 2, tol=TOL)
+        assert len(result) == 1
+        assert "1" in result[0]
+        assert "2" in result[0]
+
+    def test_equal_strings_pass(self) -> None:
+        assert compare_json_content("hello", "hello", tol=TOL) == []
+
+    def test_different_strings_fail(self) -> None:
+        result = compare_json_content("hello", "world", tol=TOL)
+        assert len(result) == 1
+        assert "hello" in result[0]
+
+    def test_equal_bools_pass(self) -> None:
+        assert compare_json_content(True, True, tol=TOL) == []
+
+    def test_different_bools_fail(self) -> None:
+        result = compare_json_content(True, False, tol=TOL)
+        assert len(result) == 1
+
+    def test_none_equal_pass(self) -> None:
+        assert compare_json_content(None, None, tol=TOL) == []
+
+    def test_type_mismatch_fail(self) -> None:
+        result = compare_json_content("1", 1, tol=TOL)
+        assert len(result) == 1
+        assert "type mismatch" in result[0]
+
+    def test_int_float_numeric_comparison(self) -> None:
+        """int vs float should be treated as numeric, not type-mismatch."""
+        assert compare_json_content(1, 1.0, tol=TOL) == []
+        result = compare_json_content(1, 2.0, tol=TOL)
+        assert len(result) == 1
+        assert "float mismatch" in result[0]
+
+
+class TestCompareJsonLists:
+    def test_equal_lists_pass(self) -> None:
+        assert compare_json_content([1, 2, 3], [1, 2, 3], tol=TOL) == []
+
+    def test_length_mismatch_fail(self) -> None:
+        result = compare_json_content([1, 2], [1], tol=TOL)
+        assert any("length mismatch" in m for m in result)
+
+    def test_element_mismatch_path_precise(self) -> None:
+        result = compare_json_content([1.0, 99.0], [1.0, 2.0], tol=TOL)
+        assert len(result) == 1
+        assert "[1]" in result[0]
+
+    def test_nested_list_path(self) -> None:
+        result = compare_json_content([[1.0]], [[2.0]], tol=TOL)
+        assert "[0][0]" in result[0]
+
+
+class TestCompareJsonDicts:
+    def test_equal_dicts_pass(self) -> None:
+        assert compare_json_content({"a": 1}, {"a": 1}, tol=TOL) == []
+
+    def test_missing_key_reported(self) -> None:
+        result = compare_json_content({"a": 1, "b": 2}, {"a": 1}, tol=TOL)
+        assert any("missing keys" in m for m in result)
+        assert any("b" in m for m in result)
+
+    def test_extra_key_reported(self) -> None:
+        result = compare_json_content({"a": 1}, {"a": 1, "extra": 2}, tol=TOL)
+        assert any("extra keys" in m for m in result)
+        assert any("extra" in m for m in result)
+
+    def test_nested_value_mismatch_path_precise(self) -> None:
+        result = compare_json_content(
+            {"outer": {"inner": 1.0}},
+            {"outer": {"inner": 99.0}},
+            tol=TOL,
+        )
+        assert len(result) == 1
+        assert "outer" in result[0]
+        assert "inner" in result[0]
+
+    def test_path_prefix_propagated(self) -> None:
+        result = compare_json_content({"x": 1}, {"x": 2}, tol=TOL, path="parent")
+        assert "parent" in result[0]
+
+
+class TestAssertBundleRegressionBasic:
+    def test_byte_equal_fast_path_passes(self, tmp_path: Path) -> None:
+        """When both files are byte-identical, no comparison overhead occurs."""
+        content = {"key": 1.0, "nested": {"val": "hello"}}
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, content)
+        _write_json(actual, content)
+        # Must not raise
+        assert_bundle_regression(expected, actual, slug="test-diag", tol=TOL, replacements={})
+
+    def test_missing_expected_silently_skipped(self, tmp_path: Path) -> None:
+        """If expected_path does not exist, the check is silently skipped."""
+        actual = tmp_path / "actual.json"
+        _write_json(actual, {"val": 1})
+        # Must not raise even though expected does not exist
+        assert_bundle_regression(
+            tmp_path / "nonexistent.json",
+            actual,
+            slug="test-diag",
+            tol=TOL,
+            replacements={},
+        )
+
+    def test_value_drift_beyond_tolerance_raises(self, tmp_path: Path) -> None:
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {"score": 1.0})
+        _write_json(actual, {"score": 999.0})
+        with pytest.raises(AssertionError, match="score"):
+            assert_bundle_regression(expected, actual, slug="test-diag", tol=TOL, replacements={})
+
+    def test_value_within_tolerance_passes(self, tmp_path: Path) -> None:
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {"score": 1.0})
+        # Within rtol=1e-6
+        _write_json(actual, {"score": 1.0000005})
+        assert_bundle_regression(expected, actual, slug="test-diag", tol=TOL, replacements={})
+
+    def test_assertion_error_contains_slug(self, tmp_path: Path) -> None:
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {"v": 1.0})
+        _write_json(actual, {"v": 999.0})
+        with pytest.raises(AssertionError, match="my-diag"):
+            assert_bundle_regression(expected, actual, slug="my-diag", tol=TOL, replacements={})
+
+    def test_assertion_error_contains_remediation_hint(self, tmp_path: Path) -> None:
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {"v": 1.0})
+        _write_json(actual, {"v": 999.0})
+        with pytest.raises(AssertionError, match="force-regen"):
+            assert_bundle_regression(expected, actual, slug="diag", tol=TOL, replacements={})
+
+
+class TestAssertBundleRegressionKeySanitisation:
+    """
+    ESMValTool's output.json uses absolute filesystem paths as dict keys.
+    TODO: Should we sanitise this globally?
+    """
+
+    def test_absolute_path_key_sanitised_passes(self, tmp_path: Path) -> None:
+        output_dir = str(tmp_path / "output")
+        expected_key = "<OUTPUT_DIR>/result.nc"
+        actual_key = f"{output_dir}/result.nc"
+
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {expected_key: {"size": 100}})
+        _write_json(actual, {actual_key: {"size": 100}})
+
+        assert_bundle_regression(
+            expected,
+            actual,
+            slug="diag",
+            tol=TOL,
+            replacements={output_dir: "<OUTPUT_DIR>"},
+        )
+
+    def test_value_drift_under_sanitised_key_fails_path_precisely(self, tmp_path: Path) -> None:
+        """
+        Edge case for drift which has been sanitised.
+        """
+        output_dir = str(tmp_path / "output")
+        expected_key = "<OUTPUT_DIR>/result.nc"
+        actual_key = f"{output_dir}/result.nc"
+
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {expected_key: {"size": 100}})
+        _write_json(actual, {actual_key: {"size": 999}})
+
+        with pytest.raises(AssertionError) as exc_info:
+            assert_bundle_regression(
+                expected,
+                actual,
+                slug="diag",
+                tol=TOL,
+                replacements={output_dir: "<OUTPUT_DIR>"},
+            )
+        msg = str(exc_info.value)
+        assert "size" in msg
+
+    def test_test_data_dir_placeholder_in_keys(self, tmp_path: Path) -> None:
+        """
+        <TEST_DATA_DIR> must also be sanitised in dict keys.
+        """
+        test_data_dir = str(tmp_path / "test-data")
+        expected_key = "<TEST_DATA_DIR>/catalog.yaml"
+        actual_key = f"{test_data_dir}/catalog.yaml"
+
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {expected_key: "present"})
+        _write_json(actual, {actual_key: "present"})
+
+        assert_bundle_regression(
+            expected,
+            actual,
+            slug="diag",
+            tol=TOL,
+            replacements={test_data_dir: "<TEST_DATA_DIR>"},
+        )
+
+    def test_longest_key_first_prevents_short_placeholder_preempt(self, tmp_path: Path) -> None:
+        # Simulate: test_data_dir is a prefix of output_dir
+        test_data_dir = str(tmp_path / "data")
+        output_dir = str(tmp_path / "data" / "output")
+
+        expected_key = "<OUTPUT_DIR>/file.nc"
+        actual_key = f"{output_dir}/file.nc"
+
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(expected, {expected_key: "ok"})
+        _write_json(actual, {actual_key: "ok"})
+
+        assert_bundle_regression(
+            expected,
+            actual,
+            slug="diag",
+            tol=TOL,
+            replacements={
+                output_dir: "<OUTPUT_DIR>",
+                test_data_dir: "<TEST_DATA_DIR>",
+            },
+        )
+
+    def test_both_key_and_value_rewritten(self, tmp_path: Path) -> None:
+        """
+        When the same real path appears in both a key AND a leaf value, both must be rewritten.
+        """
+        output_dir = str(tmp_path / "output")
+        expected = tmp_path / "expected.json"
+        actual = tmp_path / "actual.json"
+        _write_json(
+            expected,
+            {"<OUTPUT_DIR>/f.nc": {"path": "<OUTPUT_DIR>/f.nc"}},
+        )
+        _write_json(
+            actual,
+            {f"{output_dir}/f.nc": {"path": f"{output_dir}/f.nc"}},
+        )
+        # Must pass — both key and value are rewritten
+        assert_bundle_regression(
+            expected,
+            actual,
+            slug="diag",
+            tol=TOL,
+            replacements={output_dir: "<OUTPUT_DIR>"},
+        )

--- a/packages/climate-ref-core/tests/unit/regression/test_manifest.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_manifest.py
@@ -1,0 +1,202 @@
+"""
+Tests for :mod:`climate_ref_core.regression.manifest`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pooch.hashes
+import pytest
+
+from climate_ref_core.regression.manifest import (
+    SCHEMA_VERSION,
+    Manifest,
+    NativeEntry,
+    compute_committed_digests,
+    sha256_bytes,
+    sha256_file,
+    verify_committed_integrity,
+)
+
+
+@pytest.fixture()
+def tmp_file(tmp_path: Path) -> Path:
+    p = tmp_path / "sample.bin"
+    p.write_bytes(b"hello manifest test")
+    return p
+
+
+@pytest.fixture()
+def regression_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "regression"
+    d.mkdir()
+    (d / "series.json").write_text('{"series": 1}\n', encoding="utf-8")
+    (d / "diagnostic.json").write_text('{"diagnostic": 2}\n', encoding="utf-8")
+    (d / "output.json").write_text('{"output": 3}\n', encoding="utf-8")
+    return d
+
+
+class TestSha256File:
+    """``sha256_file`` must agree with pooch's own file_hash."""
+
+    def test_agrees_with_pooch(self, tmp_file: Path) -> None:
+        expected = pooch.hashes.file_hash(str(tmp_file), alg="sha256")
+        assert sha256_file(tmp_file) == expected
+
+    def test_returns_hex_string(self, tmp_file: Path) -> None:
+        result = sha256_file(tmp_file)
+        assert isinstance(result, str)
+        # sha256 hex digest is exactly 64 characters
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+
+class TestSha256Bytes:
+    def test_known_value(self) -> None:
+        data = b"abc"
+        assert sha256_bytes(data) == hashlib.sha256(data).hexdigest()
+
+    def test_empty_bytes(self) -> None:
+        assert sha256_bytes(b"") == hashlib.sha256(b"").hexdigest()
+
+    def test_agrees_with_sha256_file(self, tmp_file: Path) -> None:
+        data = tmp_file.read_bytes()
+        assert sha256_bytes(data) == sha256_file(tmp_file)
+
+
+class TestSeedV1:
+    def test_test_case_version_is_1(self) -> None:
+        m = Manifest.seed_v1({"series.json": "abc123"})
+        assert m.test_case_version == 1
+
+    def test_native_is_empty(self) -> None:
+        m = Manifest.seed_v1({"series.json": "abc123"})
+        assert m.native == {}
+
+    def test_schema_equals_schema_version(self) -> None:
+        m = Manifest.seed_v1({})
+        assert m.schema == SCHEMA_VERSION
+
+    def test_committed_digests_stored(self) -> None:
+        digests = {"series.json": "aa" * 32, "diagnostic.json": "bb" * 32}
+        m = Manifest.seed_v1(digests)
+        assert m.committed == digests
+
+
+class TestDumpLoad:
+    """dump then load must be byte-identical and stable."""
+
+    def _make_manifest(self) -> Manifest:
+        return Manifest(
+            schema=SCHEMA_VERSION,
+            test_case_version=2,
+            committed={"output.json": "cc" * 32, "series.json": "dd" * 32},
+            native={"foo/bar.nc": NativeEntry(sha256="ee" * 32, size=1024)},
+        )
+
+    def test_round_trip_values(self, tmp_path: Path) -> None:
+        original = self._make_manifest()
+        p = tmp_path / "manifest.json"
+        original.dump(p)
+        loaded = Manifest.load(p)
+        assert loaded.schema == original.schema
+        assert loaded.test_case_version == original.test_case_version
+        assert loaded.committed == original.committed
+        assert loaded.native == original.native
+
+    def test_dump_then_load_byte_identical(self, tmp_path: Path) -> None:
+        """Two successive dumps must produce the same bytes."""
+        original = self._make_manifest()
+        p1 = tmp_path / "m1.json"
+        p2 = tmp_path / "m2.json"
+        original.dump(p1)
+        original.dump(p2)
+        assert p1.read_bytes() == p2.read_bytes()
+
+    def test_trailing_newline(self, tmp_path: Path) -> None:
+        p = tmp_path / "manifest.json"
+        self._make_manifest().dump(p)
+        text = p.read_text(encoding="utf-8")
+        assert text.endswith("\n")
+
+    def test_stable_key_order(self, tmp_path: Path) -> None:
+        """Top-level keys must be sorted (sort_keys=True)."""
+        p = tmp_path / "manifest.json"
+        self._make_manifest().dump(p)
+        data = json.loads(p.read_text(encoding="utf-8"))
+        keys = list(data.keys())
+        assert keys == sorted(keys)
+
+    def test_native_entry_round_trip(self, tmp_path: Path) -> None:
+        entry = NativeEntry(sha256="ff" * 32, size=512)
+        m = Manifest(
+            schema=SCHEMA_VERSION,
+            test_case_version=1,
+            committed={},
+            native={"path/to/file.nc": entry},
+        )
+        p = tmp_path / "manifest.json"
+        m.dump(p)
+        loaded = Manifest.load(p)
+        assert loaded.native["path/to/file.nc"] == entry
+
+
+class TestComputeCommittedDigests:
+    def test_all_three_present(self, regression_dir: Path) -> None:
+        digests = compute_committed_digests(regression_dir)
+        assert set(digests.keys()) == {"series.json", "diagnostic.json", "output.json"}
+
+    def test_digest_values_match_sha256_file(self, regression_dir: Path) -> None:
+        digests = compute_committed_digests(regression_dir)
+        for relpath, digest in digests.items():
+            assert digest == sha256_file(regression_dir / relpath)
+
+    def test_missing_file_excluded(self, regression_dir: Path) -> None:
+        (regression_dir / "output.json").unlink()
+        digests = compute_committed_digests(regression_dir)
+        assert "output.json" not in digests
+        assert "series.json" in digests
+        assert "diagnostic.json" in digests
+
+    def test_empty_dir_returns_empty_dict(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert compute_committed_digests(empty) == {}
+
+
+class TestVerifyCommittedIntegrity:
+    def _make_manifest_for(self, regression_dir: Path) -> Manifest:
+        digests = compute_committed_digests(regression_dir)
+        return Manifest.seed_v1(digests)
+
+    def test_clean_bundle_returns_empty_list(self, regression_dir: Path) -> None:
+        manifest = self._make_manifest_for(regression_dir)
+        result = verify_committed_integrity(manifest, regression_dir)
+        assert result == []
+
+    def test_tampered_file_returns_named_mismatch(self, regression_dir: Path) -> None:
+        manifest = self._make_manifest_for(regression_dir)
+        # Tamper with series.json
+        (regression_dir / "series.json").write_text('{"series": 999}\n', encoding="utf-8")
+        result = verify_committed_integrity(manifest, regression_dir)
+        assert len(result) == 1
+        assert "series.json" in result[0]
+
+    def test_missing_file_returns_named_mismatch(self, regression_dir: Path) -> None:
+        manifest = self._make_manifest_for(regression_dir)
+        (regression_dir / "diagnostic.json").unlink()
+        result = verify_committed_integrity(manifest, regression_dir)
+        assert len(result) == 1
+        assert "diagnostic.json" in result[0]
+
+    def test_multiple_tampers_all_reported(self, regression_dir: Path) -> None:
+        manifest = self._make_manifest_for(regression_dir)
+        (regression_dir / "series.json").write_text("changed\n", encoding="utf-8")
+        (regression_dir / "output.json").unlink()
+        result = verify_committed_integrity(manifest, regression_dir)
+        assert len(result) == 2
+        reported_files = {line.split(":")[0] for line in result}
+        assert reported_files == {"series.json", "output.json"}

--- a/packages/climate-ref-core/tests/unit/regression/test_manifest.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_manifest.py
@@ -2,8 +2,6 @@
 Tests for :mod:`climate_ref_core.regression.manifest`.
 """
 
-from __future__ import annotations
-
 import hashlib
 import json
 from pathlib import Path

--- a/packages/climate-ref-core/tests/unit/regression/test_manifest.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_manifest.py
@@ -143,6 +143,24 @@ class TestDumpLoad:
         loaded = Manifest.load(p)
         assert loaded.native["path/to/file.nc"] == entry
 
+    def test_load_missing_keys_raises_value_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "manifest.json"
+        p.write_text(json.dumps({"schema": SCHEMA_VERSION, "committed": {}}), encoding="utf-8")
+        with pytest.raises(ValueError, match=r"missing required keys \['test_case_version', 'native'\]"):
+            Manifest.load(p)
+
+    def test_load_malformed_native_entry_raises_value_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "manifest.json"
+        payload = {
+            "schema": SCHEMA_VERSION,
+            "test_case_version": 1,
+            "committed": {},
+            "native": {"file.nc": {"sha256": "aa" * 32}},  # missing "size"
+        }
+        p.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(ValueError, match="malformed 'native' entry"):
+            Manifest.load(p)
+
 
 class TestComputeCommittedDigests:
     def test_all_three_present(self, regression_dir: Path) -> None:

--- a/packages/climate-ref-core/tests/unit/regression/test_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_store.py
@@ -100,7 +100,7 @@ class TestLocalFilesystemStore:
         blob_path = local_store._blob_path(blob_digest)
         blob_path.write_bytes(b"corrupted content")
         dest = tmp_path / "out.nc"
-        with pytest.raises((ValueError, Exception)):
+        with pytest.raises(ValueError):
             local_store.fetch(blob_digest, dest)
 
     def test_put_idempotent(
@@ -176,41 +176,44 @@ class TestPoochReadStore:
 
     def test_fetch_hash_verified(
         self,
-        blob_content: bytes,
         blob_digest: str,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
-        A blob served with corrupt content under the correct digest filename
-        must be detected by ``_verify_hash_matches`` and raise.
+        A downloaded blob whose content does not hash to the requested digest must be
+        rejected by ``_verify_hash_matches`` with a ``ValueError``.
+
+        The pooch download is mocked so the store's own hash verification is exercised
+        deterministically, without standing up an HTTP server (a real server combined
+        with pooch's ``retry_if_failed`` makes connect timeouts raise unrelated network
+        errors and can hang the test for minutes).
         """
-        flat_root = tmp_path / "serve"
-        flat_root.mkdir()
-        # Write corrupt bytes under the correct digest name.
-        (flat_root / blob_digest).write_bytes(b"corrupt bytes -- digest will not match")
+        cache_dir = tmp_path / "cache"
 
-        class _Handler(http.server.SimpleHTTPRequestHandler):
-            def log_message(self, *args: object) -> None:
-                pass
+        class _FakeRegistry:
+            """Stand-in for the pooch registry that "downloads" corrupt content."""
 
-        orig_cwd = os.getcwd()
-        os.chdir(flat_root)
-        try:
-            with http.server.HTTPServer(("127.0.0.1", 0), _Handler) as httpd:
-                port = httpd.server_address[1]
-                thread = threading.Thread(target=httpd.handle_request, daemon=True)
-                thread.start()
+            def __init__(self) -> None:
+                self.registry: dict[str, str] = {}
 
-                store = PoochReadStore(
-                    base_url=f"http://127.0.0.1:{port}",
-                    cache_dir=tmp_path / "cache",
-                )
-                dest = tmp_path / "out.nc"
-                with pytest.raises(Exception):
-                    store.fetch(blob_digest, dest)
-                thread.join(timeout=5)
-        finally:
-            os.chdir(orig_cwd)
+            def fetch(self, fname: str) -> str:
+                # Yield content that does not hash to ``fname``, bypassing pooch's own
+                # hash check so the store-level verification is the failure point.
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                cached = cache_dir / fname
+                cached.write_bytes(b"corrupt bytes -- digest will not match")
+                return str(cached)
+
+        monkeypatch.setattr(
+            "climate_ref_core.regression.store.pooch.create",
+            lambda *args, **kwargs: _FakeRegistry(),
+        )
+
+        store = PoochReadStore(base_url="http://example.invalid", cache_dir=cache_dir)
+        dest = tmp_path / "out.nc"
+        with pytest.raises(ValueError):
+            store.fetch(blob_digest, dest)
 
 
 class TestR2WriteStore:

--- a/packages/climate-ref-core/tests/unit/regression/test_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_store.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import hashlib
+import http.server
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from climate_ref_core.regression.store import (
+    LocalFilesystemStore,
+    NativeStore,
+    PoochReadStore,
+    R2WriteStore,
+    build_native_store,
+)
+
+
+@pytest.fixture()
+def blob_content() -> bytes:
+    return b"native bundle blob content for testing"
+
+
+@pytest.fixture()
+def blob_file(tmp_path: Path, blob_content: bytes) -> Path:
+    p = tmp_path / "blob.nc"
+    p.write_bytes(blob_content)
+    return p
+
+
+@pytest.fixture()
+def blob_digest(blob_content: bytes) -> str:
+    return hashlib.sha256(blob_content).hexdigest()
+
+
+@pytest.fixture()
+def local_store(tmp_path: Path) -> LocalFilesystemStore:
+    return LocalFilesystemStore(root=tmp_path / "store")
+
+
+class TestLocalFilesystemStore:
+    def test_satisfies_protocol(self, local_store: LocalFilesystemStore) -> None:
+        assert isinstance(local_store, NativeStore)
+
+    def test_put_returns_sha256(
+        self, local_store: LocalFilesystemStore, blob_file: Path, blob_digest: str
+    ) -> None:
+        result = local_store.put(blob_file)
+        assert result == blob_digest
+
+    def test_has_true_after_put(
+        self, local_store: LocalFilesystemStore, blob_file: Path, blob_digest: str
+    ) -> None:
+        local_store.put(blob_file)
+        assert local_store.has(blob_digest) is True
+
+    def test_has_false_before_put(self, local_store: LocalFilesystemStore, blob_digest: str) -> None:
+        assert local_store.has(blob_digest) is False
+
+    def test_fetch_byte_identical(
+        self,
+        local_store: LocalFilesystemStore,
+        blob_file: Path,
+        blob_content: bytes,
+        blob_digest: str,
+        tmp_path: Path,
+    ) -> None:
+        local_store.put(blob_file)
+        dest = tmp_path / "fetched.nc"
+        local_store.fetch(blob_digest, dest)
+        assert dest.read_bytes() == blob_content
+
+    def test_fetch_creates_parent_dirs(
+        self,
+        local_store: LocalFilesystemStore,
+        blob_file: Path,
+        blob_digest: str,
+        tmp_path: Path,
+    ) -> None:
+        local_store.put(blob_file)
+        dest = tmp_path / "deep" / "nested" / "file.nc"
+        local_store.fetch(blob_digest, dest)
+        assert dest.exists()
+
+    def test_fetch_missing_raises_file_not_found(
+        self, local_store: LocalFilesystemStore, blob_digest: str, tmp_path: Path
+    ) -> None:
+        with pytest.raises(FileNotFoundError):
+            local_store.fetch(blob_digest, tmp_path / "out.nc")
+
+    def test_fetch_digest_mismatch_raises_value_error(
+        self,
+        local_store: LocalFilesystemStore,
+        blob_file: Path,
+        blob_digest: str,
+        tmp_path: Path,
+    ) -> None:
+        """Corrupt the stored blob; fetch should detect the mismatch."""
+        local_store.put(blob_file)
+        # Corrupt the stored blob directly
+        blob_path = local_store._blob_path(blob_digest)
+        blob_path.write_bytes(b"corrupted content")
+        dest = tmp_path / "out.nc"
+        with pytest.raises((ValueError, Exception)):
+            local_store.fetch(blob_digest, dest)
+
+    def test_put_idempotent(
+        self,
+        local_store: LocalFilesystemStore,
+        blob_file: Path,
+        blob_digest: str,
+    ) -> None:
+        """Putting the same blob twice must succeed and return the same digest."""
+        d1 = local_store.put(blob_file)
+        d2 = local_store.put(blob_file)
+        assert d1 == d2 == blob_digest
+
+    def test_two_level_layout(
+        self, local_store: LocalFilesystemStore, blob_file: Path, blob_digest: str
+    ) -> None:
+        """Blobs must be stored at root/<digest[:2]>/<digest>."""
+        local_store.put(blob_file)
+        expected = local_store.root / blob_digest[:2] / blob_digest
+        assert expected.exists()
+
+
+# ---------------------------------------------------------------------------
+# PoochReadStore
+# ---------------------------------------------------------------------------
+
+
+class TestPoochReadStore:
+    def test_satisfies_protocol(self, tmp_path: Path) -> None:
+        store = PoochReadStore(base_url="https://example.com", cache_dir=tmp_path)
+        assert isinstance(store, NativeStore)
+
+    def test_put_raises_not_implemented(self, tmp_path: Path, blob_file: Path) -> None:
+        store = PoochReadStore(base_url="https://example.com", cache_dir=tmp_path)
+        with pytest.raises(NotImplementedError):
+            store.put(blob_file)
+
+    def test_fetch_byte_identical(
+        self,
+        blob_content: bytes,
+        blob_digest: str,
+        tmp_path: Path,
+    ) -> None:
+        """
+        PoochReadStore.fetch must download a blob and produce byte-identical content.
+
+        Served via a tiny local HTTP server since pooch does not support ``file://``.
+        """
+        # Serve blobs from a flat directory: base_url/<digest>
+        flat_root = tmp_path / "serve"
+        flat_root.mkdir()
+        (flat_root / blob_digest).write_bytes(blob_content)
+
+        class _Handler(http.server.SimpleHTTPRequestHandler):
+            def log_message(self, *args: object) -> None:
+                pass
+
+        orig_cwd = os.getcwd()
+        os.chdir(flat_root)
+        try:
+            with http.server.HTTPServer(("127.0.0.1", 0), _Handler) as httpd:
+                port = httpd.server_address[1]
+                # Each request consumes one handle_request call.
+                thread = threading.Thread(target=httpd.handle_request, daemon=True)
+                thread.start()
+
+                store = PoochReadStore(
+                    base_url=f"http://127.0.0.1:{port}",
+                    cache_dir=tmp_path / "cache",
+                )
+                dest = tmp_path / "fetched.nc"
+                store.fetch(blob_digest, dest)
+                thread.join(timeout=5)
+        finally:
+            os.chdir(orig_cwd)
+
+        assert dest.read_bytes() == blob_content
+
+    def test_fetch_hash_verified(
+        self,
+        blob_content: bytes,
+        blob_digest: str,
+        tmp_path: Path,
+    ) -> None:
+        """
+        A blob served with corrupt content under the correct digest filename
+        must be detected by ``_verify_hash_matches`` and raise.
+        """
+        flat_root = tmp_path / "serve"
+        flat_root.mkdir()
+        # Write corrupt bytes under the correct digest name.
+        (flat_root / blob_digest).write_bytes(b"corrupt bytes -- digest will not match")
+
+        class _Handler(http.server.SimpleHTTPRequestHandler):
+            def log_message(self, *args: object) -> None:
+                pass
+
+        orig_cwd = os.getcwd()
+        os.chdir(flat_root)
+        try:
+            with http.server.HTTPServer(("127.0.0.1", 0), _Handler) as httpd:
+                port = httpd.server_address[1]
+                thread = threading.Thread(target=httpd.handle_request, daemon=True)
+                thread.start()
+
+                store = PoochReadStore(
+                    base_url=f"http://127.0.0.1:{port}",
+                    cache_dir=tmp_path / "cache",
+                )
+                dest = tmp_path / "out.nc"
+                with pytest.raises(Exception):
+                    store.fetch(blob_digest, dest)
+                thread.join(timeout=5)
+        finally:
+            os.chdir(orig_cwd)
+
+
+class TestR2WriteStore:
+    def test_construction_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError, match="R2 backend deferred"):
+            R2WriteStore()
+
+
+class _StubConfig:
+    """Minimal config double satisfying _NativeStoreConfigProtocol."""
+
+    def __init__(self, url: str, cache_dir: Path) -> None:
+        self._url = url
+        self._cache_dir = cache_dir
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @property
+    def cache_dir(self) -> Path:
+        return self._cache_dir
+
+
+class TestBuildNativeStore:
+    def test_writable_false_local_path_returns_local_store(self, tmp_path: Path) -> None:
+        cfg = _StubConfig(url=str(tmp_path / "store"), cache_dir=tmp_path / "cache")
+        store = build_native_store(cfg, writable=False)
+        assert isinstance(store, LocalFilesystemStore)
+
+    def test_writable_false_file_url_returns_local_store(self, tmp_path: Path) -> None:
+        cfg = _StubConfig(
+            url=(tmp_path / "store").as_uri(),
+            cache_dir=tmp_path / "cache",
+        )
+        store = build_native_store(cfg, writable=False)
+        assert isinstance(store, LocalFilesystemStore)
+
+    def test_writable_false_remote_url_returns_pooch_store(self, tmp_path: Path) -> None:
+        cfg = _StubConfig(
+            url="https://baselines.example.com",
+            cache_dir=tmp_path / "cache",
+        )
+        store = build_native_store(cfg, writable=False)
+        assert isinstance(store, PoochReadStore)
+
+    def test_writable_false_never_requires_creds(self, tmp_path: Path) -> None:
+        """
+        ``writable=False`` must always return a credential-free store.
+
+        Local stores are inherently creds-free.
+        Remote read stores (PoochReadStore) are anonymous public-read.
+        This test asserts no :class:`NotImplementedError` is raised.
+        """
+        for url in [
+            str(tmp_path / "store"),
+            (tmp_path / "store").as_uri(),
+            "https://baselines.example.com",
+        ]:
+            cfg = _StubConfig(url=url, cache_dir=tmp_path / "cache")
+            # Must not raise — no credentials required.
+            store = build_native_store(cfg, writable=False)
+            assert isinstance(store, NativeStore)

--- a/packages/climate-ref-core/tests/unit/regression/test_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_store.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import hashlib
 import http.server
 import os
@@ -123,11 +121,6 @@ class TestLocalFilesystemStore:
         local_store.put(blob_file)
         expected = local_store.root / blob_digest[:2] / blob_digest
         assert expected.exists()
-
-
-# ---------------------------------------------------------------------------
-# PoochReadStore
-# ---------------------------------------------------------------------------
 
 
 class TestPoochReadStore:

--- a/packages/climate-ref-core/tests/unit/regression/test_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_store.py
@@ -222,7 +222,7 @@ class TestPoochReadStore:
 
 class TestR2WriteStore:
     def test_construction_raises_not_implemented(self) -> None:
-        with pytest.raises(NotImplementedError, match="R2 backend deferred"):
+        with pytest.raises(NotImplementedError, match="deferred to a follow-up PR"):
             R2WriteStore()
 
 
@@ -281,3 +281,21 @@ class TestBuildNativeStore:
             # Must not raise — no credentials required.
             store = build_native_store(cfg, writable=False)
             assert isinstance(store, NativeStore)
+
+    def test_file_url_resolves_to_absolute_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "store"
+        for url in [root.as_uri(), f"file:{root}"]:  # file:///abs and single-slash file:/abs
+            cfg = _StubConfig(url=url, cache_dir=tmp_path / "cache")
+            store = build_native_store(cfg, writable=False)
+            assert isinstance(store, LocalFilesystemStore)
+            assert store.root == root
+
+    def test_file_url_with_host_raises_value_error(self, tmp_path: Path) -> None:
+        cfg = _StubConfig(url="file://store/blobs", cache_dir=tmp_path / "cache")
+        with pytest.raises(ValueError, match="host component"):
+            build_native_store(cfg, writable=False)
+
+    def test_writable_true_remote_url_raises_not_implemented(self, tmp_path: Path) -> None:
+        cfg = _StubConfig(url="https://baselines.example.com", cache_dir=tmp_path / "cache")
+        with pytest.raises(NotImplementedError, match="deferred to a follow-up PR"):
+            build_native_store(cfg, writable=True)

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -40,6 +40,7 @@ from climate_ref._config_helpers import (
     transform_error,
 )
 from climate_ref.constants import CONFIG_FILENAME
+from climate_ref_core.dataset_registry import resolve_cache_dir
 from climate_ref_core.env import env
 from climate_ref_core.exceptions import InvalidExecutorException
 from climate_ref_core.logging import DEFAULT_LOG_FORMAT
@@ -156,6 +157,53 @@ class PathConfig:
     def _dimensions_cv_factory(self) -> Path:
         filename = "cv_cmip7_aft.yaml"
         return Path(str(importlib.resources.files("climate_ref_core.pycmec") / filename))
+
+
+@config(prefix=env_prefix)
+class NativeStoreConfig:
+    """
+    Configuration for the content-addressed native-bundle object store.
+
+    The native store holds the curated native outputs (NetCDF, PNG, ...) produced by each
+    test case, keyed by their sha256 digest.
+    Read operations (``has``, ``fetch``) are always anonymous and credential-free.
+    Write operations are gated to the ``mint`` verb only.
+    """
+
+    url: str = env_field(name="NATIVE_STORE_URL", default="https://baselines.climate-ref.org")
+    """
+    Base URL of the native-bundle object store.
+
+    Blobs are served at ``{url}/{digest}``.
+    Defaults to the production Climate-REF baselines endpoint.
+
+    Set ``REF_NATIVE_STORE_URL`` to a local ``file:///path/to/dir`` (or a plain filesystem path)
+    for offline development and testing.
+    """
+
+    credentials: str = env_field(name="NATIVE_STORE_CREDENTIALS", default="")
+    """
+    Credentials for write access to the native-bundle object store.
+
+    Only consumed by the ``mint`` verb (object-store upload).
+    Anonymous read (``fetch`` / ``has``) never requires credentials.
+    Set ``REF_NATIVE_STORE_CREDENTIALS`` to the appropriate token or key material.
+    """
+
+    @property
+    def cache_dir(self) -> Path:
+        """
+        Local pooch cache directory for downloaded native blobs.
+
+        Reuses :func:`~climate_ref_core.dataset_registry.resolve_cache_dir` so the
+        ``REF_DATASET_CACHE_DIR`` environment variable applies here too.
+
+        Returns
+        -------
+        :
+            The resolved cache directory path.
+        """
+        return resolve_cache_dir("native-baselines")
 
 
 @config(prefix=env_prefix)
@@ -445,6 +493,7 @@ class Config:
     """
 
     paths: PathConfig = Factory(PathConfig)
+    native_store: NativeStoreConfig = Factory(NativeStoreConfig)
     db: DbConfig = Factory(DbConfig)
     executor: ExecutorConfig = Factory(ExecutorConfig)
     diagnostic_providers: list[DiagnosticProviderConfig] = Factory(default_providers)  # noqa: RUF009, RUF100

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -190,19 +190,16 @@ class NativeStoreConfig:
     Set ``REF_NATIVE_STORE_CREDENTIALS`` to the appropriate token or key material.
     """
 
-    @property
-    def cache_dir(self) -> Path:
-        """
-        Local pooch cache directory for downloaded native blobs.
+    cache_dir: Path = env_field(name="NATIVE_STORE_CACHE_DIR", converter=Path)
+    """
+    Local pooch cache directory for downloaded native blobs.
 
-        Reuses :func:`~climate_ref_core.dataset_registry.resolve_cache_dir` so the
-        ``REF_DATASET_CACHE_DIR`` environment variable applies here too.
+    Defaults via :func:`~climate_ref_core.dataset_registry.resolve_cache_dir`,
+    so the ``REF_DATASET_CACHE_DIR`` environment variable applies here too.
+    """
 
-        Returns
-        -------
-        :
-            The resolved cache directory path.
-        """
+    @cache_dir.default
+    def _cache_dir_factory(self) -> Path:
         return resolve_cache_dir("native-baselines")
 
 

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -179,6 +179,10 @@ filename = "sqlite://climate_ref.db"
                 },
             ],
             "executor": {"executor": "climate_ref.executor.LocalExecutor", "config": {}},
+            "native_store": {
+                "url": "https://baselines.climate-ref.org",
+                "credentials": "",
+            },
             "paths": {
                 "log": f"{default_path}/log",
                 "results": f"{default_path}/results",

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -18,6 +18,7 @@ from climate_ref.config import (
     _get_default_ignore_datasets_file,
     transform_error,
 )
+from climate_ref_core.dataset_registry import resolve_cache_dir
 from climate_ref_core.exceptions import InvalidExecutorException
 from climate_ref_core.executor import Executor
 
@@ -182,6 +183,7 @@ filename = "sqlite://climate_ref.db"
             "native_store": {
                 "url": "https://baselines.climate-ref.org",
                 "credentials": "",
+                "cache_dir": str(resolve_cache_dir("native-baselines")),
             },
             "paths": {
                 "log": f"{default_path}/log",


### PR DESCRIPTION
## Description

Add `climate_ref_core.regression` — the building blocks for handling regression testing. This doesn't actually wire the changes in yet.

**Modules.**

- `manifest` — the `manifest.json` model (`schema`, `test_case_version`, `committed`, `native`) plus sha256 digest helpers and committed-integrity verification.
- `store` — content-addressed `NativeStore` Protocol with `LocalFilesystemStore`
  (read/write, two-level `<root>/<digest[:2]>/<digest>` layout) and an anonymous
  `PoochReadStore` (public read, caching + hash verification). `build_native_store`
  selects by config.
- `compare` — tolerant JSON comparator (float `rtol`/`atol`, dict-key + leaf-value placeholder rewriting, JSON-path-precise mismatch messages) used to check committed bundles.
- `capture` — committed-bundle + native-snapshot capture built on `copy_execution_outputs` (from #719), so the captured native set is, by construction, exactly what production persists.

Add `NativeStoreConfig` (`url` / `credentials` / `cache_dir`) to the app config.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
