### PR TITLE
fix(reingest): report failure and roll back on failed result ingestion

### DIFF
--- a/changelog/749.fix.md
+++ b/changelog/749.fix.md
@@ -1,0 +1,1 @@
+Fixed `ref executions reingest` reporting a reingest as successful when the result failed to re-ingest; a failed re-ingestion is now rolled back (leaving no orphaned execution row or output directory) and reported as a failure instead.

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -54,6 +54,12 @@ class _ReingestSavepointAbort(Exception):
     """Internal sentinel used to roll back the savepoint on a soft-fail path."""
 
 
+def _remove_dir(path: "Path | None") -> None:
+    """Remove a directory if it exists, ignoring missing paths."""
+    if path is not None and path.exists():
+        shutil.rmtree(path)
+
+
 def reconstruct_execution_definition(
     config: "Config",
     execution: Execution,
@@ -247,6 +253,7 @@ def reingest_execution(
 
     new_fragment: str | None = None
     new_scratch_dir: Path | None = None
+    new_results_dir: Path | None = None
     new_execution: Execution | None = None
 
     try:
@@ -270,6 +277,7 @@ def reingest_execution(
                 )
 
                 new_scratch_dir = config.paths.scratch / new_fragment
+                new_results_dir = config.paths.results / new_fragment
                 new_scratch_dir.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(scratch_dir, new_scratch_dir)
                 # Re-point any absolute paths embedded in the copied artifacts
@@ -303,26 +311,39 @@ def reingest_execution(
                             dataset_id=dataset.id,
                         )
                     )
+
+                # Ingest within the SAME savepoint so that a failure rolls the
+                # new Execution row (and its dataset links) back together with
+                # the partial ingest, instead of leaving an orphan row that the
+                # caller's outer transaction would commit.
+                handle_execution_result(
+                    config,
+                    database,
+                    new_execution,
+                    result,
+                    update_dirty=False,
+                )
+
+                # handle_execution_result catches ingestion errors internally,
+                # marks the execution failed, and returns without raising. Treat
+                # a non-successful outcome as a failed reingest: abort the
+                # savepoint so the new row is rolled back.
+                if new_execution.successful is not True:
+                    logger.warning(
+                        f"Reingest of execution {execution.id} failed during result ingestion; "
+                        f"rolling back the new execution."
+                    )
+                    raise _ReingestSavepointAbort
+
         except _ReingestSavepointAbort:
-            if new_scratch_dir is not None and new_scratch_dir.exists():
-                shutil.rmtree(new_scratch_dir)
+            _remove_dir(new_scratch_dir)
+            _remove_dir(new_results_dir)
             return False
 
-        handle_execution_result(
-            config,
-            database,
-            new_execution,
-            result,
-            update_dirty=False,
-        )
     except Exception:
         logger.exception(f"Ingestion failed for execution {execution.id}. Rolling back changes.")
-        if new_scratch_dir is not None and new_scratch_dir.exists():
-            shutil.rmtree(new_scratch_dir)
-        if new_fragment is not None:
-            new_results_dir = config.paths.results / new_fragment
-            if new_results_dir.exists():
-                shutil.rmtree(new_results_dir)
+        _remove_dir(new_scratch_dir)
+        _remove_dir(new_results_dir)
         return False
 
     logger.info(f"Successfully reingested execution {execution.id} -> new execution {new_execution.id}")

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -312,10 +312,8 @@ def reingest_execution(
                         )
                     )
 
-                # Ingest within the SAME savepoint so that a failure rolls the
-                # new Execution row (and its dataset links) back together with
-                # the partial ingest, instead of leaving an orphan row that the
-                # caller's outer transaction would commit.
+                # Ingest within the SAME savepoint so that a failure rolls the new Execution row
+                # (and its dataset links) back together with the partial ingest.
                 handle_execution_result(
                     config,
                     database,
@@ -324,10 +322,8 @@ def reingest_execution(
                     update_dirty=False,
                 )
 
-                # handle_execution_result catches ingestion errors internally,
-                # marks the execution failed, and returns without raising. Treat
-                # a non-successful outcome as a failed reingest: abort the
-                # savepoint so the new row is rolled back.
+                # handle_execution_result catches ingestion errors internally
+                # Treat a non-successful outcome as a failed reingest.
                 if new_execution.successful is not True:
                     logger.warning(
                         f"Reingest of execution {execution.id} failed during result ingestion; "

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -833,9 +833,8 @@ class TestReingestExecution:
         assert new_count == original_count
 
         # Fragments are 4 levels deep: provider/diag/group_short/execution_id.
-        # _remove_dir removes the leaf (execution_id) dir; intermediate dirs may remain
-        # as empty parents — those are benign. Assert that no non-empty leaf dirs
-        # (at depth 4) exist in the results root beyond known execution fragments.
+        # _remove_dir removes the leaf (execution_id) dir, but may orphan empty parent dirs.
+        # Check that no non-empty leaf dirs exist in the results root beyond known execution fragments.
         existing_fragments = {ex.output_fragment for ex in reingest_db.session.query(Execution).all()}
         leaked_leaves = []
         if results_root.exists():
@@ -866,13 +865,8 @@ class TestReingestExecution:
         mock_result_factory,
         mocker,
     ):
-        """Regression: a soft-fail in handle_execution_result must not leave a committed
+        """A soft-fail in handle_execution_result must not leave a committed
         Execution row with successful=False (orphan) while reporting success to the caller.
-
-        Before the fix, handle_execution_result would mark the execution failed and return
-        normally; reingest_execution then fell through to the success log and returned True,
-        committing the failed row.  After the fix, the soft-fail aborts the savepoint and
-        returns False, leaving the DB count unchanged and the original execution intact.
         """
         original_execution_id = reingest_execution_obj.id
         original_count = reingest_db.session.query(Execution).count()

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -797,7 +797,7 @@ class TestReingestExecution:
         assert len(new_execution.datasets) == 0
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_ingestion_failure_still_creates_execution_and_results_dir(
+    def test_ingestion_failure_returns_false_and_rolls_back(
         self,
         config,
         reingest_db,
@@ -807,15 +807,16 @@ class TestReingestExecution:
         mock_result_factory,
         mocker,
     ):
-        """handle_execution_result swallows ingestion errors; reingest still creates new execution."""
+        """A soft-fail in handle_execution_result must return False and not commit a new Execution row."""
         original_count = reingest_db.session.query(Execution).count()
+        results_root = config.paths.results
 
         mock_result = mock_result_factory(
             scratch_dir_with_results, output_bundle_filename=None, series_filename=None
         )
         _patch_build_result(mocker, mock_provider_registry, mock_result)
 
-        # Corrupt the metric bundle
+        # Corrupt the metric bundle so handle_execution_result soft-fails
         (scratch_dir_with_results / "diagnostic.json").write_text("not valid json")
 
         ok = reingest_execution(
@@ -825,16 +826,84 @@ class TestReingestExecution:
             provider_registry=mock_provider_registry,
         )
         reingest_db.session.commit()
-        assert ok is True
+        assert ok is False
 
+        # No new Execution row should have been committed
         new_count = reingest_db.session.query(Execution).count()
-        assert new_count == original_count + 1
+        assert new_count == original_count
 
-        new_execution = (
-            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
+        # Fragments are 4 levels deep: provider/diag/group_short/execution_id.
+        # _remove_dir removes the leaf (execution_id) dir; intermediate dirs may remain
+        # as empty parents — those are benign. Assert that no non-empty leaf dirs
+        # (at depth 4) exist in the results root beyond known execution fragments.
+        existing_fragments = {ex.output_fragment for ex in reingest_db.session.query(Execution).all()}
+        leaked_leaves = []
+        if results_root.exists():
+            for p1 in results_root.iterdir():
+                if not p1.is_dir():
+                    continue
+                for p2 in p1.iterdir():
+                    if not p2.is_dir():
+                        continue
+                    for p3 in p2.iterdir():
+                        if not p3.is_dir():
+                            continue
+                        for p4 in p3.iterdir():
+                            if p4.is_dir():
+                                fragment = f"{p1.name}/{p2.name}/{p3.name}/{p4.name}"
+                                if fragment not in existing_fragments:
+                                    leaked_leaves.append(p4)
+        assert not leaked_leaves, f"Orphaned results fragment directories leaked: {leaked_leaves}"
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_soft_fail_does_not_leave_orphan_execution(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mock_result_factory,
+        mocker,
+    ):
+        """Regression: a soft-fail in handle_execution_result must not leave a committed
+        Execution row with successful=False (orphan) while reporting success to the caller.
+
+        Before the fix, handle_execution_result would mark the execution failed and return
+        normally; reingest_execution then fell through to the success log and returned True,
+        committing the failed row.  After the fix, the soft-fail aborts the savepoint and
+        returns False, leaving the DB count unchanged and the original execution intact.
+        """
+        original_execution_id = reingest_execution_obj.id
+        original_count = reingest_db.session.query(Execution).count()
+
+        mock_result = mock_result_factory(
+            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
         )
-        results_dir = config.paths.results / new_execution.output_fragment
-        assert results_dir.exists(), "Results directory should exist even when ingestion had errors"
+        _patch_build_result(mocker, mock_provider_registry, mock_result)
+
+        # Corrupt the metric bundle so handle_execution_result soft-fails
+        (scratch_dir_with_results / "diagnostic.json").write_text("not valid json")
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        reingest_db.session.commit()
+
+        assert ok is False, "reingest_execution must return False when ingestion soft-fails"
+
+        # The Execution count must be unchanged — no orphan row was committed
+        assert reingest_db.session.query(Execution).count() == original_count, (
+            "No new Execution row should be committed when ingestion soft-fails"
+        )
+
+        # The original execution must remain intact and successful
+        original = reingest_db.session.get(Execution, original_execution_id)
+        assert original is not None
+        assert original.successful is True, "Original execution must remain successful after failed reingest"
 
     def test_scratch_directory_preserved_after_success(
         self,


### PR DESCRIPTION
## Description

`ref executions reingest` reported an execution as "succeeded" even when re-ingestion failed. `handle_execution_result` catches ingestion errors internally (missing log file, malformed bundle, CV/schema mismatch, DB error), marks the new execution failed, and returns without raising, so `reingest_execution` fell through to its success log and returned `True`; the caller counted the failed reingest as a success and left the copied output directory on disk. On a hard exception the new `Execution` row created in the savepoint was still committed by the caller's transaction even though its output directories had just been deleted, leaving a row that points at missing files.

The fix moves the `handle_execution_result` call inside the same `begin_nested()` savepoint that creates the new execution and aborts the savepoint when `new_execution.successful is not True`, so a soft-failed ingestion rolls the new row back and returns `False` instead of reporting success. Both failure paths now clean up the new scratch and results directories via a shared `_remove_dir` helper; a hard exception already propagates out of the savepoint and is handled by the outer `except`, now with the same cleanup.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed reingest operations to correctly report failures when reingest attempts fail.  
- Improved rollback and cleanup so unsuccessful reingests no longer leave orphaned execution records or leftover output directories behind.  
- Added regression coverage to ensure ingestion “soft-fail” does not commit new execution entries and that filesystem cleanup occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->