### PR TITLE
ci(regression): speed up the PR gate by dropping the unused input fetch

### DIFF
--- a/.github/workflows/regression-pr-gate.yaml
+++ b/.github/workflows/regression-pr-gate.yaml
@@ -40,8 +40,6 @@ jobs:
         with:
           python-version: "3.13"
       - name: Decide and verify baselines
-        # The gate fetches sample data only when a case actually needs replaying,
-        # so a PR that touches no baselines completes without any downloads.
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: bash scripts/ci/regression-pr-gate.sh

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ test-diagnostics: test-diagnostic-example test-diagnostic-esmvaltool test-diagno
 .PHONY: test-executors
 test-executors: test-celery
 
+.PHONY: regression-gate
+regression-gate:  ## run the regression baseline coupling gate + replay (compares against origin/main)
+	bash scripts/ci/regression-pr-gate.sh
+
 .PHONY: test
 test: clean test-core test-ref test-executors test-diagnostics test-integration ## run the tests
 	uv run coverage report

--- a/changelog/742.trivial.md
+++ b/changelog/742.trivial.md
@@ -1,0 +1,1 @@
+Sped up the per-pull-request regression baseline gate by no longer downloading the input data that replay never reads, and made the gate runnable locally via `make regression-gate`.

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -182,6 +182,25 @@ branch and acts on each decision:
 The job runs on the public `ubuntu-latest` runner with no secrets, so it is safe on fork pull requests.
 The decision-to-replay fan-out lives in `scripts/ci/regression-pr-gate.sh`.
 
+Neither stage downloads input datasets:
+`ci-gate` reads only manifests and the git diff,
+and `replay` rebuilds the committed bundle from the public native blobs plus the committed `catalog.yaml`/`manifest.json`
+(`build_execution_result` reads only its output directory).
+The gate therefore fetches no sample data or ESGF inputs — only the small native blobs for the cases it actually replays.
+
+#### Running the gate locally
+
+The same script is the local entry point, so you can reproduce a pull request's verdict before pushing:
+
+```bash
+make regression-gate                          # gate + replay against origin/main
+bash scripts/ci/regression-pr-gate.sh main    # or pass any base ref
+```
+
+The base ref defaults to `origin/${GITHUB_BASE_REF:-main}`.
+Under GitHub Actions the script emits log groups and `::error::`/`::warning::` annotations;
+run locally it prints plain output instead.
+
 ### Gated mint (`regression-mint.yaml`)
 
 Minting is the only step that writes to the object store,

--- a/docs/how-to-guides/testing-diagnostics.md
+++ b/docs/how-to-guides/testing-diagnostics.md
@@ -460,6 +460,9 @@ flowchart TD
 
 Bump `test_case_version` whenever you *intend* to change a baseline — it tells reviewers and CI the new output is correct.
 
+!!! tip "Check the gate locally before pushing"
+    Run the same gate your pull request will hit with `make regression-gate` (it compares against `origin/main`).
+
 #### Publishing a native baseline
 
 Native files are written to the object store only by `ref test-case mint`, which needs write credentials.

--- a/scripts/ci/regression-pr-gate.sh
+++ b/scripts/ci/regression-pr-gate.sh
@@ -2,26 +2,46 @@
 # PR-tier regression baseline gate.
 #
 # Runs the coupling gate (`ref test-cases ci-gate`) against the pull request's base branch and,
-# for every case it routes to `replay`, re-checks the cached native baseline.
+# for every case it routes to `replay`, re-checks the committed native baseline.
 #
-# All baseline data can be fetched with public read access so this does not require credentials.
+# Neither stage needs input data.
+# `replay` rebuilds the committed bundle from native output blobs pulled from the public
+# store (plus the committed catalog/manifest).
 #
-# `ci-gate` reads only manifests and the git diff, so it needs no input data.
-# The (slower) sample-data and catalog fetch is therefore deferred until the gate has found at least one case that actually needs replaying.
-# The common pull request touches no baselines and skips the download entirely.
+# Usage:
+#   make regression-gate                          # the convenient local entry point
+#   bash scripts/ci/regression-pr-gate.sh [base]  # or call directly, optionally overriding the base ref
 #
-# Environment:
+#   base             ref to diff against. Defaults to origin/${GITHUB_BASE_REF:-main}.
 #   GITHUB_BASE_REF  the PR's base branch (set automatically on pull_request events).
+#
+# Running under GitHub Actions emits log groups and ::error::/::warning:: annotations;
+# locally it prints plain, readable output instead.
+# Run it before pushing to catch a coupling violation or replay drift without waiting for CI.
 set -euo pipefail
 
-# Rich colour codes would corrupt the JSON we parse with jq. Force them off here so the
-# script is self-contained and parseable even when run outside the workflow (which also
-# sets NO_COLOR for the same reason).
+# Rich colour codes would corrupt the JSON we parse with jq
 export NO_COLOR=1
 
-base="origin/${GITHUB_BASE_REF:-main}"
+# GitHub Actions log-grouping and annotation commands are just noise on a local terminal,
+# so emit them only under Actions and print readable equivalents otherwise.
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  begin_group() { echo "::group::$*"; }
+  end_group() { echo "::endgroup::"; }
+  error() { echo "::error::$*"; }
+  warning() { echo "::warning::$*"; }
+else
+  begin_group() { printf '\n==> %s\n' "$*"; }
+  end_group() { :; }
+  error() { printf 'ERROR: %s\n' "$*" >&2; }
+  warning() { printf 'WARNING: %s\n' "$*" >&2; }
+fi
 
-echo "::group::coupling gate (base: ${base})"
+# CI passes the base via GITHUB_BASE_REF (and fetches origin/<ref> beforehand); locally,
+# pass one as the first argument or rely on the origin/main default.
+base="${1:-origin/${GITHUB_BASE_REF:-main}}"
+
+begin_group "coupling gate (base: ${base})"
 # `ci-gate` exits non-zero when any case is gated `fail`; capture the decisions
 # regardless so the failing cases can be reported before the script exits.
 set +e
@@ -29,19 +49,19 @@ decisions="$(uv run ref test-cases ci-gate --base "${base}" --json)"
 gate_rc=$?
 set -e
 printf '%s\n' "${decisions}" | jq .
-echo "::endgroup::"
+end_group
 
 if [ "${gate_rc}" -ne 0 ]; then
-  # `ci-gate` exits non-zero for two distinct reasons: at least one case was gated
-  # `fail`, or a hard error (not a git repo, an unfetched base ref, a failed diff)
+  # `ci-gate` exits non-zero for two distinct reasons: at least one case was gated `fail`,
+  # or a hard error (not a git repo, an unfetched base ref, a failed diff)
   # that printed no decisions. Only the former is a baseline-coupling violation, so
   # report each kind accurately rather than blaming every failure on the author.
   fail_cases="$(printf '%s\n' "${decisions}" | jq -r '.[]? | select(.action == "fail") | "  FAIL " + .case + " -- " + .reason')"
   if [ -n "${fail_cases}" ]; then
-    echo "::error::Coupling gate failed -- a baseline changed without an authorised test_case_version bump."
+    error "Coupling gate failed -- a baseline changed without an authorised test_case_version bump."
     echo "${fail_cases}"
   else
-    echo "::error::ci-gate exited ${gate_rc} without a fail decision -- see the gate output above (e.g. an unfetched base ref or a non-git checkout)."
+    error "ci-gate exited ${gate_rc} without a fail decision -- see the gate output above (e.g. an unfetched base ref or a non-git checkout)."
   fi
   exit 1
 fi
@@ -49,7 +69,7 @@ fi
 
 while IFS= read -r execute_case; do
   [ -n "${execute_case}" ] || continue
-  echo "::warning::${execute_case} bumped test_case_version with no native baseline -- review the committed bundle, then mint on the trusted tier to enable replay verification."
+  warning "${execute_case} bumped test_case_version with no native baseline -- review the committed bundle, then mint on the trusted tier to enable replay verification."
 done < <(printf '%s\n' "${decisions}" | jq -r '.[] | select(.action == "execute") | .case')
 
 replay_cases="$(printf '%s\n' "${decisions}" | jq -r '.[] | select(.action == "replay") | .case')"
@@ -58,33 +78,23 @@ if [ -z "${replay_cases}" ]; then
   exit 0
 fi
 
-# Only now -- with replay work to do -- pay for the input data the replay needs.
-echo "::group::fetch inputs for replay"
-uv run ref datasets fetch-sample-data
-while IFS= read -r provider; do
-  [ -n "${provider}" ] || continue
-  uv run ref test-cases fetch --provider "${provider}" \
-    || echo "::warning::test-case fetch incomplete for ${provider}"
-done < <(printf '%s\n' "${replay_cases}" | cut -d/ -f1 | sort -u)
-echo "::endgroup::"
 
-# Replay every case the gate routed to REPLAY. Process substitution (rather than a
-# pipe) keeps the loop in the current shell so the failure counter survives.
+# Replay every case the gate routed to REPLAY.
 failures=0
 replayed=0
 while IFS='/' read -r provider diagnostic test_case; do
   [ -n "${provider}" ] || continue
-  echo "::group::replay ${provider}/${diagnostic}/${test_case}"
+  begin_group "replay ${provider}/${diagnostic}/${test_case}"
   if uv run ref test-cases replay \
       --provider "${provider}" \
       --diagnostic "${diagnostic}" \
       --test-case "${test_case}"; then
     replayed=$((replayed + 1))
   else
-    echo "::error::replay drift for ${provider}/${diagnostic}/${test_case}"
+    error "replay drift for ${provider}/${diagnostic}/${test_case}"
     failures=$((failures + 1))
   fi
-  echo "::endgroup::"
+  end_group
 done < <(printf '%s\n' "${replay_cases}")
 
 echo "Replayed ${replayed} case(s); ${failures} drifted."


### PR DESCRIPTION
## Description

The PR-tier regression baseline gate ([`regression-pr-gate.yaml`](.github/workflows/regression-pr-gate.yaml)) was taking tens of minutes per run (e.g. [this run](https://github.com/Climate-REF/climate-ref/actions/runs/27753475909)), almost entirely spent downloading data it never used.

For each case a pull request touches, the gate routes to `replay`, which rebuilds the committed CMEC bundle from the native output blobs plus the committed `catalog.yaml`/`manifest.json`. `build_execution_result` reads only its output directory — it never opens the input datasets. 

### Changes

- **Drop the input-data fetch from the gate.** [`scripts/ci/regression-pr-gate.sh`](scripts/ci/regression-pr-gate.sh) no longer runs `fetch-sample-data` or `test-cases fetch`.
- **Make the gate runnable locally.** The script now emits GitHub Actions log groups / `::error::` / `::warning::` annotations only under Actions, prints plain output otherwise, and accepts an optional base ref (default `origin/${GITHUB_BASE_REF:-main}`). A new `make regression-gate` target is the convenient entry point, so a contributor can reproduce a PR's verdict before pushing.
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`