### PR TITLE
Tiered CI workflows for regression native baselines

### DIFF
--- a/.github/workflows/regression-drift.yaml
+++ b/.github/workflows/regression-drift.yaml
@@ -1,10 +1,13 @@
 # Nightly native-baseline drift check.
 #
-# Fetches every native blob referenced by a committed manifest and replays it against
-# the committed bundle, catching baselines that no longer reproduce within tolerance
-# (e.g. after a dependency upgrade) even when no pull request touched them. Read-only
-# and credential-free, so it runs on the public runner. A failure here means a stored
-# baseline has drifted and needs investigation (and possibly a re-mint).
+# Fetches every native blob referenced by a committed manifest and replays it against the committed bundle,
+# catching baselines that no longer reproduce within tolerance (e.g. after a dependency upgrade)
+# even when no pull request touched them.
+#
+# Run on the public runners with no credentials (read-only access to the public repository and public read access to the native blobs),
+# so it is safe on untrusted fork pull-request code.
+# A failure here means a stored baseline has drifted and needs investigation (and possibly a re-mint).
+# See docs/background/regression-baselines.md.
 name: Regression baselines (nightly drift)
 
 on:
@@ -38,7 +41,7 @@ jobs:
       - name: Fetch sample data
         run: uv run ref datasets fetch-sample-data
       - name: Restore test-case catalog paths
-        # Only the example provider is migrated to the native-baseline layout today;
+        # Only the example provider is migrated to the native-baseline layout today
         # extend this (and the replay step below) as providers migrate.
         run: uv run ref test-cases fetch --provider example || echo "::warning::test-case fetch incomplete"
       - name: Sync native baselines

--- a/.github/workflows/regression-drift.yaml
+++ b/.github/workflows/regression-drift.yaml
@@ -1,0 +1,48 @@
+# Nightly native-baseline drift check.
+#
+# Fetches every native blob referenced by a committed manifest and replays it against
+# the committed bundle, catching baselines that no longer reproduce within tolerance
+# (e.g. after a dependency upgrade) even when no pull request touched them. Read-only
+# and credential-free, so it runs on the public runner. A failure here means a stored
+# baseline has drifted and needs investigation (and possibly a re-mint).
+name: Regression baselines (nightly drift)
+
+on:
+  # 04:17 UTC daily, offset from the other scheduled CI to avoid contention.
+  schedule:
+    - cron: "17 4 * * *"
+  # Allow on-demand drift checks.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    # Don't run the scheduled check on forks.
+    if: github.repository == 'Climate-REF/climate-ref'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.13"
+      - name: Fetch sample data
+        run: uv run ref datasets fetch-sample-data
+      - name: Restore test-case catalog paths
+        # Only the example provider is migrated to the native-baseline layout today;
+        # extend this (and the replay step below) as providers migrate.
+        run: uv run ref test-cases fetch --provider example || echo "::warning::test-case fetch incomplete"
+      - name: Sync native baselines
+        # Fetch every native blob referenced by a committed manifest into the cache.
+        run: uv run ref test-cases sync
+      - name: Replay native baselines
+        run: uv run ref test-cases replay --provider example

--- a/.github/workflows/regression-drift.yaml
+++ b/.github/workflows/regression-drift.yaml
@@ -29,6 +29,13 @@ jobs:
     # Don't run the scheduled check on forks.
     if: github.repository == 'Climate-REF/climate-ref'
     runs-on: ubuntu-latest
+    strategy:
+      # A drift in one provider must not cancel the others' checks.
+      fail-fast: false
+      matrix:
+        # Providers migrated to the native-baseline layout. Add to this list as more
+        # providers migrate; the fetch and replay steps both use ${{ matrix.provider }}.
+        provider: [example]
     defaults:
       run:
         shell: bash
@@ -41,11 +48,13 @@ jobs:
       - name: Fetch sample data
         run: uv run ref datasets fetch-sample-data
       - name: Restore test-case catalog paths
-        # Only the example provider is migrated to the native-baseline layout today
-        # extend this (and the replay step below) as providers migrate.
-        run: uv run ref test-cases fetch --provider example || echo "::warning::test-case fetch incomplete"
+        env:
+          PROVIDER: ${{ matrix.provider }}
+        run: uv run ref test-cases fetch --provider "${PROVIDER}" || echo "::warning::test-case fetch incomplete"
       - name: Sync native baselines
         # Fetch every native blob referenced by a committed manifest into the cache.
         run: uv run ref test-cases sync
       - name: Replay native baselines
-        run: uv run ref test-cases replay --provider example
+        env:
+          PROVIDER: ${{ matrix.provider }}
+        run: uv run ref test-cases replay --provider "${PROVIDER}"

--- a/.github/workflows/regression-mint.yaml
+++ b/.github/workflows/regression-mint.yaml
@@ -1,20 +1,14 @@
-# Gated mint of native regression baselines.
+# Mint the native regression baselines.
 #
-# Minting is the only credentialed step in the baseline lifecycle: it executes a test
-# case, uploads its curated native outputs to the Cloudflare R2 object store, and
-# rewrites the committed `manifest.json` to record their digests. It is therefore
-# manually dispatched and gated behind the `native-baselines` GitHub Environment
-# (configure it with required reviewers), and never runs on fork pull-request code.
+# Minting executes a test case, uploads its curated native outputs to the Cloudflare R2 object store,
+# and rewrites the committed `manifest.json` to record their digests.
+# It requires credentials to access the object store.
+# It is therefore manually dispatched and gated behind the `native-baselines` GitHub Environment, and never runs on fork pull-request code.
 #
-# Dispatch this workflow on the *feature branch* that should receive the regenerated
-# manifest -- the job commits the result back to that branch so the change is reviewed
-# through its pull request, and so individual developers never need write credentials.
+# Dispatch this workflow on the *feature branch* that should receive the regenerated manifest.
+# The action commits the result back to that branch so the change is reviewed through its pull request,
+# and so individual developers never need write credentials.
 #
-# Required repository configuration (Settings -> Environments -> native-baselines):
-#   - Required reviewers (the human gate on writing baselines).
-#   - Secrets R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY (an object-scoped R2 token).
-# The endpoint and bucket default to the production R2 account; override with the
-# REF_NATIVE_STORE_S3_ENDPOINT_URL / REF_NATIVE_STORE_BUCKET env vars if needed.
 name: Regression baselines (mint)
 
 on:
@@ -104,6 +98,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           # Stage only the committed bundle and manifest; native blobs live in the
           # object store, not the tree, and nothing else should change during a mint.
           git add ':(glob)packages/**/test-data/**/manifest.json' \

--- a/.github/workflows/regression-mint.yaml
+++ b/.github/workflows/regression-mint.yaml
@@ -108,4 +108,7 @@ jobs:
             exit 0
           fi
           git commit -m "chore(regression): mint native baselines for ${PROVIDER}"
+          # Pushed with GITHUB_TOKEN, so GitHub will NOT start new workflow runs for this
+          # commit: the PR gate does not auto-replay the freshly minted baseline. Push a
+          # follow-up commit (or re-run the PR gate) to verify it. See docs/background/regression-baselines.md.
           git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/.github/workflows/regression-mint.yaml
+++ b/.github/workflows/regression-mint.yaml
@@ -1,0 +1,116 @@
+# Gated mint of native regression baselines.
+#
+# Minting is the only credentialed step in the baseline lifecycle: it executes a test
+# case, uploads its curated native outputs to the Cloudflare R2 object store, and
+# rewrites the committed `manifest.json` to record their digests. It is therefore
+# manually dispatched and gated behind the `native-baselines` GitHub Environment
+# (configure it with required reviewers), and never runs on fork pull-request code.
+#
+# Dispatch this workflow on the *feature branch* that should receive the regenerated
+# manifest -- the job commits the result back to that branch so the change is reviewed
+# through its pull request, and so individual developers never need write credentials.
+#
+# Required repository configuration (Settings -> Environments -> native-baselines):
+#   - Required reviewers (the human gate on writing baselines).
+#   - Secrets R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY (an object-scoped R2 token).
+# The endpoint and bucket default to the production R2 account; override with the
+# REF_NATIVE_STORE_S3_ENDPOINT_URL / REF_NATIVE_STORE_BUCKET env vars if needed.
+name: Regression baselines (mint)
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: "Provider slug to mint"
+        required: true
+        default: "example"
+      diagnostic:
+        description: "Diagnostic slug (optional; all diagnostics if blank)"
+        required: false
+        default: ""
+      test_case:
+        description: "Test case name (optional; all cases if blank)"
+        required: false
+        default: ""
+      bump_version:
+        description: "Increment test_case_version when authoring the manifest"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Preflight and preview only -- upload nothing, commit nothing"
+        type: boolean
+        default: false
+
+# Needed to commit the regenerated manifest/bundle back to the dispatched branch.
+permissions:
+  contents: write
+
+# Never cancel an in-flight mint: it performs object-store writes and a push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mint:
+    if: github.repository == 'Climate-REF/climate-ref'
+    runs-on: ubuntu-latest
+    environment: native-baselines
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Refuse to mint on the default branch
+        if: github.ref_name == github.event.repository.default_branch
+        run: |
+          echo "::error::Dispatch mint on a feature branch, not ${{ github.event.repository.default_branch }}."
+          echo "Mint commits the regenerated manifest back to the branch; review it through a pull request."
+          exit 1
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.13"
+      - name: Fetch sample data
+        run: uv run ref datasets fetch-sample-data
+      - name: Restore test-case catalog paths
+        env:
+          PROVIDER: ${{ inputs.provider }}
+        run: uv run ref test-cases fetch --provider "${PROVIDER}" || echo "::warning::test-case fetch incomplete"
+      - name: Verify store credentials
+        env:
+          REF_NATIVE_STORE_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          REF_NATIVE_STORE_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: uv run ref test-cases check-store
+      - name: Mint native baselines
+        env:
+          REF_NATIVE_STORE_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          REF_NATIVE_STORE_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          PROVIDER: ${{ inputs.provider }}
+          DIAGNOSTIC: ${{ inputs.diagnostic }}
+          TEST_CASE: ${{ inputs.test_case }}
+          BUMP_VERSION: ${{ inputs.bump_version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          args=(--provider "${PROVIDER}")
+          if [ -n "${DIAGNOSTIC}" ]; then args+=(--diagnostic "${DIAGNOSTIC}"); fi
+          if [ -n "${TEST_CASE}" ]; then args+=(--test-case "${TEST_CASE}"); fi
+          if [ "${BUMP_VERSION}" = "true" ]; then args+=(--bump-version); fi
+          if [ "${DRY_RUN}" = "true" ]; then args+=(--dry-run); fi
+          uv run ref test-cases mint "${args[@]}"
+      - name: Commit regenerated baselines
+        if: ${{ !inputs.dry_run }}
+        env:
+          PROVIDER: ${{ inputs.provider }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Stage only the committed bundle and manifest; native blobs live in the
+          # object store, not the tree, and nothing else should change during a mint.
+          git add ':(glob)packages/**/test-data/**/manifest.json' \
+                  ':(glob)packages/**/test-data/**/regression/**'
+          if git diff --cached --quiet; then
+            echo "No baseline changes to commit; the native blobs were already current."
+            exit 0
+          fi
+          git commit -m "chore(regression): mint native baselines for ${PROVIDER}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/.github/workflows/regression-pr-gate.yaml
+++ b/.github/workflows/regression-pr-gate.yaml
@@ -1,0 +1,50 @@
+# PR-tier regression baseline gate.
+#
+# Decides how each test case's regression baseline should be verified against the
+# pull request's base branch, then replays the cached native baseline for every case
+# routed to `replay`. Runs on the public `ubuntu-latest` runner with no credentials,
+# so it is safe on untrusted fork pull-request code (everything here is anonymous
+# public read). See docs/background/regression-baselines.md.
+name: Regression baselines (PR gate)
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+# Cancel superseded in-progress runs for the same PR to free up runner slots.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coupling-gate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Rich must emit uncoloured output so `ci-gate --json` is machine-parseable.
+      NO_COLOR: "1"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          # Full history so the gate can diff base...HEAD and read the base manifest.
+          fetch-depth: 0
+      - name: Make the base branch available for the diff
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.13"
+      - name: Decide and verify baselines
+        # The gate fetches sample data only when a case actually needs replaying, so a
+        # PR that touches no baselines completes without any downloads.
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/ci/regression-pr-gate.sh

--- a/.github/workflows/regression-pr-gate.yaml
+++ b/.github/workflows/regression-pr-gate.yaml
@@ -1,10 +1,7 @@
 # PR-tier regression baseline gate.
 #
 # Decides how each test case's regression baseline should be verified against the
-# pull request's base branch, then replays the cached native baseline for every case
-# routed to `replay`. Runs on the public `ubuntu-latest` runner with no credentials,
-# so it is safe on untrusted fork pull-request code (everything here is anonymous
-# public read). See docs/background/regression-baselines.md.
+# pull request's base branch, then replays test cases.
 name: Regression baselines (PR gate)
 
 on:
@@ -43,8 +40,8 @@ jobs:
         with:
           python-version: "3.13"
       - name: Decide and verify baselines
-        # The gate fetches sample data only when a case actually needs replaying, so a
-        # PR that touches no baselines completes without any downloads.
+        # The gate fetches sample data only when a case actually needs replaying,
+        # so a PR that touches no baselines completes without any downloads.
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: bash scripts/ci/regression-pr-gate.sh

--- a/changelog/733.feature.md
+++ b/changelog/733.feature.md
@@ -1,0 +1,4 @@
+Regression baselines are now verified automatically in CI.
+Every pull request runs the coupling gate and replays each test case's cached native baseline, a nightly job re-checks every baseline for silent drift, and a manually gated workflow mints new baselines to the shared object store behind required reviewers — so write credentials never run on untrusted pull-request code.
+
+The diagnostic testing guide also gained a "pull request workflow" section explaining what the gate decides for each change and how to publish a new baseline.

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -191,6 +191,11 @@ the job runs `mint`, and commits the regenerated `manifest.json` (and committed 
 so the change is reviewed through its pull request and no developer ever needs write credentials.
 A `dry_run` input previews without uploading or committing, and the job refuses to run on the default branch.
 
+!!! warning "The mint commit does not re-trigger the PR gate"
+    The mint job pushes with the default `GITHUB_TOKEN`, and GitHub deliberately does not start new workflow runs for such pushes.
+    So the freshly minted manifest is *not* automatically `replay`-verified by `regression-pr-gate.yaml`.
+    After minting, push a follow-up commit (or re-run the PR gate from the Actions tab) to verify the new native baseline reproduces the committed bundle.
+
 !!! note "Required repository configuration"
     Create a `native-baselines` Environment (Settings -> Environments) with **required reviewers**,
     and add two secrets to it holding an object-scoped R2 token:

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -157,8 +157,9 @@ the `--json` output drives CI's dispatch of the `replay` and `execute` jobs.
 
 ## Continuous integration
 
-The lifecycle commands are wired into three workflows, split along the trust boundary
-so that credentials are confined to a single, manually gated step.
+The lifecycle commands are wired into three GitHub Action workflows.
+The minting process requires credentials to upload data.
+Since this is a public project we have to be careful about when this is run to not leak these credentials.
 
 | Workflow | Trigger | Credentials | What it does |
 | --- | --- | --- | --- |
@@ -174,36 +175,31 @@ branch and acts on each decision:
 - **`fail`** aborts the job with the offending cases and their reasons.
 - **`replay`** is verified in place against the public native baseline.
 - **`execute`** is surfaced as a warning: a `test_case_version` bump authorises a new
-  baseline that only the credentialed mint tier can publish, so the PR tier flags it
-  rather than failing.
+  baseline that only the credentialed mint tier can publish, so the PR tier flags it rather than failing.
 
-The job runs on the public `ubuntu-latest` runner with no secrets, so it is safe on
-fork pull requests — every command is anonymous public read. The decision-to-replay
-fan-out lives in `scripts/ci/regression-pr-gate.sh`.
+The job runs on the public `ubuntu-latest` runner with no secrets, so it is safe on fork pull requests.
+The decision-to-replay fan-out lives in `scripts/ci/regression-pr-gate.sh`.
 
 ### Gated mint (`regression-mint.yaml`)
 
-Minting is the only step that writes to the object store, so it is **manually
-dispatched** and gated behind the `native-baselines` GitHub Environment. Dispatch it on
-the feature branch that should receive the new baseline: the job preflights the store
-credentials, runs `mint`, and commits the regenerated `manifest.json` (and committed
-bundle) back to that branch, so the change is reviewed through its pull request and no
-developer ever needs write credentials. A `dry_run` input previews without uploading or
-committing, and the job refuses to run on the default branch.
+Minting is the only step that writes to the object store,
+so it is **manually dispatched** and gated behind the `native-baselines` GitHub Environment.
+Dispatch it on the feature branch that should receive the new baseline:
+the job runs `mint`, and commits the regenerated `manifest.json` (and committed bundle) back to that branch,
+so the change is reviewed through its pull request and no developer ever needs write credentials.
+A `dry_run` input previews without uploading or committing, and the job refuses to run on the default branch.
 
 !!! note "Required repository configuration"
-    Create a `native-baselines` Environment (Settings → Environments) with **required
-    reviewers**, and add two secrets to it holding an object-scoped R2 token:
+    Create a `native-baselines` Environment (Settings -> Environments) with **required reviewers**,
+    and add two secrets to it holding an object-scoped R2 token:
 
-    - `R2_ACCESS_KEY_ID` → `REF_NATIVE_STORE_ACCESS_KEY_ID`
-    - `R2_SECRET_ACCESS_KEY` → `REF_NATIVE_STORE_SECRET_ACCESS_KEY`
+    - `R2_ACCESS_KEY_ID` -> `REF_NATIVE_STORE_ACCESS_KEY_ID`
+    - `R2_SECRET_ACCESS_KEY` -> `REF_NATIVE_STORE_SECRET_ACCESS_KEY`
 
     The endpoint and bucket default to the production R2 account
     (`REF_NATIVE_STORE_S3_ENDPOINT_URL` / `REF_NATIVE_STORE_BUCKET` override them).
 
 ### Nightly drift (`regression-drift.yaml`)
 
-A scheduled (and manually dispatchable) job `sync`s every referenced native blob and
-`replay`s it against the committed bundle. Because replay is tolerant, this catches a
-baseline that no longer reproduces within tolerance — for example after a dependency
-upgrade — independently of any pull request. It is read-only and credential-free.
+A scheduled (and manually dispatchable) job `sync`s every referenced native blob and `replay`s it against the committed bundle.
+This catches a baseline that no longer reproduce the committed results within tolerance — for example after a dependency upgrade. It is read-only and credential-free.

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -89,8 +89,8 @@ because an empty native set is legitimate, a missing native baseline downgrades 
 ### Actions
 
 - **`skip`** — nothing relevant to this case changed, or the case is not under regression management.
-- **`replay`** — cheap, anonymous re-check against the cached native baseline (only when native blobs exist).
-- **`execute`** — full end-to-end re-run with tolerant compare; required when `test_case_version` was bumped to authorise a new baseline.
+- **`replay`** — cheap, anonymous re-check against the cached native baseline (only when native blobs exist). This also verifies a `test_case_version` bump that ships native blobs.
+- **`execute`** — full end-to-end re-run with tolerant compare; required when `test_case_version` was bumped to authorise a new baseline *and* no native baseline exists to replay against.
 - **`fail`** — an unauthorised or unverifiable change (committed bundle edited without a version bump, version moved backwards, bundle drifted from its manifest, or catalog changed without regenerating the baseline).
 
 ### Decision flow
@@ -116,7 +116,9 @@ flowchart TD
 
     seeding -->|no| versionCmp{version vs base}
     versionCmp -->|decreased| failVersion[["FAIL<br/>version not monotonic"]]
-    versionCmp -->|bumped| execute[["EXECUTE<br/>authorised new baseline"]]
+    versionCmp -->|bumped| bumpNative{native<br/>present?}
+    bumpNative -->|yes| replayBump[["REPLAY<br/>verify new baseline<br/>reproduces from native"]]
+    bumpNative -->|no| execute[["EXECUTE<br/>full re-run<br/>(no native to replay)"]]
     versionCmp -->|unchanged| committedChanged{committed<br/>changed?}
 
     committedChanged -->|yes| failUnauthorised[["FAIL<br/>baseline changed without<br/>version bump"]]
@@ -174,8 +176,8 @@ branch and acts on each decision:
 
 - **`fail`** aborts the job with the offending cases and their reasons.
 - **`replay`** is verified in place against the public native baseline.
-- **`execute`** is surfaced as a warning: a `test_case_version` bump authorises a new
-  baseline that only the credentialed mint tier can publish, so the PR tier flags it rather than failing.
+- **`execute`** is surfaced as a warning: a `test_case_version` bump with no native baseline to replay against cannot be verified
+   (it would need a full diagnostic run), so the committed bundle is gated by review here and and requires `minting`.
 
 The job runs on the public `ubuntu-latest` runner with no secrets, so it is safe on fork pull requests.
 The decision-to-replay fan-out lives in `scripts/ci/regression-pr-gate.sh`.

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -154,3 +154,56 @@ the `--json` output drives CI's dispatch of the `replay` and `execute` jobs.
     `replay`, `sync`, `run`, and the gate itself are anonymous and safe to run on untrusted pull-request code.
     Only `mint` holds object-store write credentials,
     and it runs exclusively on the trusted-tier runner — never on fork pull-request code.
+
+## Continuous integration
+
+The lifecycle commands are wired into three workflows, split along the trust boundary
+so that credentials are confined to a single, manually gated step.
+
+| Workflow | Trigger | Credentials | What it does |
+| --- | --- | --- | --- |
+| `regression-pr-gate.yaml` | every pull request | none | Runs the coupling gate, then `replay`s every case it routes to `replay`. |
+| `regression-mint.yaml` | manual dispatch | R2 write | `mint`s native baselines and commits the regenerated manifest back to the branch. |
+| `regression-drift.yaml` | nightly + manual | none | `sync`s and `replay`s every baseline to catch silent drift. |
+
+### PR gate (`regression-pr-gate.yaml`)
+
+On every pull request, the gate runs `ref test-cases ci-gate --json` against the base
+branch and acts on each decision:
+
+- **`fail`** aborts the job with the offending cases and their reasons.
+- **`replay`** is verified in place against the public native baseline.
+- **`execute`** is surfaced as a warning: a `test_case_version` bump authorises a new
+  baseline that only the credentialed mint tier can publish, so the PR tier flags it
+  rather than failing.
+
+The job runs on the public `ubuntu-latest` runner with no secrets, so it is safe on
+fork pull requests — every command is anonymous public read. The decision-to-replay
+fan-out lives in `scripts/ci/regression-pr-gate.sh`.
+
+### Gated mint (`regression-mint.yaml`)
+
+Minting is the only step that writes to the object store, so it is **manually
+dispatched** and gated behind the `native-baselines` GitHub Environment. Dispatch it on
+the feature branch that should receive the new baseline: the job preflights the store
+credentials, runs `mint`, and commits the regenerated `manifest.json` (and committed
+bundle) back to that branch, so the change is reviewed through its pull request and no
+developer ever needs write credentials. A `dry_run` input previews without uploading or
+committing, and the job refuses to run on the default branch.
+
+!!! note "Required repository configuration"
+    Create a `native-baselines` Environment (Settings → Environments) with **required
+    reviewers**, and add two secrets to it holding an object-scoped R2 token:
+
+    - `R2_ACCESS_KEY_ID` → `REF_NATIVE_STORE_ACCESS_KEY_ID`
+    - `R2_SECRET_ACCESS_KEY` → `REF_NATIVE_STORE_SECRET_ACCESS_KEY`
+
+    The endpoint and bucket default to the production R2 account
+    (`REF_NATIVE_STORE_S3_ENDPOINT_URL` / `REF_NATIVE_STORE_BUCKET` override them).
+
+### Nightly drift (`regression-drift.yaml`)
+
+A scheduled (and manually dispatchable) job `sync`s every referenced native blob and
+`replay`s it against the committed bundle. Because replay is tolerant, this catches a
+baseline that no longer reproduces within tolerance — for example after a dependency
+upgrade — independently of any pull request. It is read-only and credential-free.

--- a/docs/how-to-guides/testing-diagnostics.md
+++ b/docs/how-to-guides/testing-diagnostics.md
@@ -407,11 +407,24 @@ packages/climate-ref-{provider}/tests/test-data/
     └── {test_case}/
         ├── catalog.yaml       # Dataset metadata
         ├── catalog.paths.yaml # Local file paths (gitignored)
-        └── regression/        # Regression outputs
-            ├── diagnostic.json    # Execution result
-            ├── output.json        # CMEC output bundle
-            └── ...                # Other output files
+        ├── manifest.json      # Binds the two baseline layers (see below)
+        └── regression/        # Committed bundle (text-only CMEC JSON)
+            ├── series.json       # Scalar/series metric values
+            ├── diagnostic.json   # Execution result
+            └── output.json       # CMEC output bundle
 ```
+
+A baseline has **two layers** (see
+[Regression baselines](../background/regression-baselines.md) for the full model):
+
+- the small, git-tracked **committed bundle** under `regression/`, which is what review
+  and CI actually gate on; and
+- the heavy **native bundle** (`.nc`, `.png`, ...) that lives in a shared object store,
+  content-addressed by digest, and is fetched anonymously.
+
+`manifest.json` binds them, recording a monotonic `test_case_version` that *authorises* a
+new baseline, the digests of the committed files, the digests of the native files, and the
+hash of the input `catalog.yaml`.
 
 For example, the ILAMB provider's `gpp-fluxcom` diagnostic with the `default` test case:
 
@@ -454,6 +467,71 @@ def test_regression(run_test_case, execution_regression):
     # Compare metric bundle against baseline
     execution_regression.check(result, "my-provider/my-diagnostic/default")
 ```
+
+## Baselines and the pull request workflow
+
+When you open a pull request, CI decides *how* to verify each test case's baseline
+purely from what your branch changed relative to the base. You do not run the diagnostic
+again on every PR — that would be too slow — so it helps to know what the gate will do and
+what each outcome asks of you.
+
+```mermaid
+flowchart TD
+    start([You changed a diagnostic]) --> q1{Did the committed<br/>bundle change?}
+    q1 -->|"no — refactor,<br/>same results"| openA[Open pull request]
+    q1 -->|"yes — intended<br/>new results"| regen["Regenerate locally:<br/>ref test-cases run --force-regen"]
+    regen --> bump["Bump test_case_version<br/>in manifest.json"]
+    bump --> openB[Open pull request]
+
+    openA --> gate{{"PR gate runs<br/>ref test-cases ci-gate"}}
+    openB --> gate
+
+    gate -->|skip| done1([Nothing to verify — merge])
+    gate -->|replay| rep[CI replays the cached<br/>native baseline]
+    rep --> repok{Reproduces within<br/>tolerance?}
+    repok -->|yes| done2([Gate passes — merge])
+    repok -->|no| fixcode[["Your change moved the results:<br/>regenerate + bump, or fix the code"]]
+    gate -->|fail| failed[["Baseline changed without a<br/>version bump — bump or revert"]]
+    gate -->|execute| flagged[Version bump detected —<br/>new baseline authorised]
+    flagged --> mint["Publish the native baseline:<br/>dispatch the mint workflow"]
+    mint --> done3([Reviewed via the committed diff — merge])
+```
+
+### What each gate outcome means for you
+
+| Outcome | What happened | What to do |
+| --- | --- | --- |
+| **skip** | Nothing relevant to this case changed. | Nothing — merge as usual. |
+| **replay** | Your change *could* affect the result (you touched extraction code, or re-minted native files). CI re-checks the cached native baseline against the committed bundle. | Nothing if it passes. If replay reports drift, your change moved the results: regenerate the baseline and bump `test_case_version`, or fix the code. |
+| **execute** | You bumped `test_case_version`, authorising a new baseline. The credential-free PR tier cannot publish native files, so it flags the case instead of verifying it. | Publish the new native baseline through the gated mint workflow (below). Review of the new committed bundle happens in the PR diff. |
+| **fail** | The committed bundle (or its input catalog) changed without a `test_case_version` bump, or the version moved backwards. | Bump `test_case_version` to authorise the change, or revert the unintended edit. |
+
+!!! tip "When to bump `test_case_version`"
+    Bump it whenever you *intend* to change a baseline's results. The bump is what tells
+    reviewers and CI "yes, this new output is correct" — without it, a changed baseline is
+    treated as an accidental regression and the gate fails.
+
+### Publishing a new native baseline
+
+Native files (the `.nc`/`.png` outputs referenced by the committed bundle) are written to
+the shared object store only by the **`mint`** verb, which needs write credentials. So that
+no contributor needs those credentials, minting runs as a gated CI workflow:
+
+1. Regenerate and commit your new committed bundle locally
+   (`ref test-cases run --force-regen`), and bump `test_case_version` in `manifest.json`.
+2. Push your branch and run the **"Regression baselines (mint)"** workflow from the GitHub
+   Actions tab, dispatched **on your branch**. It is gated behind a reviewed environment.
+3. The workflow uploads your native files to the store and commits the regenerated
+   `manifest.json` (now carrying the native digests) back to your branch.
+4. The PR gate then `replay`s the published baseline, and review sees the committed-bundle
+   diff as usual.
+
+Use the **`--dry-run`** input first to preflight credentials and preview what would be
+minted without uploading anything. If you do hold credentials locally, `ref test-cases mint`
+does the same thing from your machine.
+
+See [Regression baselines](../background/regression-baselines.md) for the full two-layer
+model, the tolerant comparison, and the credential trust boundary.
 
 ## Complete Example
 

--- a/docs/how-to-guides/testing-diagnostics.md
+++ b/docs/how-to-guides/testing-diagnostics.md
@@ -268,7 +268,11 @@ packages/climate-ref-{provider}/tests/test-data/
     └── {test_case}/
         ├── catalog.yaml           # Dataset metadata (tracked in git)
         ├── catalog.paths.yaml     # Local file paths (gitignored)
-        └── regression/            # Regression outputs (tracked in git)
+        ├── manifest.json          # Baseline metadata (written by `run`/`mint`)
+        └── regression/            # Committed baseline bundle (tracked in git)
+            ├── series.json
+            ├── diagnostic.json
+            └── output.json
 ```
 
 The catalog is split into two files:
@@ -292,36 +296,20 @@ to download datasets from ESGF if they cannot be found locally.
 The fetch command saves a catalog YAML file that records the paths to these files,
 so subsequent test runs can locate the data without re-scanning directories.
 
-/// Note | Using Shared ESGF Data (HPC/Shared Drives)
+/// Note | Using shared ESGF data (HPC/shared drives)
 
-If your institution has a local ESGF data archive, configure `esg_dataroot` to avoid redundant downloads:
+On HPC systems, point `esg_dataroot` at an existing shared CMIP6 archive so intake-esgf
+reuses it instead of re-downloading; new files still go to `local_cache`:
 
 ```yaml
 # ~/.config/intake-esgf/conf.yaml
 esg_dataroot:
-  - /shared/cmip6/data      # Institutional ESGF mirror (read-only)
-  - /group/climate/esgf     # Group shared cache
+  - /shared/cmip6/data      # Read-only institutional mirror, checked first
 local_cache:
-  - /scratch/$USER/.esgf    # Personal downloads go here
+  - /scratch/$USER/.esgf    # New downloads land here
 ```
 
-With this configuration, intake-esgf will:
-
-1. Check each `esg_dataroot` path for existing files
-2. Only download to `local_cache` if the file isn't found
-
-This is particularly useful on HPC systems where CMIP6 data may already be available on shared filesystems.
-
-For personal workstations without shared data,
-you only need to set `local_cache`:
-
-```yaml
-# ~/.config/intake-esgf/conf.yaml
-local_cache:
-  - /path/to/esgf/cache
-```
-
-See the [intake-esgf documentation](https://github.com/esgf2-us/intake-esgf) for more configuration options.
+See the [intake-esgf documentation](https://github.com/esgf2-us/intake-esgf) for more options.
 ///
 
 ### Running Test Cases
@@ -392,68 +380,35 @@ pytest --slow
 pytest -m "not requires_esgf_data"
 ```
 
-## Regression Testing
+## Regression baselines
 
-Regression testing is particularly useful in the REF.
-Often the diagnostics may take a significant period of time to run,
-so it isn't desireable to run a large number of them on every Pull Request.
-The regression outputs provide useful insights into what figures and data an execution produces.
+Diagnostics can be slow, so the REF doesn't re-run them on every pull request.
+Instead each test case is pinned to a **regression baseline** — a recorded, known-good
+output — and CI checks changes against it.
 
-Regression baselines are stored within each provider package, alongside the catalog:
-
-```raw
-packages/climate-ref-{provider}/tests/test-data/
-└── {diagnostic}/
-    └── {test_case}/
-        ├── catalog.yaml       # Dataset metadata
-        ├── catalog.paths.yaml # Local file paths (gitignored)
-        ├── manifest.json      # Binds the two baseline layers (see below)
-        └── regression/        # Committed bundle (text-only CMEC JSON)
-            ├── series.json       # Scalar/series metric values
-            ├── diagnostic.json   # Execution result
-            └── output.json       # CMEC output bundle
-```
-
-A baseline has **two layers** (see
+A baseline has two layers (see
 [Regression baselines](../background/regression-baselines.md) for the full model):
 
-- the small, git-tracked **committed bundle** under `regression/`, which is what review
-  and CI actually gate on; and
-- the heavy **native bundle** (`.nc`, `.png`, ...) that lives in a shared object store,
-  content-addressed by digest, and is fetched anonymously.
+- the small, git-tracked **committed bundle** (`series.json`, `diagnostic.json`,
+  `output.json`) under `regression/`, which is what review and CI gate on; and
+- the heavy **native bundle** (`.nc`, `.png`, ...), stored by digest in a shared object
+  store and fetched anonymously.
 
-`manifest.json` binds them, recording a monotonic `test_case_version` that *authorises* a
-new baseline, the digests of the committed files, the digests of the native files, and the
-hash of the input `catalog.yaml`.
+`manifest.json` (shown in the layout above) binds the two, recording a `test_case_version`
+that authorises a new baseline, the digests of both layers, and the input catalog's hash.
 
-For example, the ILAMB provider's `gpp-fluxcom` diagnostic with the `default` test case:
+### Creating or updating a baseline
 
-```
-packages/climate-ref-ilamb/tests/test-data/
-└── gpp-fluxcom/
-    └── default/
-        ├── catalog.yaml
-        ├── catalog.paths.yaml
-        └── regression/
-            ├── diagnostic.json
-            ├── output.json
-            └── ...
-```
-
-### Creating a Baseline
-
-If a new diagnostic is added or updated,
-the regression baseline should be regenerated.
+Regenerate the committed bundle when you add a diagnostic or intend to change its results:
 
 ```bash
 ref test-cases run --provider my-provider --diagnostic my-diagnostic --force-regen
 ```
 
-This can produce large files some of which may be added to the `.gitignore` file if needed.
-Generally files that are less than a few MB are ok (a pre-commit hook checks the size of committed files).
-How we store these regression outputs may need to change over time.
+We keep committed files small — a pre-commit hook flags anything over a few MB.
+Large outputs belong in the native bundle, published with `mint` (see below).
 
-### Comparing Against Baseline
+### Comparing against the baseline
 
 The `execution_regression` fixture compares results automatically:
 
@@ -468,12 +423,11 @@ def test_regression(run_test_case, execution_regression):
     execution_regression.check(result, "my-provider/my-diagnostic/default")
 ```
 
-## Baselines and the pull request workflow
+### The pull request workflow
 
-When you open a pull request, CI decides *how* to verify each test case's baseline
-purely from what your branch changed relative to the base. You do not run the diagnostic
-again on every PR — that would be too slow — so it helps to know what the gate will do and
-what each outcome asks of you.
+When you open a pull request, CI decides *how* to verify each test case from what your
+branch changed — you don't re-run every diagnostic. The diagram shows the path; the table
+below says what each outcome asks of you.
 
 ```mermaid
 flowchart TD
@@ -497,121 +451,28 @@ flowchart TD
     mint --> done3([Reviewed via the committed diff — merge])
 ```
 
-### What each gate outcome means for you
-
-| Outcome | What happened | What to do |
+| Outcome | Meaning | What to do |
 | --- | --- | --- |
-| **skip** | Nothing relevant to this case changed. | Nothing — merge as usual. |
-| **replay** | Your change *could* affect the result (you touched extraction code, or re-minted native files). CI re-checks the cached native baseline against the committed bundle. | Nothing if it passes. If replay reports drift, your change moved the results: regenerate the baseline and bump `test_case_version`, or fix the code. |
-| **execute** | You bumped `test_case_version`, authorising a new baseline. The credential-free PR tier cannot publish native files, so it flags the case instead of verifying it. | Publish the new native baseline through the gated mint workflow (below). Review of the new committed bundle happens in the PR diff. |
-| **fail** | The committed bundle (or its input catalog) changed without a `test_case_version` bump, or the version moved backwards. | Bump `test_case_version` to authorise the change, or revert the unintended edit. |
+| **skip** | Nothing relevant changed. | Nothing. |
+| **replay** | Your change could affect the result; CI re-checks the cached native baseline against the committed bundle. | Nothing if it passes. On drift, regenerate and bump `test_case_version`, or fix the code. |
+| **execute** | You bumped `test_case_version`, authorising a new baseline; the credential-free PR tier flags it rather than publishing native files. | Publish the native baseline (below); the new committed bundle is reviewed in the diff. |
+| **fail** | The committed bundle or input catalog changed without a `test_case_version` bump (or the version moved backwards). | Bump `test_case_version` to authorise it, or revert the edit. |
 
-!!! tip "When to bump `test_case_version`"
-    Bump it whenever you *intend* to change a baseline's results. The bump is what tells
-    reviewers and CI "yes, this new output is correct" — without it, a changed baseline is
-    treated as an accidental regression and the gate fails.
+Bump `test_case_version` whenever you *intend* to change a baseline — it tells reviewers and CI the new output is correct.
 
-### Publishing a new native baseline
+#### Publishing a native baseline
 
-Native files (the `.nc`/`.png` outputs referenced by the committed bundle) are written to
-the shared object store only by the **`mint`** verb, which needs write credentials. So that
-no contributor needs those credentials, minting runs as a gated CI workflow:
+Native files are written to the object store only by `ref test-case mint`, which needs write credentials.
+Instead of every contributor requiring credentials, we run the minting via a CI workflow:
 
-1. Regenerate and commit your new committed bundle locally
-   (`ref test-cases run --force-regen`), and bump `test_case_version` in `manifest.json`.
-2. Push your branch and run the **"Regression baselines (mint)"** workflow from the GitHub
-   Actions tab, dispatched **on your branch**. It is gated behind a reviewed environment.
-3. The workflow uploads your native files to the store and commits the regenerated
-   `manifest.json` (now carrying the native digests) back to your branch.
-4. The PR gate then `replay`s the published baseline, and review sees the committed-bundle
-   diff as usual.
+1. Regenerate and commit the new bundle locally (`run --force-regen`) and bump `test_case_version`.
+2. Run the **"Regression baselines (mint)"** workflow from the Actions tab,
+   dispatched **on your branch** (gated behind a reviewed environment).
+   It uploads the native files and commits the updated `manifest.json` back to your branch.
+3. The PR gate then replays the published baseline.
 
-Use the **`--dry-run`** input first to preflight credentials and preview what would be
-minted without uploading anything. If you do hold credentials locally, `ref test-cases mint`
-does the same thing from your machine.
-
-See [Regression baselines](../background/regression-baselines.md) for the full two-layer
-model, the tolerant comparison, and the credential trust boundary.
-
-## Complete Example
-
-Here's a complete diagnostic with test data specification:
-
-```python
-from climate_ref_core.diagnostics import Diagnostic, ExecutionDefinition, ExecutionResult, DataRequirement
-from climate_ref_core.datasets import FacetFilter, SourceDatasetType
-from climate_ref_core.constraints import AddSupplementaryDataset, RequireContiguousTimerange
-from climate_ref_core.testing import TestDataSpecification, TestCase
-from climate_ref_core.esgf import CMIP6Request
-
-
-class TemperatureBias(Diagnostic):
-    """Calculate temperature bias against observations."""
-
-    name = "Temperature Bias"
-    slug = "temperature-bias"
-
-    data_requirements = (
-        DataRequirement(
-            source_type=SourceDatasetType.CMIP6,
-            filters=(FacetFilter(facets={"variable_id": "tas"}),),
-            group_by=("source_id", "experiment_id", "variant_label"),
-            constraints=(
-                AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
-                RequireContiguousTimerange(group_by=("instance_id",)),
-            ),
-        ),
-    )
-
-    facets = ("source_id", "experiment_id", "variant_label", "region", "statistic")
-
-    test_data_spec = TestDataSpecification(
-        test_cases=(
-            TestCase(
-                name="default",
-                description="Historical temperature from ACCESS-ESM1-5",
-                requests=(
-                    CMIP6Request(
-                        slug="tas-historical",
-                        facets={
-                            "source_id": "ACCESS-ESM1-5",
-                            "experiment_id": "historical",
-                            "variable_id": "tas",
-                            "member_id": "r1i1p1f1",
-                            "table_id": "Amon",
-                        },
-                    ),
-                ),
-            ),
-            TestCase(
-                name="short-timeseries",
-                description="Edge case: very short time series",
-                requests=(
-                    CMIP6Request(
-                        slug="tas-short",
-                        facets={
-                            "source_id": "ACCESS-ESM1-5",
-                            "experiment_id": "historical",
-                            "variable_id": "tas",
-                            "member_id": "r1i1p1f1",
-                            "table_id": "Amon",
-                        },
-                        # TODO: this doesn't actually clip the dataset yet
-                        time_span=("2014-01", "2014-12"),
-                    ),
-                ),
-            ),
-        ),
-    )
-
-    def execute(self, definition: ExecutionDefinition) -> None:
-        # Implementation here
-        ...
-
-    def build_execution_result(self, definition: ExecutionDefinition) -> ExecutionResult:
-        # Build result here
-        ...
-```
+Use the **`--dry-run`** input to preflight without uploading.
+If you hold credentials locally, `ref test-cases mint` does the same from your machine.
 
 ## Troubleshooting
 

--- a/packages/climate-ref-core/src/climate_ref_core/regression/gate.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/gate.py
@@ -6,11 +6,13 @@ based on what changed relative to the base branch:
 
 - **EXECUTE** — re-run the diagnostic end-to-end and compare the regenerated committed
     bundle to the in-repo copy (tolerant compare).
-    Required when the author has bumped ``test_case_version`` to authorise a new baseline.
+    Required when the author has bumped ``test_case_version`` to authorise a new baseline
+    but no native baseline exists to replay against.
 - **REPLAY** — materialise the cached native baseline and re-run only
     ``build_execution_result`` against it, comparing to the committed bundle.
     Cheap and anonymous; used when extraction code changed but the committed bundle did
-    not, and to seed a newly added manifest — but only when native blobs exist to replay.
+    not, to seed a newly added manifest, and to verify a ``test_case_version`` bump that ships native blobs
+    — but only when native blobs exist to replay.
 - **FAIL** — the committed bundle (or its input catalog) changed without a
     ``test_case_version`` bump (an unauthorised baseline change), or the version moved backwards.
 - **SKIP** — nothing relevant to this test case changed, or the case is not yet under
@@ -180,10 +182,19 @@ def decide_coupling(  # noqa: PLR0911, PLR0912
     native_changed = manifest.native != base_manifest.native
 
     if version_bumped:
+        version_change = f"{base_manifest.test_case_version} -> {manifest.test_case_version}"
+        if manifest.native:
+            # A native baseline ships with the bump, so the replay can prove the new committed bundle
+            # actually reproduces from those blobs.
+            return GateDecision(
+                Action.REPLAY,
+                f"test_case_version bumped ({version_change}) with a native baseline present; "
+                "replaying to confirm the native baseline reproduces the new committed bundle",
+            )
         return GateDecision(
             Action.EXECUTE,
-            f"test_case_version bumped ({base_manifest.test_case_version} -> "
-            f"{manifest.test_case_version}); executing full run with tolerant compare",
+            f"test_case_version bumped ({version_change}) with no native baseline to replay; "
+            "full end-to-end re-run required to verify the new committed bundle",
         )
 
     if committed_changed:

--- a/packages/climate-ref-core/tests/unit/regression/test_gate.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_gate.py
@@ -95,19 +95,30 @@ class TestDecideCoupling:
         assert "WARNING" in decision.reason
         assert "de-mint" in decision.reason
 
-    def test_version_bump_executes(self) -> None:
+    def test_version_bump_without_native_executes(self) -> None:
+        # No native baseline to replay against, so the bump needs a full re-run.
         base = make_manifest(1)
         current = make_manifest(2)
         decision = decide_coupling(current, base)
         assert decision.action is Action.EXECUTE
         assert "1 -> 2" in decision.reason
+        assert "no native baseline" in decision.reason
 
-    def test_version_bump_executes_even_with_committed_change(self) -> None:
+    def test_version_bump_without_native_executes_even_with_committed_change(self) -> None:
         # A bump authorises a new baseline, so a committed change is expected.
         base = make_manifest(1, {"output.json": "a" * 64})
         current = make_manifest(2, {"output.json": "b" * 64})
         decision = decide_coupling(current, base)
         assert decision.action is Action.EXECUTE
+
+    def test_version_bump_with_native_replays(self) -> None:
+        native = {"data.nc": NativeEntry("a" * 64, 10)}
+        base = make_manifest(1, {"output.json": "a" * 64})
+        current = make_manifest(2, {"output.json": "b" * 64}, native)
+        decision = decide_coupling(current, base)
+        assert decision.action is Action.REPLAY
+        assert "1 -> 2" in decision.reason
+        assert "native baseline present" in decision.reason
 
     def test_committed_change_without_bump_fails(self) -> None:
         base = make_manifest(1, {"output.json": "a" * 64})

--- a/scripts/ci/regression-pr-gate.sh
+++ b/scripts/ci/regression-pr-gate.sh
@@ -3,9 +3,6 @@
 #
 # Runs the coupling gate (`ref test-cases ci-gate`) against the pull request's base branch and,
 # for every case it routes to `replay`, re-checks the cached native baseline.
-# `execute` cases are surfaced as warnings
-# (a `test_case_version` bump authorises a new baseline that only the credentialed mint tier can publish, so the PR tier cannot verify it);
-# `fail` cases abort the job.
 #
 # All baseline data can be fetched with public read access so this does not require credentials.
 #
@@ -35,11 +32,10 @@ if [ "${gate_rc}" -ne 0 ]; then
   exit 1
 fi
 
-# A version bump authorises a new baseline that only the trusted mint tier can
-# publish, so flag it here rather than trying (and failing) to verify it.
+
 while IFS= read -r execute_case; do
   [ -n "${execute_case}" ] || continue
-  echo "::warning::${execute_case} bumped test_case_version -- re-mint on the trusted tier after merge."
+  echo "::warning::${execute_case} bumped test_case_version with no native baseline -- review the committed bundle, then mint on the trusted tier to enable replay verification."
 done < <(echo "${decisions}" | jq -r '.[] | select(.action == "execute") | .case')
 
 replay_cases="$(echo "${decisions}" | jq -r '.[] | select(.action == "replay") | .case')"

--- a/scripts/ci/regression-pr-gate.sh
+++ b/scripts/ci/regression-pr-gate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# PR-tier regression baseline gate.
+#
+# Runs the coupling gate (`ref test-cases ci-gate`) against the pull request's base
+# branch and, for every case it routes to `replay`, re-checks the cached native
+# baseline. `execute` cases are surfaced as warnings (a `test_case_version` bump
+# authorises a new baseline that only the credentialed mint tier can publish, so the
+# PR tier cannot verify it); `fail` cases abort the job.
+#
+# No credentials are used: every command here is anonymous public read, so this is
+# safe to run on untrusted fork pull-request code.
+#
+# `ci-gate` reads only manifests and the git diff, so it needs no input data. The
+# (slower) sample-data and catalog fetch is therefore deferred until the gate has
+# found at least one case that actually needs replaying -- the common pull request
+# touches no baselines and skips the download entirely.
+#
+# Environment:
+#   GITHUB_BASE_REF  the PR's base branch (set automatically on pull_request events).
+set -euo pipefail
+
+base="origin/${GITHUB_BASE_REF:-main}"
+
+echo "::group::coupling gate (base: ${base})"
+# `ci-gate` exits non-zero when any case is gated `fail`; capture the decisions
+# regardless so the failing cases can be reported before the script exits.
+set +e
+decisions="$(uv run ref test-cases ci-gate --base "${base}" --json)"
+gate_rc=$?
+set -e
+echo "${decisions}" | jq .
+echo "::endgroup::"
+
+if [ "${gate_rc}" -ne 0 ]; then
+  echo "::error::Coupling gate failed -- a baseline changed without an authorised test_case_version bump."
+  echo "${decisions}" | jq -r '.[] | select(.action == "fail") | "  FAIL " + .case + " -- " + .reason'
+  exit 1
+fi
+
+# A version bump authorises a new baseline that only the trusted mint tier can
+# publish, so flag it here rather than trying (and failing) to verify it.
+while IFS= read -r execute_case; do
+  [ -n "${execute_case}" ] || continue
+  echo "::warning::${execute_case} bumped test_case_version -- re-mint on the trusted tier after merge."
+done < <(echo "${decisions}" | jq -r '.[] | select(.action == "execute") | .case')
+
+replay_cases="$(echo "${decisions}" | jq -r '.[] | select(.action == "replay") | .case')"
+if [ -z "${replay_cases}" ]; then
+  echo "No cases require replay; baseline gate passed."
+  exit 0
+fi
+
+# Only now -- with replay work to do -- pay for the input data the replay needs.
+echo "::group::fetch inputs for replay"
+uv run ref datasets fetch-sample-data
+while IFS= read -r provider; do
+  [ -n "${provider}" ] || continue
+  uv run ref test-cases fetch --provider "${provider}" \
+    || echo "::warning::test-case fetch incomplete for ${provider}"
+done < <(echo "${replay_cases}" | cut -d/ -f1 | sort -u)
+echo "::endgroup::"
+
+# Replay every case the gate routed to REPLAY. Process substitution (rather than a
+# pipe) keeps the loop in the current shell so the failure counter survives.
+failures=0
+replayed=0
+while IFS='/' read -r provider diagnostic test_case; do
+  [ -n "${provider}" ] || continue
+  echo "::group::replay ${provider}/${diagnostic}/${test_case}"
+  if uv run ref test-cases replay \
+      --provider "${provider}" \
+      --diagnostic "${diagnostic}" \
+      --test-case "${test_case}"; then
+    replayed=$((replayed + 1))
+  else
+    echo "::error::replay drift for ${provider}/${diagnostic}/${test_case}"
+    failures=$((failures + 1))
+  fi
+  echo "::endgroup::"
+done < <(printf '%s\n' "${replay_cases}")
+
+echo "Replayed ${replayed} case(s); ${failures} drifted."
+if [ "${failures}" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/ci/regression-pr-gate.sh
+++ b/scripts/ci/regression-pr-gate.sh
@@ -7,12 +7,17 @@
 # All baseline data can be fetched with public read access so this does not require credentials.
 #
 # `ci-gate` reads only manifests and the git diff, so it needs no input data.
-# The (slower) sample-data and catalog fetch is therefore deferred until the gate hasfound at least one case that actually needs replaying.
+# The (slower) sample-data and catalog fetch is therefore deferred until the gate has found at least one case that actually needs replaying.
 # The common pull request touches no baselines and skips the download entirely.
 #
 # Environment:
 #   GITHUB_BASE_REF  the PR's base branch (set automatically on pull_request events).
 set -euo pipefail
+
+# Rich colour codes would corrupt the JSON we parse with jq. Force them off here so the
+# script is self-contained and parseable even when run outside the workflow (which also
+# sets NO_COLOR for the same reason).
+export NO_COLOR=1
 
 base="origin/${GITHUB_BASE_REF:-main}"
 
@@ -23,12 +28,21 @@ set +e
 decisions="$(uv run ref test-cases ci-gate --base "${base}" --json)"
 gate_rc=$?
 set -e
-echo "${decisions}" | jq .
+printf '%s\n' "${decisions}" | jq .
 echo "::endgroup::"
 
 if [ "${gate_rc}" -ne 0 ]; then
-  echo "::error::Coupling gate failed -- a baseline changed without an authorised test_case_version bump."
-  echo "${decisions}" | jq -r '.[] | select(.action == "fail") | "  FAIL " + .case + " -- " + .reason'
+  # `ci-gate` exits non-zero for two distinct reasons: at least one case was gated
+  # `fail`, or a hard error (not a git repo, an unfetched base ref, a failed diff)
+  # that printed no decisions. Only the former is a baseline-coupling violation, so
+  # report each kind accurately rather than blaming every failure on the author.
+  fail_cases="$(printf '%s\n' "${decisions}" | jq -r '.[]? | select(.action == "fail") | "  FAIL " + .case + " -- " + .reason')"
+  if [ -n "${fail_cases}" ]; then
+    echo "::error::Coupling gate failed -- a baseline changed without an authorised test_case_version bump."
+    echo "${fail_cases}"
+  else
+    echo "::error::ci-gate exited ${gate_rc} without a fail decision -- see the gate output above (e.g. an unfetched base ref or a non-git checkout)."
+  fi
   exit 1
 fi
 
@@ -36,9 +50,9 @@ fi
 while IFS= read -r execute_case; do
   [ -n "${execute_case}" ] || continue
   echo "::warning::${execute_case} bumped test_case_version with no native baseline -- review the committed bundle, then mint on the trusted tier to enable replay verification."
-done < <(echo "${decisions}" | jq -r '.[] | select(.action == "execute") | .case')
+done < <(printf '%s\n' "${decisions}" | jq -r '.[] | select(.action == "execute") | .case')
 
-replay_cases="$(echo "${decisions}" | jq -r '.[] | select(.action == "replay") | .case')"
+replay_cases="$(printf '%s\n' "${decisions}" | jq -r '.[] | select(.action == "replay") | .case')"
 if [ -z "${replay_cases}" ]; then
   echo "No cases require replay; baseline gate passed."
   exit 0
@@ -51,7 +65,7 @@ while IFS= read -r provider; do
   [ -n "${provider}" ] || continue
   uv run ref test-cases fetch --provider "${provider}" \
     || echo "::warning::test-case fetch incomplete for ${provider}"
-done < <(echo "${replay_cases}" | cut -d/ -f1 | sort -u)
+done < <(printf '%s\n' "${replay_cases}" | cut -d/ -f1 | sort -u)
 echo "::endgroup::"
 
 # Replay every case the gate routed to REPLAY. Process substitution (rather than a

--- a/scripts/ci/regression-pr-gate.sh
+++ b/scripts/ci/regression-pr-gate.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 # PR-tier regression baseline gate.
 #
-# Runs the coupling gate (`ref test-cases ci-gate`) against the pull request's base
-# branch and, for every case it routes to `replay`, re-checks the cached native
-# baseline. `execute` cases are surfaced as warnings (a `test_case_version` bump
-# authorises a new baseline that only the credentialed mint tier can publish, so the
-# PR tier cannot verify it); `fail` cases abort the job.
+# Runs the coupling gate (`ref test-cases ci-gate`) against the pull request's base branch and,
+# for every case it routes to `replay`, re-checks the cached native baseline.
+# `execute` cases are surfaced as warnings
+# (a `test_case_version` bump authorises a new baseline that only the credentialed mint tier can publish, so the PR tier cannot verify it);
+# `fail` cases abort the job.
 #
-# No credentials are used: every command here is anonymous public read, so this is
-# safe to run on untrusted fork pull-request code.
+# All baseline data can be fetched with public read access so this does not require credentials.
 #
-# `ci-gate` reads only manifests and the git diff, so it needs no input data. The
-# (slower) sample-data and catalog fetch is therefore deferred until the gate has
-# found at least one case that actually needs replaying -- the common pull request
-# touches no baselines and skips the download entirely.
+# `ci-gate` reads only manifests and the git diff, so it needs no input data.
+# The (slower) sample-data and catalog fetch is therefore deferred until the gate hasfound at least one case that actually needs replaying.
+# The common pull request touches no baselines and skips the download entirely.
 #
 # Environment:
 #   GITHUB_BASE_REF  the PR's base branch (set automatically on pull_request events).


### PR DESCRIPTION
## Description

PR-4 of RFC 0005. Wires the regression-baseline lifecycle verbs (`ci-gate`,
`replay`, `mint`, `sync`) — shipped in the earlier stack PRs — into CI, split along
the trust boundary so that write credentials live in exactly one manually-gated step.

Stacked on `feat/regression-r2-backend` (PR-5); review/merge that first.

### Three workflows

| Workflow | Trigger | Credentials | What it does |
| --- | --- | --- | --- |
| `regression-pr-gate.yaml` | every pull request | none | Runs `ref test-cases ci-gate`, fails on `fail`, replays each `replay` case against the public baseline, flags `execute`. Safe on fork PRs. |
| `regression-mint.yaml` | manual dispatch | R2 write | Gated behind the `native-baselines` Environment; mints native baselines and commits the regenerated manifest back to the dispatched feature branch. |
| `regression-drift.yaml` | nightly + manual | none | `sync` + `replay` to catch baselines that no longer reproduce within tolerance. |

The PR gate's replay fan-out lives in `scripts/ci/regression-pr-gate.sh`. It defers all
data download until a case actually needs replaying, so a PR that touches no baselines
(the common case) completes without any downloads.

### Documentation

- `docs/background/regression-baselines.md`: a new **Continuous integration** section.
- `docs/how-to-guides/testing-diagnostics.md`: a diagnostic-developer **pull request
  workflow** section with a mermaid diagram, a per-outcome action table, and how to
  publish native baselines via the gated mint workflow.

### Required repository configuration (before `mint` works)

Create a **`native-baselines`** Environment (Settings → Environments) with **required
reviewers**, and add two environment secrets holding an object-scoped R2 token:

- `R2_ACCESS_KEY_ID` → `REF_NATIVE_STORE_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY` → `REF_NATIVE_STORE_SECRET_ACCESS_KEY`

The PR gate and nightly drift need no setup.

### Verification

- `actionlint` + `shellcheck` clean on all four files; `pre-commit` passes.
- `ref test-cases ci-gate --json` emits clean, ANSI-free, jq-parseable JSON.
- The exact `replay` the gate issues for the example case reproduces the committed
  bundle against live R2 (4 native files materialised, 3 bundle files compared).

### Scope

Covers the `example` provider (the only one migrated so far). Provider migrations
(PR-6) will add each provider to the drift/replay lists; real-provider mint will need
the self-hosted runner rather than `ubuntu-latest`.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added — n/a; CI configuration, validated with actionlint/shellcheck and a live `ci-gate`/`replay` run
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`