### PR TITLE
test: speed up the climate-ref suite and silence deprecation warnings

### DIFF
--- a/changelog/723.trivial.md
+++ b/changelog/723.trivial.md
@@ -1,0 +1,1 @@
+Sped up the `climate-ref` test suite and removed the deprecation and future warnings it emitted during testing.

--- a/packages/climate-ref-example/src/climate_ref_example/example.py
+++ b/packages/climate-ref-example/src/climate_ref_example/example.py
@@ -38,9 +38,6 @@ def calculate_annual_mean_timeseries(input_files: list[Path]) -> xr.Dataset:
         The annual mean timeseries of the dataset
     """
     time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
-    # Pass the historical defaults for ``data_vars`` and ``compat`` explicitly so the
-    # diagnostic output stays stable: xarray is changing these defaults and emits a
-    # FutureWarning otherwise (see xarray ``use_new_combine_kwarg_defaults``).
     xr_ds = xr.open_mfdataset(
         input_files,
         combine="by_coords",

--- a/packages/climate-ref-example/src/climate_ref_example/example.py
+++ b/packages/climate-ref-example/src/climate_ref_example/example.py
@@ -38,7 +38,17 @@ def calculate_annual_mean_timeseries(input_files: list[Path]) -> xr.Dataset:
         The annual mean timeseries of the dataset
     """
     time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
-    xr_ds = xr.open_mfdataset(input_files, combine="by_coords", chunks=None, decode_times=time_coder)
+    # Pass the historical defaults for ``data_vars`` and ``compat`` explicitly so the
+    # diagnostic output stays stable: xarray is changing these defaults and emits a
+    # FutureWarning otherwise (see xarray ``use_new_combine_kwarg_defaults``).
+    xr_ds = xr.open_mfdataset(
+        input_files,
+        combine="by_coords",
+        chunks=None,
+        decode_times=time_coder,
+        data_vars="all",
+        compat="no_conflicts",
+    )
 
     annual_mean = xr_ds.resample(time="YS").mean()
 

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -23,6 +23,7 @@ from climate_ref.datasets.cmip7_parsers import parse_cmip7_complete, parse_cmip7
 from climate_ref.datasets.obs4mips import Obs4MIPsDatasetAdapter
 from climate_ref.models.metric_value import MetricValue
 from climate_ref.provider_registry import _register_provider
+from climate_ref.solve_helpers import solve_to_results
 from climate_ref_core.cmip6_to_cmip7 import (
     convert_cmip6_dataset,
     create_cmip7_filename,
@@ -115,6 +116,17 @@ def db_seeded(db_seeded_template, config) -> Database:
     database = Database.from_config(config, run_migrations=True)
     yield database
     database.close()
+
+
+@pytest.fixture(scope="session")
+def esgf_example_solve_results(esgf_data_catalog) -> list[dict[str, Any]]:
+    """Session-cached example-provider solve over the full ESGF catalog.
+
+    The solve is expensive (tens of seconds) and side-effect free, so it is shared
+    by the solve-helpers and solve-regression suites instead of being recomputed
+    once per module.
+    """
+    return solve_to_results(esgf_data_catalog, providers=[example_provider])
 
 
 @pytest.fixture

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -122,9 +122,7 @@ def db_seeded(db_seeded_template, config) -> Database:
 def esgf_example_solve_results(esgf_data_catalog) -> list[dict[str, Any]]:
     """Session-cached example-provider solve over the full ESGF catalog.
 
-    The solve is expensive (tens of seconds) and side-effect free, so it is shared
-    by the solve-helpers and solve-regression suites instead of being recomputed
-    once per module.
+    The solve is expensive (tens of seconds) so we cache the results.
     """
     return solve_to_results(esgf_data_catalog, providers=[example_provider])
 

--- a/packages/climate-ref/tests/integration/datasets/test_adapter_integration.py
+++ b/packages/climate-ref/tests/integration/datasets/test_adapter_integration.py
@@ -151,10 +151,11 @@ class TestRoundTripAndFinalisation:
                 )
             ).reset_index(drop=True)
 
-            # Normalize null values for consistent comparison
-            with pd.option_context("future.no_silent_downcasting", True):
-                local_normalized = local_data_catalog.fillna(np.nan).infer_objects()
-                db_normalized = db_data_catalog.fillna(np.nan).infer_objects()
+            # Normalize null values for consistent comparison. Pandas >=4 no longer
+            # silently downcasts, so the deprecated ``future.no_silent_downcasting``
+            # option context is unnecessary.
+            local_normalized = local_data_catalog.fillna(np.nan).infer_objects()
+            db_normalized = db_data_catalog.fillna(np.nan).infer_objects()
 
             pd.testing.assert_frame_equal(
                 local_normalized,

--- a/packages/climate-ref/tests/integration/datasets/test_adapter_integration.py
+++ b/packages/climate-ref/tests/integration/datasets/test_adapter_integration.py
@@ -151,9 +151,7 @@ class TestRoundTripAndFinalisation:
                 )
             ).reset_index(drop=True)
 
-            # Normalize null values for consistent comparison. Pandas >=4 no longer
-            # silently downcasts, so the deprecated ``future.no_silent_downcasting``
-            # option context is unnecessary.
+            # Normalize null values for consistent comparison.
             local_normalized = local_data_catalog.fillna(np.nan).infer_objects()
             db_normalized = db_data_catalog.fillna(np.nan).infer_objects()
 

--- a/packages/climate-ref/tests/integration/test_executor_failure_modes.py
+++ b/packages/climate-ref/tests/integration/test_executor_failure_modes.py
@@ -270,7 +270,7 @@ class TestStaleExecutionSweep:
     """``fail_stale_in_progress_executions`` reaps abandoned in-progress rows."""
 
     def _backdate(self, db, execution_id: int, hours: int) -> None:
-        # Match the naive-UTC convention used by ``fail_stale_in_progress_executions``.
+        # TODO: Using a naive UTC datetime
         old = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(
             hours=hours
         )

--- a/packages/climate-ref/tests/integration/test_executor_failure_modes.py
+++ b/packages/climate-ref/tests/integration/test_executor_failure_modes.py
@@ -270,7 +270,10 @@ class TestStaleExecutionSweep:
     """``fail_stale_in_progress_executions`` reaps abandoned in-progress rows."""
 
     def _backdate(self, db, execution_id: int, hours: int) -> None:
-        old = datetime.datetime.utcnow() - datetime.timedelta(hours=hours)
+        # Match the naive-UTC convention used by ``fail_stale_in_progress_executions``.
+        old = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(
+            hours=hours
+        )
         with db.session.begin():
             db.session.execute(update(Execution).where(Execution.id == execution_id).values(created_at=old))
 

--- a/packages/climate-ref/tests/unit/cli/test_providers.py
+++ b/packages/climate-ref/tests/unit/cli/test_providers.py
@@ -96,8 +96,6 @@ class TestProvidersList:
 
 @pytest.mark.filterwarnings("ignore:create-env is deprecated:DeprecationWarning")
 class TestProvidersCreateEnv:
-    """These tests deliberately exercise the deprecated ``create-env`` command."""
-
     def test_create_env(self, config, invoke_cli):
         result = invoke_cli(["providers", "create-env"])
         assert result.exit_code == 0

--- a/packages/climate-ref/tests/unit/cli/test_providers.py
+++ b/packages/climate-ref/tests/unit/cli/test_providers.py
@@ -1,3 +1,5 @@
+import pytest
+
 from climate_ref.provider_registry import ProviderRegistry
 from climate_ref_core.providers import CondaDiagnosticProvider, DiagnosticProvider
 from climate_ref_core.summary import (
@@ -92,7 +94,10 @@ class TestProvidersList:
         assert "(not fetched)" not in result.stdout
 
 
+@pytest.mark.filterwarnings("ignore:create-env is deprecated:DeprecationWarning")
 class TestProvidersCreateEnv:
+    """These tests deliberately exercise the deprecated ``create-env`` command."""
+
     def test_create_env(self, config, invoke_cli):
         result = invoke_cli(["providers", "create-env"])
         assert result.exit_code == 0

--- a/packages/climate-ref/tests/unit/test_solve_helpers.py
+++ b/packages/climate-ref/tests/unit/test_solve_helpers.py
@@ -8,7 +8,6 @@ import json
 
 import pandas as pd
 import pytest
-from climate_ref_example import provider as example_provider
 
 from climate_ref.solve_helpers import (
     format_solve_results_json,
@@ -16,7 +15,6 @@ from climate_ref.solve_helpers import (
     generate_catalog,
     load_solve_catalog,
     solve_results_for_regression,
-    solve_to_results,
     write_catalog_parquet,
 )
 from climate_ref_core.datasets import SourceDatasetType
@@ -66,9 +64,9 @@ def obs4mips_generated_catalog(sample_data_dir):
 
 
 @pytest.fixture(scope="module")
-def example_solve_results(esgf_data_catalog):
-    """Module-cached solve results to avoid redundant solver runs."""
-    return solve_to_results(esgf_data_catalog, providers=[example_provider])
+def example_solve_results(esgf_example_solve_results):
+    """Reuse the session-cached example-provider solve (see root conftest)."""
+    return esgf_example_solve_results
 
 
 class TestGenerateCatalog:

--- a/packages/climate-ref/tests/unit/test_solve_regression.py
+++ b/packages/climate-ref/tests/unit/test_solve_regression.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 import pytest
 from climate_ref_example import provider as example_provider
 
-from climate_ref.solve_helpers import solve_results_for_regression, solve_to_results
+from climate_ref.solve_helpers import solve_results_for_regression
 
 
 @pytest.fixture(scope="module")
-def example_results(esgf_data_catalog):
-    return solve_to_results(esgf_data_catalog, providers=[example_provider])
+def example_results(esgf_example_solve_results):
+    """Reuse the session-cached example-provider solve (see root conftest)."""
+    return esgf_example_solve_results
 
 
 @pytest.mark.parametrize(

--- a/packages/climate-ref/tests/unit/test_versioning.py
+++ b/packages/climate-ref/tests/unit/test_versioning.py
@@ -347,9 +347,13 @@ class TestSolverVersionBranching:
     """
 
     def _solve_with_example_provider(self, db: Database, config) -> None:
+        # ``execute=False`` still creates the ExecutionGroup and Execution rows
+        # (with ``provider_version``) and advances ``promoted_version`` — everything
+        # these solver-branching tests assert on — but skips the expensive diagnostic
+        # run, which otherwise dominates the test runtime.
         local_solver = ExecutionSolver.build_from_db(config, db)
         local_solver.provider_registry = ProviderRegistry(providers=[example_provider])
-        solve_required_executions(db, config=config, solver=local_solver, dry_run=False)
+        solve_required_executions(db, config=config, solver=local_solver, dry_run=False, execute=False)
 
     def _example_diagnostic_row(self, db: Database) -> Diagnostic:
         slug = example_provider.diagnostics()[0].slug

--- a/packages/climate-ref/tests/unit/test_versioning.py
+++ b/packages/climate-ref/tests/unit/test_versioning.py
@@ -347,12 +347,9 @@ class TestSolverVersionBranching:
     """
 
     def _solve_with_example_provider(self, db: Database, config) -> None:
-        # ``execute=False`` still creates the ExecutionGroup and Execution rows
-        # (with ``provider_version``) and advances ``promoted_version`` — everything
-        # these solver-branching tests assert on — but skips the expensive diagnostic
-        # run, which otherwise dominates the test runtime.
         local_solver = ExecutionSolver.build_from_db(config, db)
         local_solver.provider_registry = ProviderRegistry(providers=[example_provider])
+        # We don't execute the runs, just create the ExecutionGroups
         solve_required_executions(db, config=config, solver=local_solver, dry_run=False, execute=False)
 
     def _example_diagnostic_row(self, db: Database) -> Diagnostic:


### PR DESCRIPTION
## Description

Cleans up the `climate-ref` test suite by removing all warnings and cutting the runtime roughly in half.

### Speedups
- **Versioning solver tests:** `_solve_with_example_provider` now passes `execute=False`.
- **Deduplicated the ESGF solve.** `test_solve_helpers` and `test_solve_regression`
  each ran the identical `solve_to_results(esgf_data_catalog, [example])`.

The remaining hotspots (solver parity setup, the ESGF solve, parser-parity
tests) are genuine integration/correctness coverage and were left untouched.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added (existing tests adjusted; no behaviour change)
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`