### PR TITLE
fix(solve): non-mutating dry-run and fail loudly on unmatched provider filter

### DIFF
--- a/changelog/766.fix.md
+++ b/changelog/766.fix.md
@@ -1,3 +1,4 @@
 `ref solve --dry-run` is now a read-only preview and no longer creates execution groups in the database.
+It still reports execution groups with stale, abandoned in-progress executions as runnable, matching what the next real solve would pick up.
 
 `ref solve` now exits with an error and remediation advice when no diagnostic providers are configured, or when a `--provider` filter matches none of the configured providers, instead of exiting successfully without doing anything.

--- a/changelog/766.fix.md
+++ b/changelog/766.fix.md
@@ -1,0 +1,3 @@
+`ref solve --dry-run` is now a read-only preview and no longer creates execution groups in the database.
+
+`ref solve` now exits with an error and remediation advice when no diagnostic providers are configured, or when a `--provider` filter matches none of the configured providers, instead of exiting successfully without doing anything.

--- a/packages/climate-ref/src/climate_ref/cli/solve.py
+++ b/packages/climate-ref/src/climate_ref/cli/solve.py
@@ -1,10 +1,47 @@
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
+from loguru import logger
 
 from climate_ref.cli._utils import parse_facet_filters
 
+if TYPE_CHECKING:
+    from climate_ref.config import Config
+
 app = typer.Typer()
+
+_PROVIDER_REMEDIATION = (
+    "Configure a diagnostic provider before solving:\n"
+    "  - install one, e.g. `pip install 'climate-ref[aft-providers]'` or `pip install climate-ref-example`\n"
+    "  - then regenerate your configuration, or add it under [[diagnostic_providers]] in ref.toml"
+)
+
+
+def _validate_provider_filter(config: "Config", provider: list[str] | None) -> None:
+    """
+    Fail loudly when no configured provider can satisfy the solve.
+
+    Without this, ``ref solve`` (or ``ref solve --provider <typo>``) exits 0 having
+    done nothing, which looks like success. Provider matching mirrors the solver:
+    a filter matches a provider when it is a case-insensitive substring of the slug.
+    """
+    from climate_ref_core.providers import import_provider
+
+    configured = [import_provider(p.provider).slug for p in config.diagnostic_providers]
+
+    if not configured:
+        logger.error("No diagnostic providers are configured.\n" + _PROVIDER_REMEDIATION)
+        raise typer.Exit(code=1)
+
+    if provider:
+        matched = [slug for slug in configured if any(f.lower() in slug for f in provider)]
+        if not matched:
+            available = ", ".join(configured)
+            logger.error(
+                f"No configured providers match the --provider filter {provider}. "
+                f"Available providers: {available}.\n" + _PROVIDER_REMEDIATION
+            )
+            raise typer.Exit(code=1)
 
 
 @app.command()
@@ -90,6 +127,8 @@ def solve(  # noqa: PLR0913
 
     config = ctx.obj.config
     db = ctx.obj.database
+
+    _validate_provider_filter(config, provider)
 
     try:
         parsed_dataset_filters = parse_facet_filters(dataset_filter) or None

--- a/packages/climate-ref/src/climate_ref/cli/solve.py
+++ b/packages/climate-ref/src/climate_ref/cli/solve.py
@@ -21,8 +21,9 @@ def _validate_provider_filter(config: "Config", provider: list[str] | None) -> N
     """
     Fail loudly when no configured provider can satisfy the solve.
 
-    Without this, ``ref solve`` (or ``ref solve --provider <typo>``) exits 0 having
-    done nothing, which looks like success. Provider matching mirrors the solver:
+    Without this, ``ref solve`` (or ``ref solve --provider <typo>``) exits 0 having done nothing,
+    which looks like success.
+    Provider matching mirrors the solver:
     a filter matches a provider when it is a case-insensitive substring of the slug.
     """
     from climate_ref_core.providers import import_provider

--- a/packages/climate-ref/src/climate_ref/models/execution.py
+++ b/packages/climate-ref/src/climate_ref/models/execution.py
@@ -119,11 +119,10 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
         rerun_failed
             Re-run the group even if the last execution failed and the group is not dirty.
         stale_cutoff
-            When provided, an in-progress execution created before this timestamp is
-            treated as already failed. A real solve reaps such abandoned executions
-            (via ``fail_stale_in_progress_executions``) before evaluating this method;
-            a read-only dry-run passes the same cutoff here so its preview matches what
-            the next solve would run, without mutating the database.
+            When provided,
+            an in-progress execution created before this timestamp is treated as already failed.
+            A real solve reaps such abandoned executions (via ``fail_stale_in_progress_executions``)
+            before evaluating this method.
         """
         if not self.executions:
             logger.debug(f"Execution group {self.diagnostic.slug}/{self.key} was never executed")
@@ -138,8 +137,6 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
             )
             return True
 
-        # A stale in-progress execution will be reaped (marked failed) by the next real
-        # solve, so treat it as failed when a cutoff is supplied (dry-run preview).
         treat_as_failed = (
             last_execution.successful is None
             and stale_cutoff is not None

--- a/packages/climate-ref/src/climate_ref/models/execution.py
+++ b/packages/climate-ref/src/climate_ref/models/execution.py
@@ -1,3 +1,4 @@
+import datetime
 import enum
 import pathlib
 from collections.abc import Sequence
@@ -84,7 +85,12 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
         back_populates="execution_group", order_by="Execution.created_at"
     )
 
-    def should_run(self, dataset_hash: str, rerun_failed: bool = False) -> bool:
+    def should_run(
+        self,
+        dataset_hash: str,
+        rerun_failed: bool = False,
+        stale_cutoff: "datetime.datetime | None" = None,
+    ) -> bool:
         """
         Check if the diagnostic execution group needs to be executed.
 
@@ -105,6 +111,19 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
         * an execution with the same dataset hash is already in progress
         * the last execution failed and the group is not dirty
           (use ``rerun_failed=True`` or ``flag-dirty`` to retry)
+
+        Parameters
+        ----------
+        dataset_hash
+            Hash of the candidate datasets for this run.
+        rerun_failed
+            Re-run the group even if the last execution failed and the group is not dirty.
+        stale_cutoff
+            When provided, an in-progress execution created before this timestamp is
+            treated as already failed. A real solve reaps such abandoned executions
+            (via ``fail_stale_in_progress_executions``) before evaluating this method;
+            a read-only dry-run passes the same cutoff here so its preview matches what
+            the next solve would run, without mutating the database.
         """
         if not self.executions:
             logger.debug(f"Execution group {self.diagnostic.slug}/{self.key} was never executed")
@@ -119,9 +138,17 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
             )
             return True
 
+        # A stale in-progress execution will be reaped (marked failed) by the next real
+        # solve, so treat it as failed when a cutoff is supplied (dry-run preview).
+        treat_as_failed = (
+            last_execution.successful is None
+            and stale_cutoff is not None
+            and last_execution.created_at < stale_cutoff
+        )
+
         # Don't submit duplicate tasks for an execution that is already in progress
         # Stuck tasks can be cleaned up with the `fail-running` command
-        if last_execution.successful is None:
+        if last_execution.successful is None and not treat_as_failed:
             logger.debug(
                 f"Execution group {self.diagnostic.slug}/{self.key} "
                 f"already has an in-progress execution with hash {dataset_hash}"
@@ -134,7 +161,7 @@ class ExecutionGroup(CreatedUpdatedMixin, Base):
             return True
 
         # Re-run all failed executions if explicitly requested
-        if last_execution.successful is False and rerun_failed:
+        if (last_execution.successful is False or treat_as_failed) and rerun_failed:
             logger.debug(
                 f"Execution group {self.diagnostic.slug}/{self.key} "
                 f"last execution failed, rerunning (rerun_failed=True)"

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -526,6 +526,15 @@ class ExecutionSolver:
 DEFAULT_STALE_EXECUTION_AGE_SECONDS = 6 * 60 * 60
 
 
+def _stale_execution_cutoff(
+    stale_after_seconds: int = DEFAULT_STALE_EXECUTION_AGE_SECONDS,
+) -> datetime.datetime:
+    """Naive UTC timestamp before which an in-progress execution is considered abandoned."""
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None) - datetime.timedelta(
+        seconds=stale_after_seconds
+    )
+
+
 def fail_stale_in_progress_executions(
     db: Database,
     *,
@@ -556,9 +565,7 @@ def fail_stale_in_progress_executions(
     :
         The number of executions that were marked failed.
     """
-    cutoff = datetime.datetime.now(datetime.UTC).replace(tzinfo=None) - datetime.timedelta(
-        seconds=stale_after_seconds
-    )
+    cutoff = _stale_execution_cutoff(stale_after_seconds)
 
     with db.session.begin():
         stale = (
@@ -616,8 +623,13 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     logger.info("Solving for diagnostics that require recalculation...")
 
     # A dry run is a read-only preview: it must not create execution groups,
-    # reap stale executions, or build/submit to an executor.
-    if not dry_run:
+    # reap stale executions, or build/submit to an executor. Instead of reaping,
+    # it passes the same stale cutoff to ``should_run`` so abandoned executions are
+    # previewed as runnable without mutating the database.
+    stale_cutoff = None
+    if dry_run:
+        stale_cutoff = _stale_execution_cutoff()
+    else:
         # Reap any executions that were left in-progress by a previous run that
         # crashed, hit walltime, or otherwise lost its result-handling callback.
         # Without this sweep, ``ExecutionGroup.should_run`` keeps returning False
@@ -721,7 +733,7 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
             # A not-yet-created group (dry-run only) would always run; an existing
             # group defers to its should_run logic.
             if execution_group is not None and not execution_group.should_run(
-                definition.datasets.hash, rerun_failed=rerun_failed
+                definition.datasets.hash, rerun_failed=rerun_failed, stale_cutoff=stale_cutoff
             ):
                 continue
 

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -623,17 +623,13 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     logger.info("Solving for diagnostics that require recalculation...")
 
     # A dry run is a read-only preview: it must not create execution groups,
-    # reap stale executions, or build/submit to an executor. Instead of reaping,
-    # it passes the same stale cutoff to ``should_run`` so abandoned executions are
-    # previewed as runnable without mutating the database.
+    # reap stale executions, or build/submit to an executor.
     stale_cutoff = None
     if dry_run:
         stale_cutoff = _stale_execution_cutoff()
     else:
-        # Reap any executions that were left in-progress by a previous run that
-        # crashed, hit walltime, or otherwise lost its result-handling callback.
-        # Without this sweep, ``ExecutionGroup.should_run`` keeps returning False
-        # for these rows and the group is never retried.
+        # Reap any executions that were left in-progress by a previous run that crashed,
+        # hit walltime, or otherwise lost its result-handling callback.
         fail_stale_in_progress_executions(db)
 
     executor = None if dry_run else config.executor.build(config, db)
@@ -688,8 +684,8 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
         # are created correctly before potentially executing out of process
         with db.session.begin():
             if dry_run:
-                # Read-only preview: look the group up without creating it. A group
-                # that does not exist yet is one this solve *would* create and run.
+                # Read-only preview: look the group up without creating it.
+                # A group that does not exist yet is one this solve *would* create and run.
                 execution_group = (
                     db.session.query(ExecutionGroup)
                     .filter_by(
@@ -730,8 +726,8 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
                 f"provider_count={provider_count}"
             )
 
-            # A not-yet-created group (dry-run only) would always run; an existing
-            # group defers to its should_run logic.
+            # A not-yet-created group (dry-run only) would always run;
+            # an existing group defers to its should_run logic.
             if execution_group is not None and not execution_group.should_run(
                 definition.datasets.hash, rerun_failed=rerun_failed, stale_cutoff=stale_cutoff
             ):
@@ -750,8 +746,7 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
                 if limit is not None and total_count >= limit:
                     limit_reached = True
             else:
-                # Only the dry-run branch leaves the group unresolved; here it is
-                # always the row returned by get_or_create above.
+                # Only the dry-run branch leaves the group unresolved
                 assert execution_group is not None
                 logger.info(
                     f"Running new execution for execution group: {potential_execution.execution_slug()!r}"

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -615,15 +615,18 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
 
     logger.info("Solving for diagnostics that require recalculation...")
 
-    # Reap any executions that were left in-progress by a previous run that
-    # crashed, hit walltime, or otherwise lost its result-handling callback.
-    # Without this sweep, ``ExecutionGroup.should_run`` keeps returning False
-    # for these rows and the group is never retried.
-    fail_stale_in_progress_executions(db)
+    # A dry run is a read-only preview: it must not create execution groups,
+    # reap stale executions, or build/submit to an executor.
+    if not dry_run:
+        # Reap any executions that were left in-progress by a previous run that
+        # crashed, hit walltime, or otherwise lost its result-handling callback.
+        # Without this sweep, ``ExecutionGroup.should_run`` keeps returning False
+        # for these rows and the group is never retried.
+        fail_stale_in_progress_executions(db)
 
-    executor = config.executor.build(config, db)
+    executor = None if dry_run else config.executor.build(config, db)
 
-    if not wait and getattr(executor, "collects_results_on_join", False):
+    if executor is not None and not wait and getattr(executor, "collects_results_on_join", False):
         logger.warning(
             f"--no-wait was requested with the {getattr(executor, 'name', 'configured')!r} executor, "
             f"which only persists results while waiting (during join). "
@@ -672,23 +675,36 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
         # Use a transaction to make sure that the models
         # are created correctly before potentially executing out of process
         with db.session.begin():
-            # diagnostic_version is part of the lookup key so bumping
-            # ``Diagnostic.version`` produces a fresh v2 group instead of reusing the v1 row.
-            execution_group, created = db.get_or_create(
-                ExecutionGroup,
-                key=definition.key,
-                diagnostic_id=diagnostic_id,
-                diagnostic_version=diagnostic_version,
-                defaults={
-                    "selectors": potential_execution.selectors,
-                    "dirty": True,
-                },
-            )
+            if dry_run:
+                # Read-only preview: look the group up without creating it. A group
+                # that does not exist yet is one this solve *would* create and run.
+                execution_group = (
+                    db.session.query(ExecutionGroup)
+                    .filter_by(
+                        key=definition.key,
+                        diagnostic_id=diagnostic_id,
+                        diagnostic_version=diagnostic_version,
+                    )
+                    .one_or_none()
+                )
+            else:
+                # diagnostic_version is part of the lookup key so bumping
+                # ``Diagnostic.version`` produces a fresh v2 group instead of reusing the v1 row.
+                execution_group, created = db.get_or_create(
+                    ExecutionGroup,
+                    key=definition.key,
+                    diagnostic_id=diagnostic_id,
+                    diagnostic_version=diagnostic_version,
+                    defaults={
+                        "selectors": potential_execution.selectors,
+                        "dirty": True,
+                    },
+                )
 
-            if created:
-                logger.info(f"Created new execution group: {potential_execution.execution_slug()!r}")
-                db.session.flush()
-                recompute_promoted_version(diagnostic_id, db.session)
+                if created:
+                    logger.info(f"Created new execution group: {potential_execution.execution_slug()!r}")
+                    db.session.flush()
+                    recompute_promoted_version(diagnostic_id, db.session)
 
             # TODO: Move this logic to the solver
             # Check if we should run given the one_per_provider or one_per_diagnostic flags
@@ -702,7 +718,11 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
                 f"provider_count={provider_count}"
             )
 
-            if not execution_group.should_run(definition.datasets.hash, rerun_failed=rerun_failed):
+            # A not-yet-created group (dry-run only) would always run; an existing
+            # group defers to its should_run logic.
+            if execution_group is not None and not execution_group.should_run(
+                definition.datasets.hash, rerun_failed=rerun_failed
+            ):
                 continue
 
             if (one_per_provider or one_per_diagnostic) and one_of_check_failed:
@@ -718,6 +738,9 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
                 if limit is not None and total_count >= limit:
                     limit_reached = True
             else:
+                # Only the dry-run branch leaves the group unresolved; here it is
+                # always the row returned by get_or_create above.
+                assert execution_group is not None
                 logger.info(
                     f"Running new execution for execution group: {potential_execution.execution_slug()!r}"
                 )
@@ -765,7 +788,8 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
                     limit_reached = True
 
         # Transaction has committed; safe to submit to the executor.
-        if pending is not None:
+        # ``pending`` is only set on the non-dry-run path, where the executor exists.
+        if pending is not None and executor is not None:
             pending_definition, pending_execution = pending
             executor.run(
                 definition=pending_definition,
@@ -783,6 +807,6 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     for prov, count in provider_count.items():
         logger.info(f"  {prov}: {count} new executions")
 
-    if wait:
+    if wait and executor is not None:
         executor.join(timeout=timeout)
         logger.info("All executions complete")

--- a/packages/climate-ref/tests/unit/cli/test_solve.py
+++ b/packages/climate-ref/tests/unit/cli/test_solve.py
@@ -69,6 +69,22 @@ class TestSolve:
         assert kwargs["filters"].diagnostic == ["global-mean-timeseries"]
         assert kwargs["filters"].provider == ["esmvaltool", "ilamb"]
 
+    def test_solve_with_mixed_case_provider_filter(self, sample_data_dir, db, invoke_cli, mocker, config):
+        from climate_ref.config import DiagnosticProviderConfig
+
+        # Provider matching is a case-insensitive substring match against the slug,
+        # so a mixed-case partial filter must validate and be passed through verbatim.
+        config.diagnostic_providers = [
+            DiagnosticProviderConfig(provider="climate_ref_esmvaltool"),
+        ]
+        config.save()
+
+        mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
+        invoke_cli(["solve", "--provider", "ESMval"])
+
+        _args, kwargs = mock_solve.call_args
+        assert kwargs["filters"].provider == ["ESMval"]
+
     def test_solve_provider_filter_no_match_fails(self, sample_data_dir, db, invoke_cli, mocker):
         # A --provider filter that matches no configured provider must fail loudly
         # rather than exiting 0 having done nothing.

--- a/packages/climate-ref/tests/unit/cli/test_solve.py
+++ b/packages/climate-ref/tests/unit/cli/test_solve.py
@@ -44,8 +44,8 @@ class TestSolve:
     def test_solve_with_filters(self, sample_data_dir, db, invoke_cli, mocker, config):
         from climate_ref.config import DiagnosticProviderConfig
 
-        # The provider filter is validated against configured providers, so the
-        # filtered providers must be configured for this parsing test.
+        # The provider filter is validated against configured providers,
+        # so the filtered providers must be configured for this parsing test.
         config.diagnostic_providers = [
             DiagnosticProviderConfig(provider="climate_ref_esmvaltool"),
             DiagnosticProviderConfig(provider="climate_ref_ilamb"),

--- a/packages/climate-ref/tests/unit/cli/test_solve.py
+++ b/packages/climate-ref/tests/unit/cli/test_solve.py
@@ -41,7 +41,17 @@ class TestSolve:
         _args, kwargs = mock_solve.call_args
         assert kwargs["dry_run"]
 
-    def test_solve_with_filters(self, sample_data_dir, db, invoke_cli, mocker):
+    def test_solve_with_filters(self, sample_data_dir, db, invoke_cli, mocker, config):
+        from climate_ref.config import DiagnosticProviderConfig
+
+        # The provider filter is validated against configured providers, so the
+        # filtered providers must be configured for this parsing test.
+        config.diagnostic_providers = [
+            DiagnosticProviderConfig(provider="climate_ref_esmvaltool"),
+            DiagnosticProviderConfig(provider="climate_ref_ilamb"),
+        ]
+        config.save()
+
         mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
         invoke_cli(
             [
@@ -58,6 +68,25 @@ class TestSolve:
         _args, kwargs = mock_solve.call_args
         assert kwargs["filters"].diagnostic == ["global-mean-timeseries"]
         assert kwargs["filters"].provider == ["esmvaltool", "ilamb"]
+
+    def test_solve_provider_filter_no_match_fails(self, sample_data_dir, db, invoke_cli, mocker):
+        # A --provider filter that matches no configured provider must fail loudly
+        # rather than exiting 0 having done nothing.
+        mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
+        result = invoke_cli(["solve", "--provider", "does-not-exist"], expected_exit_code=1)
+
+        assert "No configured providers match" in result.stderr
+        mock_solve.assert_not_called()
+
+    def test_solve_no_providers_configured_fails(self, sample_data_dir, db, invoke_cli, mocker, config):
+        config.diagnostic_providers = []
+        config.save()
+
+        mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
+        result = invoke_cli(["solve"], expected_exit_code=1)
+
+        assert "No diagnostic providers are configured" in result.stderr
+        mock_solve.assert_not_called()
 
     def test_solve_with_dataset_filter(self, sample_data_dir, db, invoke_cli, mocker):
         mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")

--- a/packages/climate-ref/tests/unit/models/test_metric_execution.py
+++ b/packages/climate-ref/tests/unit/models/test_metric_execution.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from climate_ref.models.execution import Execution, ExecutionGroup, ExecutionOutput, ResultOutputType
@@ -100,6 +102,59 @@ class TestMetricExecution:
         execution.dirty = False
 
         assert ExecutionGroup.should_run(execution, "dataset_hash", rerun_failed=True)
+
+    def test_should_run_stale_in_progress_dirty(self, mocker):
+        """A stale in-progress execution is treated as failed under a dry-run cutoff.
+
+        A real solve reaps it before evaluating should_run, so a dry-run preview must
+        report the dirty group as runnable rather than hiding it as in-progress.
+        """
+        execution = mocker.Mock(spec=ExecutionGroup)
+        execution_result = mocker.Mock(spec=Execution)
+
+        execution_result.dataset_hash = "dataset_hash"
+        execution_result.successful = None
+        execution_result.created_at = datetime.datetime(2020, 1, 1)
+        execution.executions = [execution_result]
+        execution.dirty = True
+
+        cutoff = datetime.datetime(2020, 6, 1)
+
+        # Without a cutoff the in-progress execution suppresses the run...
+        assert not ExecutionGroup.should_run(execution, "dataset_hash")
+        # ...but with a cutoff the stale execution is treated as reaped.
+        assert ExecutionGroup.should_run(execution, "dataset_hash", stale_cutoff=cutoff)
+
+    def test_should_run_stale_in_progress_rerun_flag(self, mocker):
+        """A stale in-progress execution re-runs under rerun_failed even if not dirty"""
+        execution = mocker.Mock(spec=ExecutionGroup)
+        execution_result = mocker.Mock(spec=Execution)
+
+        execution_result.dataset_hash = "dataset_hash"
+        execution_result.successful = None
+        execution_result.created_at = datetime.datetime(2020, 1, 1)
+        execution.executions = [execution_result]
+        execution.dirty = False
+
+        cutoff = datetime.datetime(2020, 6, 1)
+
+        assert not ExecutionGroup.should_run(execution, "dataset_hash", stale_cutoff=cutoff)
+        assert ExecutionGroup.should_run(execution, "dataset_hash", rerun_failed=True, stale_cutoff=cutoff)
+
+    def test_should_run_fresh_in_progress_with_cutoff(self, mocker):
+        """An in-progress execution newer than the cutoff is still left alone"""
+        execution = mocker.Mock(spec=ExecutionGroup)
+        execution_result = mocker.Mock(spec=Execution)
+
+        execution_result.dataset_hash = "dataset_hash"
+        execution_result.successful = None
+        execution_result.created_at = datetime.datetime(2020, 12, 1)
+        execution.executions = [execution_result]
+        execution.dirty = True
+
+        cutoff = datetime.datetime(2020, 6, 1)
+
+        assert not ExecutionGroup.should_run(execution, "dataset_hash", stale_cutoff=cutoff)
 
 
 class TestExecutionOutput:

--- a/packages/climate-ref/tests/unit/models/test_metric_execution.py
+++ b/packages/climate-ref/tests/unit/models/test_metric_execution.py
@@ -104,11 +104,7 @@ class TestMetricExecution:
         assert ExecutionGroup.should_run(execution, "dataset_hash", rerun_failed=True)
 
     def test_should_run_stale_in_progress_dirty(self, mocker):
-        """A stale in-progress execution is treated as failed under a dry-run cutoff.
-
-        A real solve reaps it before evaluating should_run, so a dry-run preview must
-        report the dirty group as runnable rather than hiding it as in-progress.
-        """
+        """A stale in-progress execution is treated as failed under a dry-run cutoff"""
         execution = mocker.Mock(spec=ExecutionGroup)
         execution_result = mocker.Mock(spec=Execution)
 

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -13,7 +13,7 @@ from climate_ref.config import ExecutorConfig
 from climate_ref.data_catalog import DataCatalog
 from climate_ref.database import Database
 from climate_ref.datasets import CMIP6DatasetAdapter, Obs4MIPsDatasetAdapter, ingest_datasets
-from climate_ref.models import Execution
+from climate_ref.models import Execution, ExecutionGroup
 from climate_ref.provider_registry import ProviderRegistry, _register_provider
 from climate_ref.solver import (
     DiagnosticExecution,
@@ -750,9 +750,22 @@ def test_solve_metrics(mocker, db_seeded, solver, data_regression, mock_executor
 
 
 def test_solve_metrics_dry_run(db_seeded, config, solver, mock_executor):
+    def group_count() -> int:
+        with db_seeded.session.begin():
+            return db_seeded.session.query(ExecutionGroup).count()
+
+    assert group_count() == 0
+
     solve_required_executions(config=config, db=db_seeded, dry_run=True, solver=solver)
 
     assert mock_executor.return_value.run.call_count == 0
+    # A dry run is a read-only preview: it must not persist any execution groups.
+    assert group_count() == 0
+
+    # A real solve over the same catalog does create groups, confirming the dry
+    # run had candidates to report and only the persistence was suppressed.
+    solve_required_executions(config=config, db=db_seeded, dry_run=False, execute=False, solver=solver)
+    assert group_count() > 0
 
 
 def test_solve_metric_executions_missing(mock_diagnostic, provider):


### PR DESCRIPTION
## Description

Fixing some oddities about `ref solve`

**`--dry-run` is now genuinely non-mutating.** Previously `ref solve --dry-run` still created `ExecutionGroup` rows (via `get_or_create`), reaped stale in-progress executions, and built/joined an executor. It now performs a read-only preview: it looks groups up without creating them, skips the stale-execution sweep, and never builds an executor. A group that does not yet exist is reported as one the solve would create. A regression test asserts the execution-group row count is unchanged by a dry run, and that a subsequent real solve over the same catalog does create groups.

**Provider filters now fail loudly.** `ref solve --provider <name>` previously exited 0 with no work done when no providers were configured or the filter matched none of them, which looks like success. The command now validates before solving and exits non-zero with remediation (install a provider, regenerate config, or add it under `[[diagnostic_providers]]`). Matching mirrors the solver: a filter matches when it is a case-insensitive substring of a configured provider slug.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * `ref solve` now fails with error + remediation when no diagnostic providers are configured, or when `--provider` matches none of the configured providers.
  * `ref solve --dry-run` is now strictly read-only: it no longer creates execution groups or triggers execution steps, and it won’t run or wait on executors.
  * Dry-run scheduling now uses a stale cutoff so stale in-progress executions are treated as runnable (and can rerun when enabled).

* **Tests**
  * Updated and expanded unit tests for provider-filter validation and dry-run persistence/scheduling behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->