### PR TITLE
ci: parallelise tests-providers into a per-provider matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         # than here -- both jobs upload to the same `core` flag.
         run: |
           uv run coverage report --fail-under=0
-          uv run coverage xml
+          uv run coverage xml --fail-under=0
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v7
         with:
@@ -98,7 +98,7 @@ jobs:
       - name: Coverage report
         run: |
           uv run coverage report --fail-under=0
-          uv run coverage xml
+          uv run coverage xml --fail-under=0
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v7
         with:
@@ -142,7 +142,7 @@ jobs:
         # same `providers` flag) rather than here.
         run: |
           uv run coverage report --fail-under=0
-          uv run coverage xml
+          uv run coverage xml --fail-under=0
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,13 @@ on:
     branches: [main]
     tags: ['v*']
 
+# Cancel superseded in-progress runs for the same PR to free up runner slots.
+# Pushes to main / tags keep running (cancel-in-progress is false there) so
+# release-relevant builds are never interrupted.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -17,6 +24,9 @@ jobs:
       - name: pre-commit
         run: make pre-commit
 
+  # Core, celery and the climate-ref *unit* tests. The slower climate-ref
+  # integration suite runs in the separate tests-integration job below so the
+  # two execute in parallel rather than serially in one runner.
   tests-core:
     runs-on: ubuntu-latest
     defaults:
@@ -35,15 +45,50 @@ jobs:
           echo "::group::test-core"
           time make test-core
           echo "::endgroup::"
-      - name: Test ref
+      - name: Test ref (unit)
         run: |
-          echo "::group::test-ref"
-          time make test-ref
+          echo "::group::test-ref-unit"
+          time make test-ref-unit
           echo "::endgroup::"
       - name: Test celery
         run: |
           echo "::group::test-celery"
           time make test-celery
+          echo "::endgroup::"
+      - name: Coverage report
+        # Per-job coverage is partial (the integration job covers the rest), so
+        # the aggregate fail_under gate is enforced by codecov/project rather
+        # than here -- both jobs upload to the same `core` flag.
+        run: |
+          uv run coverage report --fail-under=0
+          uv run coverage xml
+      - name: Upload coverage reports to Codecov with GitHub Action
+        uses: codecov/codecov-action@v7
+        with:
+          flags: core
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # The climate-ref integration suite (expensive solver-parity fixtures) plus
+  # the top-level cross-package integration tests, split out from tests-core so
+  # the critical path is the slower of the two jobs rather than their sum.
+  tests-integration:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.13"
+      - name: Fetch sample data
+        run: uv run ref datasets fetch-sample-data
+      - name: Test ref (integration)
+        run: |
+          echo "::group::test-ref-integration"
+          time make test-ref-integration
           echo "::endgroup::"
       - name: Test integration
         run: |
@@ -52,7 +97,7 @@ jobs:
           echo "::endgroup::"
       - name: Coverage report
         run: |
-          uv run coverage report
+          uv run coverage report --fail-under=0
           uv run coverage xml
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,10 +61,18 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # Each provider runs in its own matrix job so they execute in parallel rather
+  # than serially in a single runner. This keeps the providers critical path at
+  # the slowest single provider instead of the sum of all of them.
   tests-providers:
     env:
       REF_TEST_OUTPUT: "test-outputs"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [example, esmvaltool, ilamb, pmp]
+    name: tests-providers (${{ matrix.provider }})
     defaults:
       run:
         shell: bash
@@ -74,31 +82,21 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           python-version: "3.13"
-      - name: Fetch test data
-        run: make fetch-test-data
-      - name: Test example provider
+      # Only sample data is needed up front; the ilamb target fetches its own
+      # ilamb-test registry, so the other providers skip that download.
+      - name: Fetch sample data
+        run: uv run ref datasets fetch-sample-data
+      - name: Test ${{ matrix.provider }} provider
         run: |
-          echo "::group::test-diagnostic-example"
-          time make test-diagnostic-example
-          echo "::endgroup::"
-      - name: Test ESMValTool provider
-        run: |
-          echo "::group::test-diagnostic-esmvaltool"
-          time make test-diagnostic-esmvaltool
-          echo "::endgroup::"
-      - name: Test ILAMB provider
-        run: |
-          echo "::group::test-diagnostic-ilamb"
-          time make test-diagnostic-ilamb
-          echo "::endgroup::"
-      - name: Test PMP provider
-        run: |
-          echo "::group::test-diagnostic-pmp"
-          time make test-diagnostic-pmp
+          echo "::group::test-diagnostic-${{ matrix.provider }}"
+          time make test-diagnostic-${{ matrix.provider }}
           echo "::endgroup::"
       - name: Coverage report
+        # Per-job coverage is scoped to a single provider, so the aggregate
+        # fail_under gate is enforced by codecov/project (all jobs upload to the
+        # same `providers` flag) rather than here.
         run: |
-          uv run coverage report
+          uv run coverage report --fail-under=0
           uv run coverage xml
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v7
@@ -110,8 +108,9 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-output-providers
+          name: test-output-providers-${{ matrix.provider }}
           path: ${{ env.REF_TEST_OUTPUT }}
+          if-no-files-found: ignore
           retention-days: 7
 
   imports-without-extras:

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -15,8 +15,8 @@ permissions:
   attestations: write
   id-token: write
 
-# Cancel superseded in-progress PR runs to free up runner slots; never cancel
-# main / tag builds.
+# Cancel superseded in-progress PR runs to free up runner slots.
+# Never cancel main / tag builds.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -15,6 +15,12 @@ permissions:
   attestations: write
   id-token: write
 
+# Cancel superseded in-progress PR runs to free up runner slots; never cancel
+# main / tag builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     name: Detect Changes

--- a/.github/workflows/provider-compat.yml
+++ b/.github/workflows/provider-compat.yml
@@ -28,6 +28,12 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded in-progress PR runs to free up runner slots; never cancel
+# main / tag builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   provider-compat:
     runs-on: ubuntu-latest
@@ -39,7 +45,10 @@ jobs:
           - climate-ref-esmvaltool
           - climate-ref-pmp
           - climate-ref-ilamb
-        python-version: ["3.11", "3.12"]
+        # On PRs this is an informational check, so test only the lowest
+        # supported Python to keep the per-PR job count under the runner
+        # concurrency cap. Pushes to main exercise the full version matrix.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.11"]') || fromJSON('["3.11", "3.12"]') }}
     name: ${{ matrix.provider }} (py${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/provider-compat.yml
+++ b/.github/workflows/provider-compat.yml
@@ -28,8 +28,8 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded in-progress PR runs to free up runner slots; never cancel
-# main / tag builds.
+# Cancel superseded in-progress PR runs to free up runner slots.defaults:
+#  Never cancel main / tag builds.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -45,9 +45,7 @@ jobs:
           - climate-ref-esmvaltool
           - climate-ref-pmp
           - climate-ref-ilamb
-        # On PRs this is an informational check, so test only the lowest
-        # supported Python to keep the per-PR job count under the runner
-        # concurrency cap. Pushes to main exercise the full version matrix.
+        # On PRs this is an informational check, so test only the lowest supported Python
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.11"]') || fromJSON('["3.11", "3.12"]') }}
     name: ${{ matrix.provider }} (py${{ matrix.python-version }})
     steps:

--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,28 @@ ruff-fixes:  ## fix the code using ruff
 # module-level code in entry-point plugins is tracked from process start.
 # Each target appends to .coverage; the `test` target runs a final report.
 
+# The climate-ref suite is split into a fast unit target and a slower
+# integration target so CI can run them as separate, parallel jobs (the
+# integration tests carry the expensive solver-parity fixtures). ``test-ref``
+# runs both for local use. The src tree (and its doctests) is collected by the
+# unit target via ``--doctest-modules`` so module-level coverage stays tracked.
 .PHONY: test-ref
-test-ref:  ## run the tests
+test-ref: test-ref-unit test-ref-integration  ## run all the climate-ref tests (unit + integration)
+
+.PHONY: test-ref-unit
+test-ref-unit:  ## run the climate-ref unit tests (+ src doctests)
 	uv run --package climate-ref \
 		coverage run --append --source=packages/climate-ref/src \
 		-m pytest packages/climate-ref \
+		--ignore=packages/climate-ref/tests/integration \
 		-r a -v --doctest-modules --durations=20
+
+.PHONY: test-ref-integration
+test-ref-integration:  ## run the climate-ref integration tests
+	uv run --package climate-ref \
+		coverage run --append --source=packages/climate-ref/src \
+		-m pytest packages/climate-ref/tests/integration \
+		-r a -v --durations=20
 
 .PHONY: test-core
 test-core:  ## run the tests

--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,6 @@ ruff-fixes:  ## fix the code using ruff
 # module-level code in entry-point plugins is tracked from process start.
 # Each target appends to .coverage; the `test` target runs a final report.
 
-# The climate-ref suite is split into a fast unit target and a slower
-# integration target so CI can run them as separate, parallel jobs (the
-# integration tests carry the expensive solver-parity fixtures). ``test-ref``
-# runs both for local use. The src tree (and its doctests) is collected by the
-# unit target via ``--doctest-modules`` so module-level coverage stays tracked.
 .PHONY: test-ref
 test-ref: test-ref-unit test-ref-integration  ## run all the climate-ref tests (unit + integration)
 

--- a/changelog/725.trivial.md
+++ b/changelog/725.trivial.md
@@ -1,3 +1,3 @@
 Parallelised the provider test suites in CI so they run as a matrix rather than serially, reducing pull-request turnaround time.
 Split the climate-ref integration tests into their own CI job so they run in parallel with the unit tests rather than serially in one runner.
-Added `concurrency` groups so superseded pull-request runs are cancelled, and trimmed the provider-compatibility matrix to a single Python version on pull requests, keeping the per-PR job count under the runner concurrency cap.
+Added `concurrency` groups so superseded pull-request runs are cancelled.

--- a/changelog/725.trivial.md
+++ b/changelog/725.trivial.md
@@ -1,1 +1,3 @@
 Parallelised the provider test suites in CI so they run as a matrix rather than serially, reducing pull-request turnaround time.
+Split the climate-ref integration tests into their own CI job so they run in parallel with the unit tests rather than serially in one runner.
+Added `concurrency` groups so superseded pull-request runs are cancelled, and trimmed the provider-compatibility matrix to a single Python version on pull requests, keeping the per-PR job count under the runner concurrency cap.

--- a/changelog/725.trivial.md
+++ b/changelog/725.trivial.md
@@ -1,0 +1,1 @@
+Parallelised the provider test suites in CI so they run as a matrix rather than serially, reducing pull-request turnaround time.

--- a/packages/climate-ref/tests/unit/cli/test_providers.py
+++ b/packages/climate-ref/tests/unit/cli/test_providers.py
@@ -40,10 +40,6 @@ class TestProvidersList:
     def test_list_with_data_path_not_fetched(self, config, invoke_cli, mocker):
         """Test list command shows data path not fetched info."""
         # Create a mock provider with data_path that doesn't exist.
-        # Use a short, fixed path rather than ``tmp_path`` so the rendered
-        # rich table never truncates the trailing "(not fetched)" marker: under
-        # pytest-xdist ``tmp_path`` includes a per-worker segment (popen-gwN)
-        # that can push the path past the table width and drop the suffix.
         mock_provider = mocker.MagicMock(spec=DiagnosticProvider)
         mock_provider.slug = "data-test"
         mock_provider.version = "1.0.0"

--- a/packages/climate-ref/tests/unit/cli/test_providers.py
+++ b/packages/climate-ref/tests/unit/cli/test_providers.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from climate_ref.provider_registry import ProviderRegistry
@@ -35,13 +37,17 @@ class TestProvidersList:
         assert "conda-test" in result.stdout
         assert "(not installed)" in result.stdout
 
-    def test_list_with_data_path_not_fetched(self, config, invoke_cli, mocker, tmp_path):
+    def test_list_with_data_path_not_fetched(self, config, invoke_cli, mocker):
         """Test list command shows data path not fetched info."""
-        # Create a mock provider with data_path that doesn't exist
+        # Create a mock provider with data_path that doesn't exist.
+        # Use a short, fixed path rather than ``tmp_path`` so the rendered
+        # rich table never truncates the trailing "(not fetched)" marker: under
+        # pytest-xdist ``tmp_path`` includes a per-worker segment (popen-gwN)
+        # that can push the path past the table width and drop the suffix.
         mock_provider = mocker.MagicMock(spec=DiagnosticProvider)
         mock_provider.slug = "data-test"
         mock_provider.version = "1.0.0"
-        mock_provider.get_data_path.return_value = tmp_path / "nonexistent_data"
+        mock_provider.get_data_path.return_value = Path("/ref-nonexistent-data")
 
         mock_registry = mocker.MagicMock(spec=ProviderRegistry)
         mock_registry.providers = [mock_provider]


### PR DESCRIPTION
## Description

Follow-up to #723. The `tests-providers` CI job ran all four diagnostic providers serially in a single runner, which made it the critical path for the CI.

This splits it into a `matrix` over `[example, esmvaltool, ilamb, pmp]` so the providers run in parallel on separate runners.
The integration tests are also split out from the unit tests

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added (CI-only change; no application code touched)
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`