### PR TITLE
fix(reingest): rewrite embedded absolute paths when copying execution outputs

### DIFF
--- a/changelog/736.fix.md
+++ b/changelog/736.fix.md
@@ -1,0 +1,4 @@
+Fixed `ref executions reingest` failing for ESMValTool diagnostics.
+Reingest copies an execution's outputs to a new directory, but the absolute paths recorded in ESMValTool's provenance files still pointed at the original location,
+which caused an error that silently rolled back the reingest.
+These embedded paths are now re-pointed at the new output directory so the results are reingested as expected.

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -157,6 +157,48 @@ def _extract_dataset_attributes(dataset: "Dataset") -> dict[str, object]:
     return attrs
 
 
+# Text artifacts that may embed absolute output paths which ``shutil.copytree``
+# duplicates verbatim. ESMValTool records absolute output paths inside its
+# ``diagnostic_provenance.yml`` files (and within ``index.html`` and logs).
+_REWRITABLE_PATTERNS = ("*.json", "*.yml", "*.yaml", "*.txt", "*.html", "*.xml")
+
+
+def _rewrite_copied_paths(root: "Path", old_prefix: str, new_prefix: str) -> None:
+    """
+    Rewrite absolute paths embedded in copied text artifacts.
+
+    ``reingest`` duplicates an execution's scratch tree with ``shutil.copytree``,
+    which copies file *contents* verbatim. Providers that record absolute output
+    paths inside their artifacts -- notably ESMValTool's ``diagnostic_provenance.yml``
+    -- therefore still reference the original execution's directory after the copy.
+    ``build_execution_result`` then tries to express those paths relative to the new
+    output directory and raises ``ValueError`` because they are not in its subpath.
+
+    Rewriting ``old_prefix`` -> ``new_prefix`` across the copied text files re-points
+    the embedded paths at the new output directory so the result can be rebuilt.
+
+    Parameters
+    ----------
+    root
+        Directory tree to rewrite in place (the new scratch directory).
+    old_prefix
+        The original scratch directory path embedded in the copied artifacts.
+    new_prefix
+        The new scratch directory path to substitute.
+    """
+    if old_prefix == new_prefix:
+        return
+    for pattern in _REWRITABLE_PATTERNS:
+        for file in root.rglob(pattern):
+            try:
+                content = file.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                # Skip binary or unreadable files that happen to match the glob.
+                continue
+            if old_prefix in content:
+                file.write_text(content.replace(old_prefix, new_prefix), encoding="utf-8")
+
+
 def _validate_path_containment(path: "Path", base: "Path", label: str) -> None:
     """
     Check that *path* stays within *base* after resolving symlinks and ``..`` segments.
@@ -282,6 +324,11 @@ def reingest_execution(
                 new_scratch_dir = config.paths.scratch / new_fragment
                 new_scratch_dir.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(scratch_dir, new_scratch_dir)
+                # Re-point any absolute paths embedded in the copied artifacts
+                # (e.g. ESMValTool's diagnostic_provenance.yml) from the original
+                # scratch directory to the new one so build_execution_result can
+                # resolve them within the new output directory.
+                _rewrite_copied_paths(new_scratch_dir, str(scratch_dir), str(new_scratch_dir))
 
                 definition = reconstruct_execution_definition(
                     config, execution, diagnostic, output_fragment=new_fragment

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -34,6 +34,7 @@ from climate_ref_core.datasets import (
     SourceDatasetType,
 )
 from climate_ref_core.diagnostics import ExecutionDefinition
+from climate_ref_core.output_files import SANITISED_FILE_GLOBS, rewrite_tree
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -155,48 +156,6 @@ def _extract_dataset_attributes(dataset: "Dataset") -> dict[str, object]:
         if val is not None:
             attrs[col_name] = val
     return attrs
-
-
-# Text artifacts that may embed absolute output paths which ``shutil.copytree``
-# duplicates verbatim. ESMValTool records absolute output paths inside its
-# ``diagnostic_provenance.yml`` files (and within ``index.html`` and logs).
-_REWRITABLE_PATTERNS = ("*.json", "*.yml", "*.yaml", "*.txt", "*.html", "*.xml")
-
-
-def _rewrite_copied_paths(root: "Path", old_prefix: str, new_prefix: str) -> None:
-    """
-    Rewrite absolute paths embedded in copied text artifacts.
-
-    ``reingest`` duplicates an execution's scratch tree with ``shutil.copytree``,
-    which copies file *contents* verbatim. Providers that record absolute output
-    paths inside their artifacts -- notably ESMValTool's ``diagnostic_provenance.yml``
-    -- therefore still reference the original execution's directory after the copy.
-    ``build_execution_result`` then tries to express those paths relative to the new
-    output directory and raises ``ValueError`` because they are not in its subpath.
-
-    Rewriting ``old_prefix`` -> ``new_prefix`` across the copied text files re-points
-    the embedded paths at the new output directory so the result can be rebuilt.
-
-    Parameters
-    ----------
-    root
-        Directory tree to rewrite in place (the new scratch directory).
-    old_prefix
-        The original scratch directory path embedded in the copied artifacts.
-    new_prefix
-        The new scratch directory path to substitute.
-    """
-    if old_prefix == new_prefix:
-        return
-    for pattern in _REWRITABLE_PATTERNS:
-        for file in root.rglob(pattern):
-            try:
-                content = file.read_text(encoding="utf-8")
-            except (UnicodeDecodeError, OSError):
-                # Skip binary or unreadable files that happen to match the glob.
-                continue
-            if old_prefix in content:
-                file.write_text(content.replace(old_prefix, new_prefix), encoding="utf-8")
 
 
 def _validate_path_containment(path: "Path", base: "Path", label: str) -> None:
@@ -328,7 +287,11 @@ def reingest_execution(
                 # (e.g. ESMValTool's diagnostic_provenance.yml) from the original
                 # scratch directory to the new one so build_execution_result can
                 # resolve them within the new output directory.
-                _rewrite_copied_paths(new_scratch_dir, str(scratch_dir), str(new_scratch_dir))
+                rewrite_tree(
+                    new_scratch_dir,
+                    {str(scratch_dir): str(new_scratch_dir)},
+                    SANITISED_FILE_GLOBS,
+                )
 
                 definition = reconstruct_execution_definition(
                     config, execution, diagnostic, output_fragment=new_fragment

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -10,7 +10,6 @@ from climate_ref_pmp import provider as pmp_provider
 
 from climate_ref.executor.reingest import (
     _extract_dataset_attributes,
-    _rewrite_copied_paths,
     _validate_path_containment,
     get_executions_for_reingest,
     reconstruct_execution_definition,
@@ -199,50 +198,6 @@ class TestValidatePathContainment:
         escaping_path = base / ".." / "outside"
         with pytest.raises(ValueError, match="escapes"):
             _validate_path_containment(escaping_path, base, "test")
-
-
-class TestRewriteCopiedPaths:
-    def test_rewrites_old_prefix_in_text_files(self, tmp_path):
-        """Embedded absolute paths under the old prefix are re-pointed at the new prefix."""
-        old = "/scratch/frag/160"
-        new = "/scratch/frag/2217"
-        provenance = tmp_path / "executions" / "recipe" / "diagnostic_provenance.yml"
-        provenance.parent.mkdir(parents=True)
-        provenance.write_text(
-            yaml.safe_dump({f"{old}/plots/jointplot.png": {"caption": "c"}}), encoding="utf-8"
-        )
-
-        _rewrite_copied_paths(tmp_path, old, new)
-
-        content = provenance.read_text(encoding="utf-8")
-        assert old not in content
-        assert f"{new}/plots/jointplot.png" in content
-
-    def test_noop_when_prefixes_equal(self, tmp_path):
-        """No file is touched when the old and new prefixes are identical."""
-        original = '{"path": "/scratch/frag/160"}'
-        target = tmp_path / "output.json"
-        target.write_text(original, encoding="utf-8")
-
-        _rewrite_copied_paths(tmp_path, "/scratch/frag/160", "/scratch/frag/160")
-
-        assert target.read_text(encoding="utf-8") == original
-
-    def test_skips_binary_and_non_matching_files(self, tmp_path):
-        """Binary files matching a glob are skipped, and unrelated content is left intact."""
-        binary = tmp_path / "blob.json"
-        binary.write_bytes(b"\xff\xfe\x00\x01")
-        untouched = tmp_path / "notes.txt"
-        untouched.write_text("nothing to rewrite here", encoding="utf-8")
-        image = tmp_path / "jointplot.png"
-        image.write_bytes(b"\x89PNG/scratch/frag/160")
-
-        _rewrite_copied_paths(tmp_path, "/scratch/frag/160", "/scratch/frag/2217")
-
-        assert binary.read_bytes() == b"\xff\xfe\x00\x01"
-        assert untouched.read_text(encoding="utf-8") == "nothing to rewrite here"
-        # .png is not a rewritable pattern, so even a matching prefix is left alone.
-        assert image.read_bytes() == b"\x89PNG/scratch/frag/160"
 
 
 class TestExtractDatasetAttributes:

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -4,11 +4,13 @@ import json
 import pathlib
 
 import pytest
+import yaml
 from climate_ref_esmvaltool import provider as esmvaltool_provider
 from climate_ref_pmp import provider as pmp_provider
 
 from climate_ref.executor.reingest import (
     _extract_dataset_attributes,
+    _rewrite_copied_paths,
     _validate_path_containment,
     get_executions_for_reingest,
     reconstruct_execution_definition,
@@ -197,6 +199,50 @@ class TestValidatePathContainment:
         escaping_path = base / ".." / "outside"
         with pytest.raises(ValueError, match="escapes"):
             _validate_path_containment(escaping_path, base, "test")
+
+
+class TestRewriteCopiedPaths:
+    def test_rewrites_old_prefix_in_text_files(self, tmp_path):
+        """Embedded absolute paths under the old prefix are re-pointed at the new prefix."""
+        old = "/scratch/frag/160"
+        new = "/scratch/frag/2217"
+        provenance = tmp_path / "executions" / "recipe" / "diagnostic_provenance.yml"
+        provenance.parent.mkdir(parents=True)
+        provenance.write_text(
+            yaml.safe_dump({f"{old}/plots/jointplot.png": {"caption": "c"}}), encoding="utf-8"
+        )
+
+        _rewrite_copied_paths(tmp_path, old, new)
+
+        content = provenance.read_text(encoding="utf-8")
+        assert old not in content
+        assert f"{new}/plots/jointplot.png" in content
+
+    def test_noop_when_prefixes_equal(self, tmp_path):
+        """No file is touched when the old and new prefixes are identical."""
+        original = '{"path": "/scratch/frag/160"}'
+        target = tmp_path / "output.json"
+        target.write_text(original, encoding="utf-8")
+
+        _rewrite_copied_paths(tmp_path, "/scratch/frag/160", "/scratch/frag/160")
+
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_skips_binary_and_non_matching_files(self, tmp_path):
+        """Binary files matching a glob are skipped, and unrelated content is left intact."""
+        binary = tmp_path / "blob.json"
+        binary.write_bytes(b"\xff\xfe\x00\x01")
+        untouched = tmp_path / "notes.txt"
+        untouched.write_text("nothing to rewrite here", encoding="utf-8")
+        image = tmp_path / "jointplot.png"
+        image.write_bytes(b"\x89PNG/scratch/frag/160")
+
+        _rewrite_copied_paths(tmp_path, "/scratch/frag/160", "/scratch/frag/2217")
+
+        assert binary.read_bytes() == b"\xff\xfe\x00\x01"
+        assert untouched.read_text(encoding="utf-8") == "nothing to rewrite here"
+        # .png is not a rewritable pattern, so even a matching prefix is left alone.
+        assert image.read_bytes() == b"\x89PNG/scratch/frag/160"
 
 
 class TestExtractDatasetAttributes:
@@ -429,6 +475,72 @@ class TestReingestExecution:
             definition.output_directory
         ).startswith(str(config.paths.scratch))
         assert definition.output_directory.exists()
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_reingest_rewrites_embedded_absolute_paths(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mock_result_factory,
+        mocker,
+    ):
+        """Absolute paths embedded in copied artifacts are re-pointed at the new scratch dir.
+
+        Regression test for the reingest crash: ESMValTool records absolute output
+        paths in ``diagnostic_provenance.yml``. ``shutil.copytree`` copies these
+        verbatim, so before the fix they still referenced the original execution's
+        directory and ``build_execution_result`` raised
+        ``ValueError: ... is not in the subpath of ...``.
+        """
+        original_scratch = scratch_dir_with_results
+        provenance = (
+            original_scratch
+            / "executions"
+            / "recipe_20260617_122233"
+            / "run"
+            / "diag"
+            / "script1"
+            / "diagnostic_provenance.yml"
+        )
+        provenance.parent.mkdir(parents=True)
+        embedded_plot = original_scratch / "executions" / "recipe_20260617_122233" / "plots" / "jointplot.png"
+        provenance.write_text(yaml.safe_dump({str(embedded_plot): {"caption": "c"}}), encoding="utf-8")
+
+        mock_result = mock_result_factory(original_scratch)
+        spy = mocker.patch.object(
+            mock_provider_registry.get_metric("mock_provider", "mock"),
+            "build_execution_result",
+            return_value=mock_result,
+        )
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        reingest_db.session.commit()
+        assert ok is True
+
+        new_scratch = spy.call_args[0][0].output_directory
+        assert new_scratch != original_scratch
+        copied_provenance = (
+            new_scratch
+            / "executions"
+            / "recipe_20260617_122233"
+            / "run"
+            / "diag"
+            / "script1"
+            / "diagnostic_provenance.yml"
+        )
+        content = copied_provenance.read_text(encoding="utf-8")
+        # The original fragment's absolute path must be gone, replaced by the new one.
+        assert str(original_scratch) not in content
+        expected = new_scratch / "executions" / "recipe_20260617_122233" / "plots" / "jointplot.png"
+        assert str(expected) in content
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
     def test_creates_new_execution(


### PR DESCRIPTION
## Description

`ref executions reingest` failed for every ESMValTool diagnostic.

Reingest creates a new execution and copies the original execution's scratch tree to the new fragment with `shutil.copytree`, then re-runs `build_execution_result` against it. ESMValTool records **absolute** output paths in its `diagnostic_provenance.yml` files, and `copytree` duplicates those contents verbatim — so the copied provenance still pointed at the *original* execution's directory (`.../<old_id>/executions/...`). `build_execution_result` then tried to express those paths relative to the new output directory (`.../<new_id>`) and raised:

```
ValueError: '.../<old_id>/executions/.../jointplot.png' is not in the subpath of '.../<new_id>' OR one path is relative and the other is absolute.
```

The exception propagated to reingest's catch-all, which logged "Ingestion failed … Rolling back changes" and discarded the copy — so ESMValTool executions silently never reingested.

PMP/ILAMB were unaffected because they build their output lists by globbing the live output directory (always in-tree), whereas ESMValTool is the only provider that reads paths from a recorded artifact.

### Fix

After `copytree`, rewrite the copied text artifacts to use the new scratch dir. Binary artefacts are never touched and unchanged files are left alone.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`