### PR TITLE
feat(db): normalise series index into shared index_axis table

### DIFF
--- a/changelog/747.improvement.md
+++ b/changelog/747.improvement.md
@@ -1,0 +1,2 @@
+Reduced database size by deduplicating the index of series metric values into a shared `index_axis` table, referenced by each series rather than stored inline on every row.
+A database migration backfills existing data losslessly; on SQLite, run `VACUUM` afterwards to release the freed space on disk.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,12 @@
+codecov:
+  notify:
+    # Wait for every coverage report before posting any status, so the
+    # project/patch checks are not transiently marked failed while jobs
+    # are still uploading partial coverage.
+    # Count = tests-core (1) + tests-integration (1) + tests-providers (4).
+    # Bump this if the set of coverage-uploading jobs changes.
+    after_n_builds: 6
+    wait_for_ci: true
 coverage:
   status:
     project:
@@ -8,3 +17,5 @@ coverage:
       default:
         target: auto
         threshold: 5%
+comment:
+  after_n_builds: 6

--- a/packages/climate-ref/src/climate_ref/executor/result_handling.py
+++ b/packages/climate-ref/src/climate_ref/executor/result_handling.py
@@ -18,7 +18,7 @@ from loguru import logger
 from sqlalchemy import insert
 
 from climate_ref.database import Database
-from climate_ref.models import ScalarMetricValue, SeriesMetricValue
+from climate_ref.models import ScalarMetricValue, SeriesIndex, SeriesMetricValue
 from climate_ref.models.execution import Execution, ExecutionOutput, ResultOutputType
 from climate_ref_core.diagnostics import ExecutionDefinition, ExecutionResult, ensure_relative_path
 from climate_ref_core.exceptions import ResultValidationError
@@ -177,15 +177,25 @@ def ingest_series_values(
             "Diagnostic series values do not conform with the controlled vocabulary", exc_info=True
         )
 
+    # Resolve (deduplicate) the shared index axes for this batch first,
+    # so each distinct index is stored once in ``index_axis`` and referenced by id rather
+    # than duplicated on every series row.
+    axis_id_by_hash: dict[str, int] = {}
+    for series_result in series_values:
+        digest = SeriesIndex.compute_hash(series_result.index_name, series_result.index)
+        if digest not in axis_id_by_hash:
+            axis = SeriesIndex.get_or_create(database.session, series_result.index_name, series_result.index)
+            axis_id_by_hash[digest] = axis.id
+
     new_values = []
     for series_result in series_values:
+        digest = SeriesIndex.compute_hash(series_result.index_name, series_result.index)
         new_values.append(
             {
                 "execution_id": execution.id,
                 "values": series_result.values,
                 "attributes": series_result.attributes,
-                "index": series_result.index,
-                "index_name": series_result.index_name,
+                "index_id": axis_id_by_hash[digest],
                 **series_result.dimensions,
             }
         )

--- a/packages/climate-ref/src/climate_ref/migrations/versions/2026-06-19T0000_d4e5f6a7b8c9_normalise_series_index.py
+++ b/packages/climate-ref/src/climate_ref/migrations/versions/2026-06-19T0000_d4e5f6a7b8c9_normalise_series_index.py
@@ -21,6 +21,12 @@ from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.sql import quoted_name
+
+# ``index`` is not in SQLAlchemy's dialect reserved-word tables, so identifiers are
+# emitted unquoted by default. PostgreSQL then rejects ``... COLUMN index``; forcing the
+# quote keeps the DDL valid on both PostgreSQL and SQLite.
+_INDEX_COL = quoted_name("index", quote=True)
 
 revision: str = "d4e5f6a7b8c9"
 down_revision: str | None = "b1c2d3e4f5a6"
@@ -102,14 +108,14 @@ def upgrade() -> None:
     _backfill()
 
     with op.batch_alter_table("metric_value", schema=None) as batch_op:
-        batch_op.drop_column("index")
+        batch_op.drop_column(_INDEX_COL)
         batch_op.drop_column("index_name")
 
 
 def downgrade() -> None:
     # Best-effort: recreate the inline columns and copy the axis content back.
     with op.batch_alter_table("metric_value", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("index", sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column(_INDEX_COL, sa.JSON(), nullable=True))
         batch_op.add_column(sa.Column("index_name", sa.String(), nullable=True))
 
     op.get_bind().execute(

--- a/packages/climate-ref/src/climate_ref/migrations/versions/2026-06-19T0000_d4e5f6a7b8c9_normalise_series_index.py
+++ b/packages/climate-ref/src/climate_ref/migrations/versions/2026-06-19T0000_d4e5f6a7b8c9_normalise_series_index.py
@@ -1,0 +1,130 @@
+"""normalise series index into a shared index_axis table
+
+Series metric values previously stored their full index array (and index name)
+inline on every row.
+
+In practice a small number of axes are shared by tens of thousands of series (e.g. one monthly time axis),
+so the index dominated the database (~40% of a 922MB production database, ~100% redundant).
+
+This migration moves the index into a deduplicated ``index_axis`` table keyed by
+a content hash, and replaces ``metric_value.index`` / ``index_name`` with an
+``index_id`` foreign key. It is lossless.
+
+Revision ID: d4e5f6a7b8c9
+Revises: b1c2d3e4f5a6
+Create Date: 2026-06-19
+"""
+
+import hashlib
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: str | None = "b1c2d3e4f5a6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Number of rows updated per executemany batch during the backfill.
+_BATCH_SIZE = 5000
+
+
+def _hash(name, values) -> str:
+    # Must match SeriesIndex.compute_hash in the model layer.
+    payload = json.dumps([name, list(values)], separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _as_list(idx):
+    # Raw SELECT of a JSON column returns text on SQLite and a parsed object on
+    # PostgreSQL; normalise to a Python list either way.
+    if idx is None:
+        return None
+    return idx if isinstance(idx, (list, dict)) else json.loads(idx)
+
+
+def _backfill() -> None:
+    bind = op.get_bind()
+    index_axis = sa.Table("index_axis", sa.MetaData(), autoload_with=bind)
+
+    # Single streaming pass over the series rows: dedupe axes and record each
+    # row's hash. Only the (few) distinct axes are held in memory, not every row.
+    result = bind.execution_options(stream_results=True).execute(
+        sa.text('SELECT id, index_name, "index" FROM metric_value WHERE type = :t AND "index" IS NOT NULL'),
+        {"t": "SERIES"},
+    )
+    axis_payload: dict[str, dict] = {}  # hash -> row to insert
+    row_hashes: list[tuple[int, str]] = []  # (metric_value.id, hash)
+    for mv_id, name, idx in result:
+        values = _as_list(idx)
+        digest = _hash(name, values)
+        row_hashes.append((mv_id, digest))
+        if digest not in axis_payload:
+            axis_payload[digest] = {"hash": digest, "name": name, "values": values, "length": len(values)}
+
+    if axis_payload:
+        bind.execute(index_axis.insert(), list(axis_payload.values()))
+
+    hash_to_id = {h: i for i, h in bind.execute(sa.text("SELECT id, hash FROM index_axis"))}
+
+    upd = sa.text("UPDATE metric_value SET index_id = :aid WHERE id = :mid")
+    batch: list[dict] = []
+    for mv_id, digest in row_hashes:
+        batch.append({"aid": hash_to_id[digest], "mid": mv_id})
+        if len(batch) >= _BATCH_SIZE:
+            bind.execute(upd, batch)
+            batch = []
+    if batch:
+        bind.execute(upd, batch)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "index_axis",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("hash", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("values", sa.JSON(), nullable=False),
+        sa.Column("length", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_index_axis")),
+    )
+    op.create_index(op.f("ix_index_axis_hash"), "index_axis", ["hash"], unique=True)
+
+    with op.batch_alter_table("metric_value", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("index_id", sa.Integer(), nullable=True))
+        batch_op.create_index(batch_op.f("ix_metric_value_index_id"), ["index_id"], unique=False)
+        batch_op.create_foreign_key(
+            batch_op.f("fk_metric_value_index_id_index_axis"), "index_axis", ["index_id"], ["id"]
+        )
+
+    _backfill()
+
+    with op.batch_alter_table("metric_value", schema=None) as batch_op:
+        batch_op.drop_column("index")
+        batch_op.drop_column("index_name")
+
+
+def downgrade() -> None:
+    # Best-effort: recreate the inline columns and copy the axis content back.
+    with op.batch_alter_table("metric_value", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("index", sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("index_name", sa.String(), nullable=True))
+
+    op.get_bind().execute(
+        sa.text(
+            "UPDATE metric_value SET "
+            '"index" = (SELECT a."values" FROM index_axis a WHERE a.id = metric_value.index_id), '
+            "index_name = (SELECT a.name FROM index_axis a WHERE a.id = metric_value.index_id) "
+            "WHERE index_id IS NOT NULL"
+        )
+    )
+
+    with op.batch_alter_table("metric_value", schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f("fk_metric_value_index_id_index_axis"), type_="foreignkey")
+        batch_op.drop_index(batch_op.f("ix_metric_value_index_id"))
+        batch_op.drop_column("index_id")
+
+    op.drop_index(op.f("ix_index_axis_hash"), table_name="index_axis")
+    op.drop_table("index_axis")

--- a/packages/climate-ref/src/climate_ref/migrations/versions/2026-06-19T0000_d4e5f6a7b8c9_normalise_series_index.py
+++ b/packages/climate-ref/src/climate_ref/migrations/versions/2026-06-19T0000_d4e5f6a7b8c9_normalise_series_index.py
@@ -57,10 +57,14 @@ def _backfill() -> None:
 
     # Single streaming pass over the series rows: dedupe axes and record each
     # row's hash. Only the (few) distinct axes are held in memory, not every row.
-    result = bind.execution_options(stream_results=True).execute(
-        sa.text('SELECT id, index_name, "index" FROM metric_value WHERE type = :t AND "index" IS NOT NULL'),
-        {"t": "SERIES"},
-    )
+    # ``stream_results`` is scoped to *this statement* rather than set on the shared
+    # migration connection: a connection-level option is sticky and would make
+    # PostgreSQL wrap the later DDL in a server-side cursor (DECLARE ... CURSOR FOR
+    # ALTER TABLE ...), which is a syntax error.
+    select_series = sa.text(
+        'SELECT id, index_name, "index" FROM metric_value WHERE type = :t AND "index" IS NOT NULL'
+    ).execution_options(stream_results=True)
+    result = bind.execute(select_series, {"t": "SERIES"})
     axis_payload: dict[str, dict] = {}  # hash -> row to insert
     row_hashes: list[tuple[int, str]] = []  # (metric_value.id, hash)
     for mv_id, name, idx in result:

--- a/packages/climate-ref/src/climate_ref/models/__init__.py
+++ b/packages/climate-ref/src/climate_ref/models/__init__.py
@@ -12,7 +12,12 @@ from climate_ref.models.execution import (
     ExecutionGroup,
     ExecutionOutput,
 )
-from climate_ref.models.metric_value import MetricValue, ScalarMetricValue, SeriesMetricValue
+from climate_ref.models.metric_value import (
+    MetricValue,
+    ScalarMetricValue,
+    SeriesIndex,
+    SeriesMetricValue,
+)
 from climate_ref.models.provider import Provider
 
 __all__ = [
@@ -25,6 +30,7 @@ __all__ = [
     "MetricValue",
     "Provider",
     "ScalarMetricValue",
+    "SeriesIndex",
     "SeriesMetricValue",
     "Table",
 ]

--- a/packages/climate-ref/src/climate_ref/models/metric_value.py
+++ b/packages/climate-ref/src/climate_ref/models/metric_value.py
@@ -1,9 +1,11 @@
 import enum
-from collections.abc import Mapping
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from sqlalchemy import ForeignKey, event
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import ForeignKey, event, select
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from climate_ref.models.base import Base
 from climate_ref.models.mixins import CreatedUpdatedMixin, DimensionMixin
@@ -138,6 +140,80 @@ class ScalarMetricValue(MetricValue):
         )
 
 
+class SeriesIndex(Base):
+    """
+    A shared 1-d index axis for series metric values
+
+    Many series share the same index (for example a common monthly time axis),
+    so the index is stored once here and referenced by
+    [SeriesMetricValue.index_id][climate_ref.models.metric_value.SeriesMetricValue]
+    rather than duplicated on every row. Axes are deduplicated by ``hash``.
+    """
+
+    __tablename__ = "index_axis"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    hash: Mapped[str] = mapped_column(unique=True, index=True)
+    """
+    Content hash of ``(name, values)``.
+
+    The axes are deduplicated by this hash, so identical axes will share the same row and be referenced by id.
+    """
+
+    name: Mapped[str] = mapped_column(nullable=True)
+    """Name of the index (e.g. ``"time"``). Used for presentation."""
+
+    values: Mapped[list[float | int | str]] = mapped_column()
+    """The 1-d array of index values."""
+
+    length: Mapped[int] = mapped_column()
+    """Number of points in the index; used to validate series lengths."""
+
+    def __repr__(self) -> str:
+        return f"<SeriesIndex id={self.id} name={self.name} length={self.length}>"
+
+    @staticmethod
+    def compute_hash(name: str | None, values: Sequence[float | int | str]) -> str:
+        """
+        Compute the content hash used to deduplicate identical axes.
+
+        The hash covers both the name and the ordered values,
+        so two axes are only shared when they are genuinely identical.
+        """
+        payload = json.dumps([name, list(values)], separators=(",", ":"), ensure_ascii=False)
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    @classmethod
+    def get_or_create(
+        cls, session: Session, name: str | None, values: Sequence[float | int | str]
+    ) -> "SeriesIndex":
+        """
+        Return the existing axis with this content, or create and flush a new one.
+
+        Parameters
+        ----------
+        session
+            Active database session.
+        name
+            Name of the index.
+        values
+            1-d array of index values.
+
+        Returns
+        -------
+            The shared [SeriesIndex][climate_ref.models.metric_value.SeriesIndex] row.
+        """
+        digest = cls.compute_hash(name, values)
+        existing = session.execute(select(cls).where(cls.hash == digest)).scalar_one_or_none()
+        if existing is not None:
+            return existing
+        axis = cls(hash=digest, name=name, values=list(values), length=len(values))
+        session.add(axis)
+        session.flush()
+        return axis
+
+
 class SeriesMetricValue(MetricValue):
     """
     A 1d series with associated dimensions
@@ -150,10 +226,20 @@ class SeriesMetricValue(MetricValue):
         "polymorphic_identity": MetricValueType.SERIES,
     }
 
-    # This is a scalar value
     values: Mapped[list[float | int]] = mapped_column(nullable=True)
-    index: Mapped[list[float | int | str]] = mapped_column(nullable=True)
-    index_name: Mapped[str] = mapped_column(nullable=True)
+
+    index_id: Mapped[int | None] = mapped_column(ForeignKey("index_axis.id"), nullable=True, index=True)
+    index_axis: Mapped["SeriesIndex | None"] = relationship(lazy="joined")
+
+    @property
+    def index(self) -> list[float | int | str] | None:
+        """The 1-d index values, resolved from the shared axis."""
+        return self.index_axis.values if self.index_axis is not None else None
+
+    @property
+    def index_name(self) -> str | None:
+        """The name of the index, resolved from the shared axis."""
+        return self.index_axis.name if self.index_axis is not None else None
 
     def __repr__(self) -> str:
         return (
@@ -162,13 +248,12 @@ class SeriesMetricValue(MetricValue):
         )
 
     @classmethod
-    def build(  # noqa: PLR0913
+    def build(
         cls,
         *,
         execution_id: int,
         values: list[float | int],
-        index: list[float | int | str],
-        index_name: str,
+        index_axis: "SeriesIndex",
         dimensions: dict[str, str],
         attributes: dict[str, Any] | None,
     ) -> "MetricValue":
@@ -181,10 +266,9 @@ class SeriesMetricValue(MetricValue):
             Execution that created the diagnostic value
         values
             1-d array of values
-        index
-            1-d array of index values
-        index_name
-            Name of the index. Used for presentation purposes
+        index_axis
+            The shared index axis for this series, obtained via
+            [SeriesIndex.get_or_create][climate_ref.models.metric_value.SeriesIndex.get_or_create]
         dimensions
             Dimensions that describe the diagnostic execution result
         attributes
@@ -208,14 +292,13 @@ class SeriesMetricValue(MetricValue):
             if k not in cls._cv_dimensions:
                 raise KeyError(f"Unknown dimension column '{k}'")
 
-        if len(values) != len(index):
-            raise ValueError(f"Index length ({len(index)}) must match values length ({len(values)})")
+        if len(values) != index_axis.length:
+            raise ValueError(f"Index length ({index_axis.length}) must match values length ({len(values)})")
 
         return SeriesMetricValue(
             execution_id=execution_id,
             values=values,
-            index=index,
-            index_name=index_name,
+            index_axis=index_axis,
             attributes=attributes,
             **dimensions,
         )
@@ -225,11 +308,10 @@ class SeriesMetricValue(MetricValue):
 @event.listens_for(SeriesMetricValue, "before_update")
 def validate_series_lengths(mapper: Any, connection: Any, target: SeriesMetricValue) -> None:
     """
-    Validate that values and index have matching lengths
+    Validate that values and the referenced index axis have matching lengths
 
     This is done on insert and update to ensure that the database is consistent.
     """
-    if target.values is not None and target.index is not None and len(target.values) != len(target.index):
-        raise ValueError(
-            f"Index length ({len(target.index)}) must match values length ({len(target.values)})"
-        )
+    axis = target.index_axis
+    if target.values is not None and axis is not None and len(target.values) != axis.length:
+        raise ValueError(f"Index length ({axis.length}) must match values length ({len(target.values)})")

--- a/packages/climate-ref/tests/unit/models/test_metric_value.py
+++ b/packages/climate-ref/tests/unit/models/test_metric_value.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from climate_ref.models import ScalarMetricValue, SeriesMetricValue
+from climate_ref.models import ScalarMetricValue, SeriesIndex, SeriesMetricValue
 
 
 class TestScalarMetricValue:
@@ -74,11 +74,11 @@ class TestScalarMetricValue:
 class TestSeriesMetricValue:
     def test_build_with_matching_lengths(self, db_seeded):
         """Test that building a SeriesMetricValue with matching lengths works"""
+        axis = SeriesIndex.get_or_create(db_seeded.session, "time", [0, 1, 2])
         item = SeriesMetricValue.build(
             execution_id=1,
             values=[1.0, 2.0, 3.0],
-            index=[0, 1, 2],
-            index_name="time",
+            index_axis=axis,
             dimensions={"source_id": "test"},
             attributes={"attr": "value"},
         )
@@ -94,23 +94,23 @@ class TestSeriesMetricValue:
 
     def test_build_with_mismatched_lengths(self, db_seeded):
         """Test that building a SeriesMetricValue with mismatched lengths raises an error"""
+        axis = SeriesIndex.get_or_create(db_seeded.session, "time", [0, 1])
         with pytest.raises(ValueError, match=re.escape(r"Index length (2) must match values length (3)")):
             SeriesMetricValue.build(
                 execution_id=1,
                 values=[1.0, 2.0, 3.0],
-                index=[0, 1],
-                index_name="time",
+                index_axis=axis,
                 dimensions={"source_id": "test"},
                 attributes=None,
             )
 
     def test_update_with_mismatched_lengths(self, db_seeded):
         """Test that updating a SeriesMetricValue with mismatched lengths raises an error"""
+        axis = SeriesIndex.get_or_create(db_seeded.session, "time", [0, 1])
         item = SeriesMetricValue.build(
             execution_id=1,
             values=[1.0, 2.0],
-            index=[0, 1],
-            index_name="time",
+            index_axis=axis,
             dimensions={"source_id": "test"},
             attributes=None,
         )


### PR DESCRIPTION
## Description

Series metric values previously stored their full index array (and index name) inline on every row. In production a handful of axes — for example a single common monthly time axis — are shared by tens of thousands of series, so the index column dominated the database: it accounted for ~40% of a 922MB production database and was almost entirely redundant.

This moves the index into a deduplicated `index_axis` table keyed by a content hash (`sha256` over `(name, values)`), and replaces `metric_value.index` / `metric_value.index_name` with an `index_id` foreign key. Ingestion (`ingest_series_values`) now resolves the distinct axes for a batch once via `SeriesIndex.get_or_create` and references them by id.

`SeriesMetricValue.index` and `SeriesMetricValue.index_name` remain available as read-only properties resolved from the shared axis (loaded eagerly via `lazy="joined"`), so existing readers — including the ref-app API and the series length validator — are unaffected. The on-disk `series.json` shape (the `climate_ref_core` Pydantic type) is unchanged.

The Alembic migration is lossless: it streams the series rows, deduplicates axes by content hash, backfills `index_id` in batches, then drops the old columns. Verified against a copy of the production database it reclaimed 388MB (42%, 924MB -> 536MB) with zero hash collisions and zero reconstruction mismatches across the sampled rows. Note that a `VACUUM` is required after applying the migration for SQLite to release the freed pages on disk.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Database Optimisation**
  * Series metric index axes are now deduplicated into a shared structure, with series records referencing the shared axis to reduce storage overhead and improve ingestion efficiency.
  * SQLite users should run `VACUUM` after the upgrade to reclaim freed disk space.

* **Chores**
  * Improved CI coverage notifications to wait for all coverage uploads before posting status checks and aligning related comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->