### PR TITLE
fix(esgf): build intake-esgf catalogue with legacy object-string dtype

### DIFF
--- a/changelog/726.fix.md
+++ b/changelog/726.fix.md
@@ -1,0 +1,2 @@
+Fixed fetching datasets from ESGF failing with `Must have equal len keys and value when setting with an iterable` under pandas 3.0,
+by running the intake-esgf catalogue build with the legacy object-string dtype.

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
@@ -104,19 +104,23 @@ class IntakeESGFMixin:
             if isinstance(value, tuple):
                 facets[key] = list(value)
 
-        cat = ESGFCatalog()  # type: ignore[no-untyped-call]
-        cat.search(**facets)
+        # intake-esgf assigns Python lists into individual DataFrame cells, which only works for object dtype.
+        # Pandas >= 3.0 defaults strings to the pyarrow-backed dtype, where that assignment raises,
+        # so pin the legacy object-string behaviour for the intake-esgf interaction.
+        with pd.option_context("future.infer_string", False):
+            cat = ESGFCatalog()  # type: ignore[no-untyped-call]
+            cat.search(**facets)
 
-        if self.remove_ensembles:
-            cat.remove_ensembles()
+            if self.remove_ensembles:
+                cat.remove_ensembles()
 
-        path_dict = cat.to_path_dict(prefer_streaming=False, minimal_keys=False, quiet=True)
-        if cat.df is None or cat.df.empty:
-            raise ValueError("No datasets found for the given ESGF request")
-        merged_df = cat.df.merge(pd.Series(path_dict, name="files"), left_on="key", right_index=True)
+            path_dict = cat.to_path_dict(prefer_streaming=False, minimal_keys=False, quiet=True)
+            if cat.df is None or cat.df.empty:
+                raise ValueError("No datasets found for the given ESGF request")
+            merged_df = cat.df.merge(pd.Series(path_dict, name="files"), left_on="key", right_index=True)
 
-        if self.time_span:
-            merged_df["time_start"] = self.time_span[0]
-            merged_df["time_end"] = self.time_span[1]
+            if self.time_span:
+                merged_df["time_start"] = self.time_span[0]
+                merged_df["time_end"] = self.time_span[1]
 
-        return _deduplicate_datasets(merged_df)
+            return _deduplicate_datasets(merged_df)

--- a/packages/climate-ref-core/tests/unit/esgf/test_base.py
+++ b/packages/climate-ref-core/tests/unit/esgf/test_base.py
@@ -143,6 +143,37 @@ class TestIntakeESGFMixin:
         assert "key" in result.columns
         assert "files" in result.columns
 
+    def test_fetch_datasets_pyarrow_string_backend(self):
+        """
+        Regression: intake-esgf assigns Python lists into single string cells
+        (``df.at[idx, "id"] = [...]``), which raises under pandas' pyarrow-backed
+        string dtype (``future.infer_string=True``, the default from pandas 3.0).
+        fetch_datasets must run the intake-esgf interaction with that disabled,
+        so the call succeeds regardless of the ambient option.
+        """
+        request = CMIP6Request(slug="test", facets={"variable_id": "tas"})
+
+        mock_cat = MagicMock()
+
+        def fake_search(**_kwargs):
+            # Mirror intake_esgf.base.combine_results: a list assigned into one cell.
+            df = pd.DataFrame({"key": ["ds1"], "id": ["placeholder"]})
+            df.at[df.index[0], "id"] = ["node1.example.org", "node2.example.org"]
+            mock_cat.df = df
+
+        mock_cat.search.side_effect = fake_search
+        mock_cat.to_path_dict.return_value = {"ds1": ["/path/to/file.nc"]}
+
+        # Simulate the pandas >= 3.0 default that triggers the upstream crash.
+        with (
+            pd.option_context("future.infer_string", True),
+            patch("climate_ref_core.esgf.base.ESGFCatalog", return_value=mock_cat),
+        ):
+            result = request.fetch_datasets()
+
+        assert not result.empty
+        assert result.iloc[0]["key"] == "ds1"
+
     def test_fetch_datasets_with_time_span(self):
         """Test fetch_datasets with time span filter."""
         request = CMIP6Request(


### PR DESCRIPTION
## Description

Fixes ESGF dataset fetching, which was broken since #708.

`intake-esgf`'s `combine_results` assigns Python lists into individual DataFrame cells (e.g. `df.at[idx, "id"] = grp.id.to_list()`). That is only valid for object-dtype columns. From pandas 3.0, string columns default to the pyarrow-backed dtype (`future.infer_string=True`), so the assignment raises:

```
ValueError: Must have equal len keys and value when setting with an iterable
```

inside `cat.search()`, before any climate-ref code runs. This broke `ref test-cases fetch`.

### Fix

Pin the legacy pandas behaviour in `IntakeESGFMixin.fetch_datasets` with `pd.option_context("future.infer_string", False)`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`