### PR TITLE
fix(config): don't fail config load when ignore-datasets cache is unwritable

### DIFF
--- a/changelog/734.fix.md
+++ b/changelog/734.fix.md
@@ -1,0 +1,3 @@
+Fixed loading the default configuration in environments where the user cache directory cannot be written (for example, read-only or restricted HPC systems).
+Previously, running a `ref` command without an existing configuration file could fail with `Error loading configuration` because the default ignore-datasets file could not be cached.
+The REF now degrades gracefully and continues without the cached ignore-datasets file.

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -88,7 +88,14 @@ class DiagnosticProvider:
         #     source_type:
         #       - facet: value
         #       - other_facet: [other_value1, other_value2]
-        ignore_datasets_all = yaml.safe_load(config.ignore_datasets_file.read_text(encoding="utf-8")) or {}
+        ignore_datasets_file = config.ignore_datasets_file
+        if ignore_datasets_file.is_file():
+            ignore_datasets_all = yaml.safe_load(ignore_datasets_file.read_text(encoding="utf-8")) or {}
+        else:
+            logger.warning(
+                f"Ignore datasets file {ignore_datasets_file} not found; no datasets will be ignored"
+            )
+            ignore_datasets_all = {}
         ignore_datasets = ignore_datasets_all.get(self.slug, {})
         if unknown_slugs := {slug for slug in ignore_datasets} - {d.slug for d in self.diagnostics()}:
             logger.warning(

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -85,6 +85,14 @@ class TestDiagnosticProvider:
         expected_constraint = IgnoreFacets(facets={"source_id": ("A",)})
         assert provider.diagnostics()[0].data_requirements[0][0].constraints[0] == expected_constraint
 
+    def test_configure_missing_ignore_file(self, provider, mock_config, caplog):
+        # A missing ignore datasets file (e.g. the cache could not be written) must not raise;
+        # it is treated as "ignore nothing".
+        mock_config.ignore_datasets_file.unlink()
+        with caplog.at_level(logging.WARNING):
+            provider.configure(mock_config)
+        assert f"Ignore datasets file {mock_config.ignore_datasets_file} not found" in caplog.text
+
     def test_configure_unknown_diagnostic(self, provider, mock_config, caplog):
         mock_config.ignore_datasets_file.write_text(
             textwrap.dedent(

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -398,31 +398,39 @@ def _get_default_ignore_datasets_file() -> Path:
     Get the path to the ignore datasets file
     """
     cache_dir = platformdirs.user_cache_path("climate_ref")
-    cache_dir.mkdir(parents=True, exist_ok=True)
     ignore_datasets_file = cache_dir / "default_ignore_datasets.yaml"
 
-    download = True
-    if ignore_datasets_file.exists():
-        # Only update if the ignore datasets file is older than `DEFAULT_IGNORE_DATASETS_MAX_AGE`.
-        modification_time = datetime.datetime.fromtimestamp(ignore_datasets_file.stat().st_mtime)
-        age = datetime.datetime.now() - modification_time
-        if age < DEFAULT_IGNORE_DATASETS_MAX_AGE:
-            download = False
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
 
-    if download:
-        logger.info(
-            f"Downloading default ignore datasets file from {DEFAULT_IGNORE_DATASETS_URL} "
-            f"to {ignore_datasets_file}"
-        )
-        try:
-            response = requests.get(DEFAULT_IGNORE_DATASETS_URL, timeout=120)
-            response.raise_for_status()
-        except requests.RequestException as exc:
-            logger.warning(f"Failed to download default ignore datasets file: {exc}")
-            ignore_datasets_file.touch(exist_ok=True)
-        else:
-            with ignore_datasets_file.open(mode="wb") as file:
-                file.write(response.content)
+        download = True
+        if ignore_datasets_file.exists():
+            # Only update if the ignore datasets file is older than `DEFAULT_IGNORE_DATASETS_MAX_AGE`.
+            modification_time = datetime.datetime.fromtimestamp(ignore_datasets_file.stat().st_mtime)
+            age = datetime.datetime.now() - modification_time
+            if age < DEFAULT_IGNORE_DATASETS_MAX_AGE:
+                download = False
+
+        if download:
+            logger.info(
+                f"Downloading default ignore datasets file from {DEFAULT_IGNORE_DATASETS_URL} "
+                f"to {ignore_datasets_file}"
+            )
+            try:
+                response = requests.get(DEFAULT_IGNORE_DATASETS_URL, timeout=120)
+                response.raise_for_status()
+            except requests.RequestException as exc:
+                logger.warning(f"Failed to download default ignore datasets file: {exc}")
+                ignore_datasets_file.touch(exist_ok=True)
+            else:
+                with ignore_datasets_file.open(mode="wb") as file:
+                    file.write(response.content)
+    except OSError as exc:
+        # Acquiring the default ignore datasets file is a best-effort optimisation.
+        # If the cache directory cannot be created or written to
+        # (e.g. a read-only or otherwise restricted environment),
+        # fall back to the (possibly missing) path rather than breaking configuration loading.
+        logger.warning(f"Unable to prepare default ignore datasets file at {ignore_datasets_file}: {exc}")
 
     return ignore_datasets_file
 

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -52,6 +52,24 @@ class TestConfig:
         loaded = Config.default()
         assert loaded.paths.scratch == Path("data").resolve()
 
+    def test_default_missing_file_unwritable_cache(self, tmp_path, monkeypatch, mocker):
+        # Regression: Config.default() must not fail when no config file exists and the
+        # ignore-datasets cache directory cannot be written. Previously the OSError raised by the
+        # ignore_datasets_file factory surfaced as a misleading "Error loading configuration".
+        monkeypatch.setenv("REF_CONFIGURATION", str(tmp_path / "climate_ref"))
+        assert not (tmp_path / "climate_ref" / "ref.toml").exists()
+
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory", encoding="utf-8")
+        mocker.patch.object(
+            climate_ref.config.platformdirs, "user_cache_path", return_value=blocker / "climate_ref"
+        )
+
+        loaded = Config.default()
+
+        assert loaded.ignore_datasets_file == blocker / "climate_ref" / "default_ignore_datasets.yaml"
+        assert loaded.paths.scratch == tmp_path / "climate_ref" / "scratch"
+
     def test_load(self, config, tmp_path):
         res = config.dump(defaults=True)
 
@@ -308,6 +326,23 @@ def test_get_default_ignore_datasets_file_fail(mocker, tmp_path):
     assert path == tmp_path / "default_ignore_datasets.yaml"
     assert path.parent.exists()
     assert path.read_text(encoding="utf-8") == ""
+
+
+def test_get_default_ignore_datasets_file_unwritable_cache(mocker, tmp_path, caplog):
+    """A non-writable cache directory must degrade gracefully rather than raise."""
+    # A regular file standing where the cache directory should be makes mkdir() raise an OSError,
+    # mimicking a read-only or otherwise restricted environment (e.g. an HPC login node).
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    unwritable_cache = blocker / "climate_ref"
+    mocker.patch.object(climate_ref.config.platformdirs, "user_cache_path", return_value=unwritable_cache)
+
+    with caplog.at_level(logging.WARNING):
+        path = _get_default_ignore_datasets_file()
+
+    assert path == unwritable_cache / "default_ignore_datasets.yaml"
+    assert not path.exists()
+    assert any("Unable to prepare default ignore datasets file" in r.message for r in caplog.records)
 
 
 def test_get_default_ignore_datasets_file_network_error(mocker, tmp_path):


### PR DESCRIPTION
## Description

`uv run ref config list` (and any `ref` command) crashes with a misleading
`ValueError: Error loading configuration from .../ref.toml` when **no config file exists yet** and the user cache directory cannot be written. A default `Config` should load without a config file.

### Root cause

The `ignore_datasets_file` config field uses a default factory, `_get_default_ignore_datasets_file()`, that performs filesystem I/O
(`cache_dir.mkdir`, `touch`, `file.write`) while the `Config` object is being structured.
 
### Fix

Acquiring the default ignore-datasets file is a best-effort optimisation, so:

- `_get_default_ignore_datasets_file()` now degrades gracefully on any filesystem error, logging a warning and returning the (possibly missing) path instead of breaking config loading.
- `DiagnosticProvider.configure()` tolerates an absent ignore-datasets file, treating it as "ignore nothing" rather than raising `FileNotFoundError` downstream.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`