### PR TITLE
fix(solve): wait and collect results when --timeout 0

### DIFF
--- a/changelog/735.fix.md
+++ b/changelog/735.fix.md
@@ -1,0 +1,6 @@
+Fixed `ref solve --timeout 0` discarding completed work instead of waiting for it.
+A timeout of `0` (or any non-positive value) now means "wait with no time limit",
+so executions are collected, copied to the results directory, and ingested as expected;
+previously they ran but their outputs were left in the scratch directory.
+Use `--no-wait` to queue executions and exit immediately,
+and recover any orphaned scratch outputs from an earlier run with `ref executions reingest --include-failed`.

--- a/packages/climate-ref-celery/src/climate_ref_celery/executor.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/executor.py
@@ -35,6 +35,11 @@ class CeleryExecutor(Executor):
 
     name = "celery"
 
+    # Results are persisted by the worker via the ``handle_result`` task link, so
+    # ``join`` only waits for completion. Skipping it (queue-and-exit) does not lose
+    # work: the workers keep processing and ingesting results in the background.
+    collects_results_on_join = False
+
     def __init__(self, *, config: Config, **kwargs: Any) -> None:
         self.config = config
         super().__init__(**kwargs)  # type: ignore
@@ -97,12 +102,13 @@ class CeleryExecutor(Executor):
         Parameters
         ----------
         timeout
-            Maximum time to wait in seconds before raising a TimeoutError
+            Maximum time to wait in seconds before raising a TimeoutError.
+            A non-positive value (``<= 0``) waits indefinitely.
 
         Raises
         ------
         TimeoutError
-            If all executions aren't completed within the specified timeout
+            If all executions aren't completed within a positive timeout
         """
         start_time = time.time()
         refresh_time = 0.5  # Time to wait between checking for completed tasks in seconds
@@ -117,7 +123,8 @@ class CeleryExecutor(Executor):
 
                 elapsed_time = time.time() - start_time
 
-                if elapsed_time > timeout:
+                # ``timeout <= 0`` means wait indefinitely (no overall deadline).
+                if timeout > 0 and elapsed_time > timeout:
                     raise TimeoutError("Not all tasks completed within the specified timeout")
 
                 # Iterate over a copy of the list and remove finished tasks

--- a/packages/climate-ref-celery/src/climate_ref_celery/executor.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/executor.py
@@ -35,9 +35,10 @@ class CeleryExecutor(Executor):
 
     name = "celery"
 
-    # Results are persisted by the worker via the ``handle_result`` task link, so
-    # ``join`` only waits for completion. Skipping it (queue-and-exit) does not lose
-    # work: the workers keep processing and ingesting results in the background.
+    # Results are persisted by the worker via the ``handle_result`` task link,
+    # so ``join`` only waits for completion.
+    # Skipping it (queue-and-exit) does not lose work.
+    # The workers keep processing and ingesting results in the background.
     collects_results_on_join = False
 
     def __init__(self, *, config: Config, **kwargs: Any) -> None:

--- a/packages/climate-ref-core/src/climate_ref_core/executor.py
+++ b/packages/climate-ref-core/src/climate_ref_core/executor.py
@@ -107,10 +107,11 @@ class Executor(Protocol):
     Whether execution results are only collected and persisted during ``join``.
 
     When ``True`` (e.g. the local process pool and HPC executors), skipping ``join``
-    -- as ``--no-wait`` does -- leaves completed outputs in the scratch directory
-    without copying them to the results directory or ingesting them. When ``False``
-    (e.g. the synchronous and Celery executors), results are persisted elsewhere
-    (inline in ``run`` or by a worker callback), so ``join`` only waits for completion.
+    (via ``--no-wait``) leaves completed outputs in the scratch directory
+    without copying them to the results directory or ingesting them.
+    When ``False`` (e.g. the synchronous and Celery executors),
+    results are persisted elsewhere (inline in ``run`` or by a worker callback),
+    so ``join`` only waits for completion.
     """
 
     def __init__(self, **kwargs: Any) -> None: ...

--- a/packages/climate-ref-core/src/climate_ref_core/executor.py
+++ b/packages/climate-ref-core/src/climate_ref_core/executor.py
@@ -102,6 +102,17 @@ class Executor(Protocol):
 
     name: str
 
+    collects_results_on_join: bool
+    """
+    Whether execution results are only collected and persisted during ``join``.
+
+    When ``True`` (e.g. the local process pool and HPC executors), skipping ``join``
+    -- as ``--no-wait`` does -- leaves completed outputs in the scratch directory
+    without copying them to the results directory or ingesting them. When ``False``
+    (e.g. the synchronous and Celery executors), results are persisted elsewhere
+    (inline in ``run`` or by a worker callback), so ``join`` only waits for completion.
+    """
+
     def __init__(self, **kwargs: Any) -> None: ...
 
     def run(

--- a/packages/climate-ref/src/climate_ref/cli/solve.py
+++ b/packages/climate-ref/src/climate_ref/cli/solve.py
@@ -20,7 +20,8 @@ def solve(  # noqa: PLR0913
     ] = True,
     timeout: int = typer.Option(
         6 * 60 * 60,
-        help="Timeout in seconds for waiting on executions to complete. Defaults to 6 hours.",
+        help="Timeout in seconds for waiting on executions to complete. Defaults to 6 hours. "
+        "Set to 0 (or a negative value) to wait with no time limit. Ignored when --no-wait is used.",
     ),
     wait: Annotated[
         bool,
@@ -106,7 +107,8 @@ def solve(  # noqa: PLR0913
         db=db,
         dry_run=dry_run,
         execute=execute,
-        timeout=timeout if wait else 0,
+        wait=wait,
+        timeout=timeout,
         one_per_provider=one_per_provider,
         one_per_diagnostic=one_per_diagnostic,
         filters=filters,

--- a/packages/climate-ref/src/climate_ref/executor/hpc.py
+++ b/packages/climate-ref/src/climate_ref/executor/hpc.py
@@ -195,6 +195,10 @@ class HPCExecutor:
 
     name = "hpc"
 
+    # Results are copied to the results directory and ingested only during ``join``,
+    # so skipping ``join`` (queue-and-exit) would orphan completed work in scratch.
+    collects_results_on_join = True
+
     def __init__(
         self,
         *,

--- a/packages/climate-ref/src/climate_ref/executor/local.py
+++ b/packages/climate-ref/src/climate_ref/executor/local.py
@@ -69,6 +69,10 @@ class LocalExecutor:
 
     name = "local"
 
+    # Results are copied to the results directory and ingested only during ``join``,
+    # so skipping ``join`` (queue-and-exit) would orphan completed work in scratch.
+    collects_results_on_join = True
+
     def __init__(
         self,
         *,
@@ -151,12 +155,13 @@ class LocalExecutor:
         Parameters
         ----------
         timeout
-            Overall wall-clock timeout in seconds for the whole join
+            Overall wall-clock timeout in seconds for the whole join.
+            A non-positive value (``<= 0``) waits indefinitely.
 
         Raises
         ------
         TimeoutError
-            If the overall timeout is reached
+            If a positive overall timeout is reached
         """
         start_time = time.time()
         refresh_time = 0.5  # Time to wait between checking for completed tasks in seconds
@@ -223,7 +228,8 @@ class LocalExecutor:
 
                 elapsed_time = time.time() - start_time
 
-                if elapsed_time > timeout:
+                # ``timeout <= 0`` means wait indefinitely (no overall deadline).
+                if timeout > 0 and elapsed_time > timeout:
                     self._fail_outstanding(results, t)
                     self.pool.shutdown(wait=False, cancel_futures=True)
                     raise TimeoutError("Not all tasks completed within the specified timeout")

--- a/packages/climate-ref/src/climate_ref/executor/synchronous.py
+++ b/packages/climate-ref/src/climate_ref/executor/synchronous.py
@@ -18,8 +18,7 @@ class SynchronousExecutor:
 
     name = "synchronous"
 
-    # Results are processed inline in ``run``; ``join`` is a no-op, so skipping it
-    # (queue-and-exit) does not lose any work.
+    # ``join`` is a no-op, so skipping it (queue-and-exit) does not lose any work.
     collects_results_on_join = False
 
     def __init__(

--- a/packages/climate-ref/src/climate_ref/executor/synchronous.py
+++ b/packages/climate-ref/src/climate_ref/executor/synchronous.py
@@ -18,6 +18,10 @@ class SynchronousExecutor:
 
     name = "synchronous"
 
+    # Results are processed inline in ``run``; ``join`` is a no-op, so skipping it
+    # (queue-and-exit) does not lose any work.
+    collects_results_on_join = False
+
     def __init__(
         self, *, database: Database | None = None, config: Config | None = None, **kwargs: Any
     ) -> None:

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -585,6 +585,7 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     solver: ExecutionSolver | None = None,
     config: Config | None = None,
     timeout: int = 60,
+    wait: bool = True,
     one_per_provider: bool = False,
     one_per_diagnostic: bool = False,
     filters: SolveFilterOptions | None = None,
@@ -597,10 +598,15 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     This may trigger a number of additional calculations depending on what data has been ingested
     since the last solve.
 
+    When ``wait`` is True (the default) this blocks until all executions complete, copying their
+    outputs to the results directory and ingesting them. ``timeout`` bounds that wait; a
+    non-positive ``timeout`` (``<= 0``) waits with no time limit. ``wait=False`` queues the
+    executions and returns immediately without collecting their results.
+
     Raises
     ------
     TimeoutError
-        If the execution isn't completed within the specified timeout
+        If the executions aren't completed within a positive ``timeout``
     """
     if config is None:
         config = Config.default()
@@ -616,6 +622,18 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     fail_stale_in_progress_executions(db)
 
     executor = config.executor.build(config, db)
+
+    # Some executors (e.g. the local process pool and HPC) only copy outputs to the
+    # results directory and ingest them during ``join``. Skipping that step with
+    # ``--no-wait`` would silently orphan completed work in the scratch directory.
+    if not wait and getattr(executor, "collects_results_on_join", False):
+        logger.warning(
+            f"--no-wait was requested with the {getattr(executor, 'name', 'configured')!r} executor, "
+            f"which only persists results while waiting (during join). Queued executions will run, "
+            f"but their outputs will be left in the scratch directory and never copied to the results "
+            f"directory or ingested into the database. Re-run without --no-wait, or recover existing "
+            f"scratch outputs with `ref executions reingest --include-failed`."
+        )
 
     diagnostic_count: dict[str, int] = {}
     provider_count: dict[str, int] = {}
@@ -767,6 +785,9 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     for prov, count in provider_count.items():
         logger.info(f"  {prov}: {count} new executions")
 
-    if timeout > 0:
+    if wait:
+        # ``timeout <= 0`` means "wait with no time limit"; the executors treat a
+        # non-positive timeout as unbounded. ``--no-wait`` (wait=False) is the
+        # explicit "queue and exit" path that skips result collection.
         executor.join(timeout=timeout)
         logger.info("All executions complete")

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -598,10 +598,10 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     This may trigger a number of additional calculations depending on what data has been ingested
     since the last solve.
 
-    When ``wait`` is True (the default) this blocks until all executions complete, copying their
-    outputs to the results directory and ingesting them. ``timeout`` bounds that wait; a
-    non-positive ``timeout`` (``<= 0``) waits with no time limit. ``wait=False`` queues the
-    executions and returns immediately without collecting their results.
+    When ``wait`` is True (the default) this blocks until all executions complete,
+    copying their outputs to the results directory and ingesting them.
+    ``timeout`` bounds that wait; a non-positive ``timeout`` (``<= 0``) waits with no time limit.
+    ``wait=False`` queues the executions and returns immediately without collecting their results.
 
     Raises
     ------
@@ -623,13 +623,11 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
 
     executor = config.executor.build(config, db)
 
-    # Some executors (e.g. the local process pool and HPC) only copy outputs to the
-    # results directory and ingest them during ``join``. Skipping that step with
-    # ``--no-wait`` would silently orphan completed work in the scratch directory.
     if not wait and getattr(executor, "collects_results_on_join", False):
         logger.warning(
             f"--no-wait was requested with the {getattr(executor, 'name', 'configured')!r} executor, "
-            f"which only persists results while waiting (during join). Queued executions will run, "
+            f"which only persists results while waiting (during join). "
+            f"Queued executions will run, "
             f"but their outputs will be left in the scratch directory and never copied to the results "
             f"directory or ingested into the database. Re-run without --no-wait, or recover existing "
             f"scratch outputs with `ref executions reingest --include-failed`."
@@ -786,8 +784,5 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
         logger.info(f"  {prov}: {count} new executions")
 
     if wait:
-        # ``timeout <= 0`` means "wait with no time limit"; the executors treat a
-        # non-positive timeout as unbounded. ``--no-wait`` (wait=False) is the
-        # explicit "queue and exit" path that skips result collection.
         executor.join(timeout=timeout)
         logger.info("All executions complete")

--- a/packages/climate-ref/tests/integration/test_executor_failure_modes.py
+++ b/packages/climate-ref/tests/integration/test_executor_failure_modes.py
@@ -197,13 +197,6 @@ class TestLocalExecutorFailureModes:
     def test_timeout_zero_waits_for_completion(
         self, db_with_provider, config, provider, definition_factory, mock_diagnostic, thread_pool
     ):
-        """Regression: ``join(timeout=0)`` waits indefinitely instead of failing immediately.
-
-        ``--timeout 0`` reaches the executor as ``timeout=0``. The future below is
-        still pending when ``join`` starts, so the old behaviour (treating any
-        elapsed time past ``0`` as a timeout) would have abandoned it on the first
-        iteration. The fix must instead wait until the result lands.
-        """
         # task_timeout=0 disables the per-task deadline so only the overall
         # (timeout=0) branch is under test.
         executor = _build_executor(db_with_provider, config, thread_pool, task_timeout=0)

--- a/packages/climate-ref/tests/integration/test_executor_failure_modes.py
+++ b/packages/climate-ref/tests/integration/test_executor_failure_modes.py
@@ -10,6 +10,7 @@ state for each failure mode.
 from __future__ import annotations
 
 import datetime
+import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
@@ -192,6 +193,48 @@ class TestLocalExecutorFailureModes:
             execution_group = db_with_provider.session.get(ExecutionGroup, eg_id)
         assert execution.successful is False
         assert execution_group.dirty is True
+
+    def test_timeout_zero_waits_for_completion(
+        self, db_with_provider, config, provider, definition_factory, mock_diagnostic, thread_pool
+    ):
+        """Regression: ``join(timeout=0)`` waits indefinitely instead of failing immediately.
+
+        ``--timeout 0`` reaches the executor as ``timeout=0``. The future below is
+        still pending when ``join`` starts, so the old behaviour (treating any
+        elapsed time past ``0`` as a timeout) would have abandoned it on the first
+        iteration. The fix must instead wait until the result lands.
+        """
+        # task_timeout=0 disables the per-task deadline so only the overall
+        # (timeout=0) branch is under test.
+        executor = _build_executor(db_with_provider, config, thread_pool, task_timeout=0)
+        definition = definition_factory(diagnostic=mock_diagnostic)
+        execution_id, eg_id, _ = _seed_execution(
+            db_with_provider, provider, "mock", config, key="timeout-zero-waits"
+        )
+
+        # A future that only resolves after join has started polling.
+        future: Future = Future()
+        timer = threading.Timer(
+            0.3,
+            future.set_result,
+            args=[ExecutionResult.build_from_failure(definition, retryable=False)],
+        )
+        _attach_future(executor, definition, execution_id, future)
+
+        timer.start()
+        try:
+            # Must NOT raise TimeoutError despite timeout=0 and a slow result.
+            executor.join(timeout=0)
+        finally:
+            timer.cancel()
+
+        assert executor._results == []
+        with db_with_provider.session.begin():
+            execution = db_with_provider.session.get(Execution, execution_id)
+            execution_group = db_with_provider.session.get(ExecutionGroup, eg_id)
+        # The result was collected and processed (not abandoned).
+        assert execution.successful is False
+        assert execution_group.dirty is False
 
     def test_overall_join_timeout_fails_outstanding(
         self, db_with_provider, config, provider, definition_factory, mock_diagnostic, thread_pool

--- a/packages/climate-ref/tests/unit/cli/test_solve.py
+++ b/packages/climate-ref/tests/unit/cli/test_solve.py
@@ -27,8 +27,6 @@ class TestSolve:
         assert kwargs["timeout"] == 10
 
     def test_solve_with_zero_timeout_still_waits(self, sample_data_dir, db, invoke_cli, mocker):
-        # Regression: --timeout 0 must mean "wait with no time limit", not "queue and exit".
-        # It is no longer collapsed onto the --no-wait sentinel.
         mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
         invoke_cli(["solve", "--timeout", "0"])
 

--- a/packages/climate-ref/tests/unit/cli/test_solve.py
+++ b/packages/climate-ref/tests/unit/cli/test_solve.py
@@ -13,6 +13,7 @@ class TestSolve:
         _args, kwargs = mock_solve.call_args
 
         assert kwargs["timeout"] == 6 * 60 * 60
+        assert kwargs["wait"] is True
         assert not kwargs["dry_run"]
         assert kwargs["execute"]
         assert kwargs["filters"].diagnostic is None
@@ -24,6 +25,16 @@ class TestSolve:
 
         _args, kwargs = mock_solve.call_args
         assert kwargs["timeout"] == 10
+
+    def test_solve_with_zero_timeout_still_waits(self, sample_data_dir, db, invoke_cli, mocker):
+        # Regression: --timeout 0 must mean "wait with no time limit", not "queue and exit".
+        # It is no longer collapsed onto the --no-wait sentinel.
+        mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
+        invoke_cli(["solve", "--timeout", "0"])
+
+        _args, kwargs = mock_solve.call_args
+        assert kwargs["timeout"] == 0
+        assert kwargs["wait"] is True
 
     def test_solve_with_dryrun(self, sample_data_dir, db, invoke_cli, mocker):
         mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
@@ -122,5 +133,8 @@ class TestSolve:
         mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
         invoke_cli(["solve", "--no-wait", "--timeout", "30"])
 
+        # --no-wait is now passed through explicitly rather than being collapsed
+        # onto timeout=0, so --timeout keeps its literal value.
         _args, kwargs = mock_solve.call_args
-        assert kwargs["timeout"] == 0
+        assert kwargs["wait"] is False
+        assert kwargs["timeout"] == 30

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -656,6 +656,36 @@ def test_solve_metrics_default_solver(mocker, mock_metric_execution, mock_execut
     assert run_kwargs["execution"].id == execution_result.id
 
 
+def test_solve_waits_when_timeout_zero(mocker, mock_metric_execution, mock_executor, db_seeded):
+    """Regression: --timeout 0 (wait=True) must still join so results are collected.
+
+    Previously the solver only joined when ``timeout > 0``, so ``--timeout 0`` queued
+    work to the executor and exited without ever copying outputs to results.
+    """
+    mock_build_solver = mocker.patch.object(ExecutionSolver, "build_from_db")
+    solver = mock.MagicMock(spec=ExecutionSolver)
+    solver.solve.return_value = [mock_metric_execution]
+    mock_build_solver.return_value = solver
+
+    solve_required_executions(db_seeded, wait=True, timeout=0)
+
+    mock_executor.return_value.join.assert_called_once()
+    assert mock_executor.return_value.join.call_args.kwargs["timeout"] == 0
+
+
+def test_solve_skips_join_when_no_wait(mocker, mock_metric_execution, mock_executor, db_seeded):
+    """``wait=False`` queues executions and returns without joining (collecting results)."""
+    mock_build_solver = mocker.patch.object(ExecutionSolver, "build_from_db")
+    solver = mock.MagicMock(spec=ExecutionSolver)
+    solver.solve.return_value = [mock_metric_execution]
+    mock_build_solver.return_value = solver
+
+    solve_required_executions(db_seeded, wait=False, timeout=0)
+
+    mock_executor.return_value.run.assert_called_once()
+    mock_executor.return_value.join.assert_not_called()
+
+
 def test_two_executions_same_group_distinct_output_fragments(
     mocker, mock_metric_execution, mock_executor, db_seeded
 ):

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -657,11 +657,7 @@ def test_solve_metrics_default_solver(mocker, mock_metric_execution, mock_execut
 
 
 def test_solve_waits_when_timeout_zero(mocker, mock_metric_execution, mock_executor, db_seeded):
-    """Regression: --timeout 0 (wait=True) must still join so results are collected.
-
-    Previously the solver only joined when ``timeout > 0``, so ``--timeout 0`` queued
-    work to the executor and exited without ever copying outputs to results.
-    """
+    """--timeout 0 (wait=True) must still join so results are collected"""
     mock_build_solver = mocker.patch.object(ExecutionSolver, "build_from_db")
     solver = mock.MagicMock(spec=ExecutionSolver)
     solver.solve.return_value = [mock_metric_execution]


### PR DESCRIPTION
## Description

`ref solve --timeout 0` ran every diagnostic successfully into the scratch directory but copied **nothing** to the results directory and ingested nothing into the database.

### Root cause

The default `LocalExecutor` only *submits* work in `run()`; all result handling (copying scratch → results, DB ingestion, `mark_successful`) happens inside `join()`. The solver only called `join()` when `timeout > 0`:

```python
if timeout > 0:
    executor.join(timeout=timeout)
```

The CLI overloaded `timeout` as the "don't wait" sentinel (`timeout=timeout if wait else 0`), so `--no-wait` and `--timeout 0` were the same thing internally. Passing `--timeout 0` — which intuitively reads as "no time limit" — therefore skipped `join()` entirely, orphaning the completed work in scratch and leaving every `Execution` row stuck at `successful=None`.

### Fix

- Decouple *whether to wait* from *how long*: `solve_required_executions` now takes an explicit `wait` and joins whenever `wait` is True, regardless of the timeout value.
- A non-positive `timeout` (`<= 0`) now means **wait with no time limit** in `LocalExecutor.join` and `CeleryExecutor.join` (HPC already did this via walltime).
- The CLI passes `wait` and `timeout` through separately instead of collapsing `--no-wait` onto `timeout=0`.
- Warn when `--no-wait` is used with an executor that only persists results during `join` (local, HPC), since skipping the join silently orphans completed work. This is driven by a new `collects_results_on_join` marker on each executor (`True` for local/HPC; `False` for synchronous, which collects in `run()`, and Celery, which collects via the `handle_result` worker callback).

### Recovery for affected users

Existing scratch outputs from a previous `--timeout 0` run can be recovered without re-computing via `ref executions reingest --include-failed`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
