### PR TITLE
perf(reingest): batch dataset loading and remove N+1 queries

### DIFF
--- a/changelog/750.improvement.md
+++ b/changelog/750.improvement.md
@@ -1,0 +1,1 @@
+Sped up `ref executions reingest` by eager-loading datasets and batching the database writes, so bulk reingests now scale with the number of executions rather than the number of data files.

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 from loguru import logger
+from sqlalchemy.orm import object_session, selectinload, with_polymorphic
 
 from climate_ref.datasets import get_slug_column
 from climate_ref.executor.fragment import (
@@ -25,6 +26,7 @@ from climate_ref.executor.fragment import (
     assign_execution_fragment,
 )
 from climate_ref.executor.result_handling import handle_execution_result
+from climate_ref.models.dataset import Dataset
 from climate_ref.models.execution import (
     Execution,
     ExecutionGroup,
@@ -45,7 +47,6 @@ if TYPE_CHECKING:
 
     from climate_ref.config import Config
     from climate_ref.database import Database
-    from climate_ref.models.dataset import Dataset
     from climate_ref.provider_registry import ProviderRegistry
     from climate_ref_core.diagnostics import Diagnostic
 
@@ -93,9 +94,27 @@ def reconstruct_execution_definition(
     """
     execution_group = execution.execution_group
 
+    session = object_session(execution)
+    if session is None:  # pragma: no cover - executions are always session-bound here
+        raise RuntimeError("reconstruct_execution_definition requires a session-bound execution")
+
+    # Load the execution's linked datasets, eager-loading both their polymorphic
+    # subclass columns (``with_polymorphic`` -> no per-row subclass SELECT in
+    # ``_extract_dataset_attributes``) and their files (``selectinload`` -> no
+    # per-dataset SELECT in the ``for file in dataset.files`` loop below). This
+    # keeps the query count constant rather than scaling with the dataset count.
+    dataset_poly = with_polymorphic(Dataset, "*")
+    datasets = (
+        session.query(dataset_poly)
+        .join(execution_datasets, execution_datasets.c.dataset_id == dataset_poly.id)
+        .where(execution_datasets.c.execution_id == execution.id)
+        .options(selectinload(dataset_poly.files))
+        .all()
+    )
+
     # Build DatasetCollection per source type from the execution's linked datasets
     datasets_by_type: dict[SourceDatasetType, list[Any]] = defaultdict(list)
-    for dataset in execution.datasets:
+    for dataset in datasets:
         datasets_by_type[dataset.dataset_type].append(dataset)
 
     collection: dict[SourceDatasetType | str, DatasetCollection] = {}
@@ -304,13 +323,12 @@ def reingest_execution(
                     raise _ReingestSavepointAbort
 
                 # Copy dataset links from the original execution
-                for dataset in execution.datasets:
-                    database.session.execute(
-                        execution_datasets.insert().values(
-                            execution_id=new_execution.id,
-                            dataset_id=dataset.id,
-                        )
-                    )
+                link_rows = [
+                    {"execution_id": new_execution.id, "dataset_id": dataset.id}
+                    for dataset in execution.datasets
+                ]
+                if link_rows:
+                    database.session.execute(execution_datasets.insert(), link_rows)
 
                 # Ingest within the SAME savepoint so that a failure rolls the new Execution row
                 # (and its dataset links) back together with the partial ingest.
@@ -330,7 +348,6 @@ def reingest_execution(
                         f"rolling back the new execution."
                     )
                     raise _ReingestSavepointAbort
-
         except _ReingestSavepointAbort:
             _remove_dir(new_scratch_dir)
             _remove_dir(new_results_dir)
@@ -392,6 +409,14 @@ def get_executions_for_reingest(
     if execution_group_ids:
         id_set = set(execution_group_ids)
         results = [(eg, ex) for eg, ex in results if eg.id in id_set]
+
+    group_ids = [eg.id for eg, _ in results]
+    if group_ids:
+        # Warm the session identity map so eg.executions[0] below does not
+        # issue one SELECT per group.
+        database.session.query(ExecutionGroup).filter(ExecutionGroup.id.in_(group_ids)).options(
+            selectinload(ExecutionGroup.executions)
+        ).all()
 
     # Filter out entries with no execution, then select the oldest per group.
     # ExecutionGroup.executions is ordered by created_at ascending,

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 from climate_ref_esmvaltool import provider as esmvaltool_provider
 from climate_ref_pmp import provider as pmp_provider
+from sqlalchemy import event
 
 from climate_ref.executor.reingest import (
     _extract_dataset_attributes,
@@ -16,7 +17,7 @@ from climate_ref.executor.reingest import (
 )
 from climate_ref.executor.result_handling import ingest_execution_result
 from climate_ref.models import ScalarMetricValue, SeriesMetricValue
-from climate_ref.models.dataset import CMIP6Dataset
+from climate_ref.models.dataset import CMIP6Dataset, DatasetFile
 from climate_ref.models.diagnostic import Diagnostic as DiagnosticModel
 from climate_ref.models.execution import (
     Execution,
@@ -182,6 +183,88 @@ def _patch_build_result(mocker, registry, mock_result):
     return diagnostic
 
 
+def _count_selects(bind):
+    """Attach a SELECT counter to ``bind``; returns (counter, listener) for teardown."""
+    counter = {"n": 0}
+
+    def _listener(conn, cursor, statement, *args):
+        if statement.lstrip().upper().startswith("SELECT"):
+            counter["n"] += 1
+
+    event.listen(bind, "before_cursor_execute", _listener)
+    return counter, _listener
+
+
+def _seed_execution_with_datasets(db, n_datasets, n_files_per_dataset, *, suffix=""):
+    """Create an execution linked to ``n_datasets`` CMIP6 datasets, each with files.
+
+    ``suffix`` keeps the unique ``slug``/``instance_id`` values distinct so the
+    helper can be called more than once against the same database.
+    """
+    with db.session.begin():
+        provider_model = ProviderModel(
+            name=f"qc_provider{suffix}", slug=f"qc_provider{suffix}", version="v0.1.0"
+        )
+        db.session.add(provider_model)
+        db.session.flush()
+
+        diag_model = DiagnosticModel(name="qc", slug=f"qc{suffix}", provider_id=provider_model.id)
+        db.session.add(diag_model)
+        db.session.flush()
+
+        eg = ExecutionGroup(
+            key=f"qc-key{suffix}",
+            diagnostic_id=diag_model.id,
+            selectors={"cmip6": [["source_id", "ACCESS-ESM1-5"]]},
+            dirty=False,
+        )
+        db.session.add(eg)
+        db.session.flush()
+
+        execution = Execution(
+            execution_group_id=eg.id,
+            successful=True,
+            output_fragment=f"qc_provider{suffix}/qc/abc123",
+            dataset_hash="hash-qc",
+        )
+        db.session.add(execution)
+        db.session.flush()
+
+        for i in range(n_datasets):
+            dataset = CMIP6Dataset(
+                slug=f"qc-dataset{suffix}-{i}.tas.gn",
+                instance_id=f"CMIP6.qc{suffix}.tas.{i}",
+                variable_id="tas",
+                source_id="ACCESS-ESM1-5",
+                experiment_id="historical",
+                table_id="Amon",
+                grid_label="gn",
+                member_id="r1i1p1f1",
+                variant_label="r1i1p1f1",
+                version="v20200101",
+                activity_id="CMIP",
+                institution_id="CSIRO",
+            )
+            db.session.add(dataset)
+            db.session.flush()
+
+            for j in range(n_files_per_dataset):
+                db.session.add(
+                    DatasetFile(
+                        dataset_id=dataset.id,
+                        path=f"/data/qc{suffix}-{i}-{j}.nc",
+                        start_time="2000-01-01",
+                        end_time="2000-12-31",
+                    )
+                )
+
+            db.session.execute(
+                execution_datasets.insert().values(execution_id=execution.id, dataset_id=dataset.id)
+            )
+
+    return db.session.get(Execution, execution.id)
+
+
 class TestExtractDatasetAttributes:
     def test_extracts_cmip6_attributes(self, db_seeded):
         dataset = db_seeded.session.query(CMIP6Dataset).first()
@@ -281,6 +364,41 @@ class TestReconstructExecutionDefinition:
         assert definition.key == "recon-test"
         if dataset:
             assert SourceDatasetType.CMIP6 in definition.datasets
+
+    def test_query_count_is_constant_in_dataset_count(self, db, config, provider):
+        """Reconstruction must not issue one query per dataset/file (no N+1).
+
+        With files eager-loaded via a single ``selectinload`` query, the SELECT
+        count for reconstruction is a small constant independent of how many
+        datasets (and files) the execution links. Before the eager load, the
+        inner ``for file in dataset.files`` loop issued one SELECT per dataset,
+        so the count grew with the dataset count and this assertion would fail.
+        """
+        diagnostic = provider.get("mock")
+
+        def _count_for(n_datasets, suffix):
+            execution = _seed_execution_with_datasets(db, n_datasets, n_files_per_dataset=3, suffix=suffix)
+            db.session.expire_all()  # force reconstruction to actually hit the DB
+            bind = db.session.get_bind()
+            counter, listener = _count_selects(bind)
+            try:
+                reconstruct_execution_definition(config, execution, diagnostic)
+            finally:
+                event.remove(bind, "before_cursor_execute", listener)
+            # Close the read-only transaction autobegun by the measured query so a
+            # subsequent ``session.begin()`` (for the next seed) does not collide.
+            db.session.rollback()
+            return counter["n"]
+
+        few = _count_for(1, suffix="-few")
+        many = _count_for(8, suffix="-many")
+
+        assert many == few, (
+            f"reconstruct_execution_definition scales queries with dataset count: "
+            f"1 dataset -> {few} SELECTs, 8 datasets -> {many} SELECTs"
+        )
+        # Sanity: the SELECT count is a small constant, not zero (it really queried).
+        assert 0 < few <= 6, f"expected a small constant SELECT count, got {few}"
 
 
 class TestReingestExecution:


### PR DESCRIPTION
## Description

`ref executions reingest` reconstructs each completed execution's `ExecutionDefinition` from the database before re-running `build_execution_result()`. Reconstruction walked `execution.datasets` and then `dataset.files` lazily, and `_extract_dataset_attributes` triggered a per-dataset load of the polymorphic subclass table, so a bulk reingest issued O(M × D) queries (M executions, D datasets each). The dataset links were also copied with one `INSERT` per row, and the eligibility scan lazy-loaded each group's full `executions` collection just to read `[0]`.

This makes reingest scale with the number of executions rather than the number of files, with no behaviour change:

- `reconstruct_execution_definition` now loads the linked datasets in a single query using `with_polymorphic(Dataset, "*")` (eager-loads the polymorphic subclass columns) plus `selectinload(.files)`, so neither the `for file in dataset.files` loop nor `_extract_dataset_attributes` issues a per-dataset query.
- The dataset-link copy is now a single batched `session.execute(insert(), rows)`, mirroring `Execution.register_datasets`.
- `get_executions_for_reingest` warms the `ExecutionGroup.executions` identity map once before the loop instead of lazy-loading each group's collection.

On a synthetic execution with 8 datasets and 3 files each, reconstruction drops from 18 SELECTs to a constant 3, independent of dataset count. The reconstructed definition, the set of `(execution_id, dataset_id)` links, and the reingest failure-handling path are all unchanged. A new regression test asserts the reconstruction SELECT count is constant in the dataset count (it grows, and fails, if the eager load is reverted).

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Performance Improvements

* Reference execution reingestion is now substantially faster through operational optimisations. Bulk reingests now scale more efficiently based on the number of executions rather than the total number of data files, delivering notably improved performance for users conducting large-scale bulk reingestion operations and workflows without any degradation in quality or reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->