### PR TITLE
Expand ref config CLI management commands

### DIFF
--- a/changelog/768.feature.md
+++ b/changelog/768.feature.md
@@ -1,0 +1,1 @@
+Added `ref config init`, `get`, `set`, `unset`, `edit`, and `validate` commands to make configuration onboarding and management easier from the CLI.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,33 @@ provider = "climate_ref_pmp:provider"
 [diagnostic_providers.config]
 ```
 
+## Managing configuration from the CLI
+
+Use `ref config init` to create a supported starter `ref.toml` in `REF_CONFIGURATION`.
+The command creates parent directories and refuses to overwrite an existing file unless you pass `--force`.
+
+Individual scalar values can be inspected or changed with dotted keys:
+
+```bash
+ref config get paths.scratch
+ref config set log_level DEBUG
+ref config unset log_level
+```
+
+`ref config get` prints the effective value the REF will use at runtime,
+so environment variables such as `REF_DATABASE_URL` take precedence over values in `ref.toml`.
+When an environment variable shadows a requested key,
+the CLI keeps stdout script-friendly and writes the notice to stderr.
+
+Run `ref config validate` after hand-editing the file.
+For CI or editor integrations, use `ref config validate --format json` and rely on the exit code:
+0 means valid, 1 means invalid.
+
+`ref config set` and `ref config unset` rewrite `ref.toml` from the parsed configuration model.
+This is convenient for simple scalar changes,
+but it does not preserve comments or custom key ordering in a hand-edited file.
+Edit structured values such as `diagnostic_providers` and `executor.config` directly in TOML.
+
 ## Additional Environment Variables
 
 Environment variables are used to control some aspects of the framework

--- a/docs/getting-started/01-configure.md
+++ b/docs/getting-started/01-configure.md
@@ -26,14 +26,14 @@ export REF_CONFIGURATION="/path/to/your/ref/configuration"
 
 ## 2. Generate
 
-Climate-REF provides a script to write out the default configuration.
+Climate-REF provides a command to write out the default configuration.
 
 ```bash
-mkdir $REF_CONFIGURATION
-ref config list > $REF_CONFIGURATION/ref.toml
+ref config init
 ```
 
 This command will create the `$REF_CONFIGURATION` directory and create a `ref.toml` inside it with the default configuration settings.
+It refuses to overwrite an existing file unless you pass `--force`.
 
 /// admonition | Note
 
@@ -54,6 +54,7 @@ You will see a template configuration file with sections for logging, paths, dat
 These should be customized to suit your environment and preferences.
 
 Additional information about the configuration file can be found in the [Configuration documentation](../configuration.md).
+After editing, run `ref config validate` to check that `ref.toml` is valid before continuing.
 
 An example configuration file might look like this with some placeholders:
 
@@ -122,10 +123,14 @@ If environment variables are set, Climate-REF will use their values in preferenc
 To ensure your configuration is valid and correctly read by the REF, you can run the following command:
 
 ```bash
-ref config list
+ref config validate
 ```
 
-Your configuration should be displayed without errors and should include any changes you made in the `ref.toml` file.
+You can also inspect the effective configuration, including environment variable overrides, with:
+
+```bash
+ref config list
+```
 
 ## 6. Set up diagnostic providers
 

--- a/packages/climate-ref/src/climate_ref/cli/__init__.py
+++ b/packages/climate-ref/src/climate_ref/cli/__init__.py
@@ -16,12 +16,15 @@ from climate_ref.config import Config
 from climate_ref.constants import CONFIG_FILENAME
 from climate_ref.database import Database
 from climate_ref_core import __version__ as __core_version__
+from climate_ref_core.env import env
 from climate_ref_core.logging import initialise_logging
 
 # Registry of read-only command paths (group, command)
 # These commands skip database backup before migrations since they don't modify data
 _READ_ONLY_COMMANDS: set[tuple[str, str]] = {
     ("config", "list"),
+    ("config", "get"),
+    ("config", "validate"),
     ("datasets", "list"),
     ("datasets", "list-columns"),
     ("datasets", "stats"),
@@ -47,6 +50,27 @@ _READ_ONLY_COMMANDS: set[tuple[str, str]] = {
     ("test-cases", "check-store"),
 }
 
+# Commands whose job is to create or inspect the configuration file, so they must
+# run even when that file is missing or malformed.
+_CONFIG_BOOTSTRAP_COMMANDS: set[tuple[str, str]] = {
+    ("config", "init"),
+    ("config", "validate"),
+}
+
+
+def _command_path_in_argv(command_paths: set[tuple[str, str]]) -> bool:
+    args = sys.argv[1:]
+    for index, arg in enumerate(args[:-1]):
+        if arg.startswith("-"):
+            continue
+        for group, command in command_paths:
+            if arg != group:
+                continue
+            remaining = [candidate for candidate in args[index + 1 :] if not candidate.startswith("-")]
+            if remaining and remaining[0] == command:
+                return True
+    return False
+
 
 def _is_read_only_command() -> bool:
     """
@@ -55,15 +79,12 @@ def _is_read_only_command() -> bool:
     This checks against a registry of known read-only command paths since
     the Typer callback runs before nested commands are resolved.
     """
-    # Parse sys.argv to find the command path
-    # Skip options (--flag) and the program name
-    args = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
+    return _command_path_in_argv(_READ_ONLY_COMMANDS)
 
-    if len(args) >= 2:  # noqa: PLR2004
-        # Check if (group, command) is in our read-only registry
-        return (args[0], args[1]) in _READ_ONLY_COMMANDS
 
-    return False
+def _is_config_bootstrap_command() -> bool:
+    """Check if the current command must tolerate missing or malformed config."""
+    return _command_path_in_argv(_CONFIG_BOOTSTRAP_COMMANDS)
 
 
 class LogLevel(StrEnum):
@@ -88,6 +109,8 @@ class CLIContext:
 
     config: Config
     console: Console
+    configuration_directory: Path | None = None
+    config_load_error: str | None = None
     skip_backup: bool = False
     _database: Database | None = field(default=None, alias="_database")
     _database_unmigrated: Database | None = field(default=None, alias="_database_unmigrated")
@@ -137,7 +160,9 @@ def _create_console() -> Console:
     return Console()
 
 
-def _load_config(configuration_directory: Path | None = None) -> Config:
+def _load_config(
+    configuration_directory: Path | None = None, tolerate_problems: bool = False
+) -> tuple[Config, str | None]:
     """
     Load the configuration from the specified directory
 
@@ -155,6 +180,18 @@ def _load_config(configuration_directory: Path | None = None) -> Config:
     :
         The configuration loaded from the specified directory
     """
+    if tolerate_problems:
+        if configuration_directory:
+            target = configuration_directory / CONFIG_FILENAME
+        else:
+            target = env.path("REF_CONFIGURATION") / CONFIG_FILENAME
+        try:
+            return Config.load(target, allow_missing=True), None
+        except Exception as exc:
+            config = Config()
+            config._config_file = target
+            return config, str(exc)
+
     try:
         if configuration_directory:
             config = Config.load(configuration_directory / CONFIG_FILENAME, allow_missing=False)
@@ -163,7 +200,7 @@ def _load_config(configuration_directory: Path | None = None) -> Config:
     except FileNotFoundError:
         typer.secho("Configuration file not found", fg=typer.colors.RED)
         raise typer.Exit(1)
-    return config
+    return config, None
 
 
 def build_app() -> typer.Typer:
@@ -229,9 +266,9 @@ def main(  # noqa: PLR0913
         typer.Option("--quiet", "-q", help="Set the log level to WARNING"),
     ] = False,
     log_level: Annotated[
-        LogLevel,
+        LogLevel | None,
         typer.Option(case_sensitive=False, help="Set the level of logging information to display"),
-    ] = LogLevel.Info,
+    ] = None,
     version: Annotated[
         bool | None,
         typer.Option(
@@ -251,8 +288,13 @@ def main(  # noqa: PLR0913
 
     logger.remove()
 
-    config = _load_config(configuration_directory)
-    config.log_level = log_level.value
+    tolerate_config_problems = ctx.invoked_subcommand == "config" or _is_config_bootstrap_command()
+    config, config_load_error = _load_config(
+        configuration_directory,
+        tolerate_problems=tolerate_config_problems,
+    )
+    if log_level is not None:
+        config.log_level = log_level.value
 
     log_format = config.log_format
     initialise_logging(level=config.log_level, format=log_format, log_directory=config.paths.log)
@@ -266,7 +308,13 @@ def main(  # noqa: PLR0913
     # The database is only created when first accessed
     # Skip backup for read-only commands to reduce overhead
     skip_backup = _is_read_only_command()
-    cli_context = CLIContext(config=config, console=_create_console(), skip_backup=skip_backup)
+    cli_context = CLIContext(
+        config=config,
+        console=_create_console(),
+        configuration_directory=configuration_directory,
+        config_load_error=config_load_error,
+        skip_backup=skip_backup,
+    )
     ctx.obj = cli_context
 
     # Register cleanup to close database connection when CLI exits

--- a/packages/climate-ref/src/climate_ref/cli/_config_access.py
+++ b/packages/climate-ref/src/climate_ref/cli/_config_access.py
@@ -1,0 +1,141 @@
+"""Helpers for reading and updating dotted configuration keys."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, cast, get_args, get_origin
+
+import attrs
+from attrs import NOTHING, Attribute
+
+from climate_ref.config import _converter_defaults_relaxed
+
+
+class ConfigKeyError(KeyError):
+    """Raised when a dotted configuration key cannot be resolved."""
+
+    def __init__(self, key: str, segment: str) -> None:
+        super().__init__(key)
+        self.key = key
+        self.segment = segment
+
+
+def _field_map(obj: object) -> dict[str, Attribute[Any]]:
+    if not attrs.has(obj.__class__):
+        return {}
+    return {field.name: field for field in attrs.fields(obj.__class__)}
+
+
+def resolve_key(config: object, dotted: str) -> tuple[object, Attribute[Any], Any]:
+    """Resolve a dotted key to its parent object, attrs field and current value."""
+    if not dotted:
+        raise ConfigKeyError(dotted, dotted)
+
+    current = config
+    parts = dotted.split(".")
+    for index, part in enumerate(parts):
+        fields = _field_map(current)
+        field = fields.get(part)
+        if field is None:
+            raise ConfigKeyError(dotted, part)
+
+        value = getattr(current, field.name)
+        if index == len(parts) - 1:
+            return current, field, value
+        current = value
+
+    raise ConfigKeyError(dotted, dotted)  # pragma: no cover
+
+
+def env_var_for(parent: object, field: Attribute[Any]) -> str | None:
+    """Return the environment variable that overrides a field, if any."""
+    env_name = field.metadata.get("env")
+    if not env_name:
+        return None
+    prefix = getattr(parent, "_prefix", None)
+    if not prefix:
+        return None
+    return f"{prefix}_{env_name}"
+
+
+def _is_bool_type(field_type: Any) -> bool:
+    if field_type is bool:
+        return True
+    origin = get_origin(field_type)
+    if origin is None:
+        return False
+    return bool in get_args(field_type)
+
+
+def _parse_bool(raw: str) -> bool:
+    normalised = raw.strip().lower()
+    if normalised in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalised in {"0", "false", "no", "n", "off"}:
+        return False
+    raise ValueError("expected one of true/false/1/0/yes/no")
+
+
+def coerce_value(field: Attribute[Any], raw: str) -> Any:
+    """Coerce a CLI string to the type required by an attrs field."""
+    if _is_bool_type(field.type):
+        value: Any = _parse_bool(raw)
+    elif field.type is Path:
+        value = Path(raw)
+    else:
+        value = raw
+
+    if field.converter is not None:
+        return cast(Callable[[Any], Any], field.converter)(value)
+
+    if field.type is None:
+        return value
+    return _converter_defaults_relaxed.structure(value, field.type)
+
+
+def is_structured(value: Any, field: Attribute[Any]) -> bool:
+    """Return whether a field is too structured for scalar CLI set/unset."""
+    if isinstance(value, dict | list | tuple | set):
+        return True
+    if attrs.has(value.__class__) and not isinstance(value, Path):
+        return True
+
+    origin = get_origin(field.type)
+    if origin in {dict, list, tuple, set}:
+        return True
+    return isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray)
+
+
+def default_value(parent: object, field: Attribute[Any]) -> Any:
+    """Return the attrs default for a field without reading the current value."""
+    default = field.default
+    if default is NOTHING:
+        raise ValueError(f"Configuration key {field.name!r} has no default")
+
+    if hasattr(default, "factory") and hasattr(default, "takes_self"):
+        default_factory = cast(Any, default)
+        if default_factory.takes_self:
+            value = default_factory.factory(parent)
+        else:
+            value = default_factory.factory()
+    else:
+        value = default
+
+    if field.converter is not None:
+        return cast(Callable[[Any], Any], field.converter)(value)
+    return value
+
+
+def available_keys(config: object, prefix: str = "") -> list[str]:
+    """Return all dotted scalar configuration keys."""
+    keys: list[str] = []
+    for field in _field_map(config).values():
+        value = getattr(config, field.name)
+        dotted = f"{prefix}.{field.name}" if prefix else field.name
+        if is_structured(value, field):
+            if attrs.has(value.__class__) and not isinstance(value, Path):
+                keys.extend(available_keys(value, dotted))
+        else:
+            keys.append(dotted)
+    return keys

--- a/packages/climate-ref/src/climate_ref/cli/_config_access.py
+++ b/packages/climate-ref/src/climate_ref/cli/_config_access.py
@@ -24,7 +24,11 @@ class ConfigKeyError(KeyError):
 def _field_map(obj: object) -> dict[str, Attribute[Any]]:
     if not attrs.has(obj.__class__):
         return {}
-    return {field.name: field for field in attrs.fields(obj.__class__)}
+    return {
+        field.name: field
+        for field in attrs.fields(obj.__class__)
+        if field.init and not field.name.startswith("_")
+    }
 
 
 def resolve_key(config: object, dotted: str) -> tuple[object, Attribute[Any], Any]:

--- a/packages/climate-ref/src/climate_ref/cli/config.py
+++ b/packages/climate-ref/src/climate_ref/cli/config.py
@@ -2,12 +2,30 @@
 View and update the REF configuration
 """
 
-import json
-import tomllib
-from enum import StrEnum
-from typing import Annotated
+from __future__ import annotations
 
+import json
+import os
+import tomllib
+from difflib import get_close_matches
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated, Any, cast
+
+import click
 import typer
+from loguru import logger
+from tomlkit import TOMLDocument
+
+from climate_ref.cli._config_access import (
+    ConfigKeyError,
+    available_keys,
+    coerce_value,
+    default_value,
+    env_var_for,
+    is_structured,
+    resolve_key,
+)
 
 app = typer.Typer(help=__doc__)
 
@@ -17,6 +35,87 @@ class ConfigFormat(StrEnum):
 
     toml = "toml"
     json = "json"
+
+
+class ValidationFormat(StrEnum):
+    """Output format for the ``config validate`` command."""
+
+    text = "text"
+    json = "json"
+
+
+def _config_file(ctx: typer.Context) -> Path:
+    config_file = ctx.obj.config._config_file
+    if config_file is None:  # pragma: no cover
+        typer.secho("No configuration file location is configured.", fg=typer.colors.RED)
+        raise typer.Exit(1)
+    return cast(Path, config_file)
+
+
+def _ensure_config_loaded(ctx: typer.Context) -> None:
+    config_file = _config_file(ctx)
+    if ctx.obj.configuration_directory is not None and not config_file.is_file():
+        typer.secho("Configuration file not found", fg=typer.colors.RED)
+        raise typer.Exit(1)
+    if ctx.obj.config_load_error is not None:
+        typer.secho(
+            f"Error loading configuration from {config_file}: {ctx.obj.config_load_error}",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+
+def _print_key_error(config: Any, key: str) -> None:
+    typer.secho(f"Unknown configuration key: {key}", fg=typer.colors.RED, err=True)
+    matches = get_close_matches(key, available_keys(config), n=3)
+    if matches:
+        typer.secho(f"Did you mean: {', '.join(matches)}?", err=True)
+
+
+def _ensure_scalar(key: str, value: Any, field: Any) -> None:
+    if is_structured(value, field):
+        typer.secho(
+            f"Editing structured configuration values from the CLI is not supported: {key}. "
+            "Edit ref.toml directly.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
+def _warn_if_env_shadowed(parent: object, field: Any, key: str) -> None:
+    env_var = env_var_for(parent, field)
+    if env_var and os.environ.get(env_var) is not None:
+        typer.secho(
+            f"Warning: {key} is overridden by environment variable {env_var}; "
+            "the file change may not take effect until it is unset.",
+            fg=typer.colors.YELLOW,
+            err=True,
+        )
+
+
+def _stringify_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _toml_for_key(config: Any, dotted: str) -> str:
+    node: Any = config.dump(defaults=True)
+    for part in dotted.split("."):
+        node = node[part]
+
+    doc = TOMLDocument()
+    doc[dotted.rsplit(".", maxsplit=1)[-1]] = node
+    return doc.as_string()
+
+
+def _validation_payload(errors: list[str]) -> dict[str, Any]:
+    return {
+        "valid": not errors,
+        "error_count": len(errors),
+        "diagnostics": [{"severity": "error", "message": error} for error in errors],
+    }
 
 
 @app.command(name="list")
@@ -33,6 +132,7 @@ def list_(
     If a configuration directory is provided,
     the configuration will attempt to load from the specified directory.
     """
+    _ensure_config_loaded(ctx)
     config = ctx.obj.config
 
     rendered = config.dumps(defaults=True)
@@ -42,9 +142,204 @@ def list_(
         print(rendered)
 
 
-# @app.command()
-# def update() -> None:
-#     """
-#     Update a configuration value
-#     """
-#     print("config")
+@app.command(name="init")
+def init(
+    ctx: typer.Context,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Overwrite an existing ref.toml with a fresh template."),
+    ] = False,
+    no_defaults: Annotated[
+        bool,
+        typer.Option("--no-defaults", help="Write a minimal template that omits default values."),
+    ] = False,
+) -> None:
+    """
+    Create a ref.toml configuration file for onboarding.
+
+    By default this writes a complete template with defaults included. ``--force`` is destructive:
+    it replaces any existing configuration file with a fresh template.
+    """
+    config = ctx.obj.config
+    config_file = _config_file(ctx)
+
+    if config_file.exists() and not force:
+        typer.secho(
+            f"Configuration already exists at {config_file}. Use --force to overwrite.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    if no_defaults:
+        config_file.write_text(config.dumps(defaults=False))
+    else:
+        config.save(config_file)
+
+    action = "Overwrote" if force else "Wrote"
+    ctx.obj.console.print(f"{action} configuration file at {config_file}")
+    ctx.obj.console.print("\nNext steps:")
+    ctx.obj.console.print("  1. Set REF_CONFIGURATION to this directory if needed.")
+    ctx.obj.console.print("  2. Edit ref.toml for your paths, database, executor and providers.")
+    ctx.obj.console.print("  3. Run `ref config validate`.")
+    ctx.obj.console.print("  4. Run `ref providers list`, then `ref solve` when data is available.")
+
+
+@app.command(name="get")
+def get(ctx: typer.Context, key: Annotated[str, typer.Argument(help="Dotted configuration key")]) -> None:
+    """
+    Print one effective configuration value.
+
+    Environment variables are already applied, so this shows the value the REF will use at runtime.
+    Scalar values are printed alone on stdout for scripts; structured sections are printed as TOML.
+    """
+    _ensure_config_loaded(ctx)
+    config = ctx.obj.config
+    try:
+        parent, field, value = resolve_key(config, key)
+    except ConfigKeyError:
+        _print_key_error(config, key)
+        raise typer.Exit(1)
+
+    env_var = env_var_for(parent, field)
+    if env_var and os.environ.get(env_var) is not None:
+        logger.info(f"{key} is overridden by environment variable {env_var}; showing the effective value.")
+
+    if is_structured(value, field):
+        print(_toml_for_key(config, key))
+    else:
+        print(_stringify_scalar(value))
+
+
+@app.command(name="set")
+def set_(
+    ctx: typer.Context,
+    key: Annotated[str, typer.Argument(help="Dotted scalar configuration key")],
+    value: Annotated[str, typer.Argument(help="New value")],
+) -> None:
+    """
+    Set one scalar configuration value and persist it to ref.toml.
+
+    This rewrites the whole configuration file from the in-memory model, so comments and custom key
+    ordering in a hand-edited file are not preserved.
+    """
+    _ensure_config_loaded(ctx)
+    config = ctx.obj.config
+    try:
+        parent, field, current_value = resolve_key(config, key)
+    except ConfigKeyError:
+        _print_key_error(config, key)
+        raise typer.Exit(1)
+
+    _ensure_scalar(key, current_value, field)
+    try:
+        coerced = coerce_value(field, value)
+    except Exception as exc:
+        typer.secho(f"Invalid value for {key}: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+    setattr(parent, field.name, coerced)
+    config.save()
+    _warn_if_env_shadowed(parent, field, key)
+    typer.echo(f"{key} = {_stringify_scalar(coerced)}")
+    typer.echo(f"Saved to {config._config_file}")
+
+
+@app.command(name="unset")
+def unset(
+    ctx: typer.Context,
+    key: Annotated[str, typer.Argument(help="Dotted scalar configuration key")],
+) -> None:
+    """
+    Reset one scalar configuration value to its default and persist it to ref.toml.
+
+    Structured values such as provider lists and executor config dictionaries must be edited directly.
+    """
+    _ensure_config_loaded(ctx)
+    config = ctx.obj.config
+    try:
+        parent, field, current_value = resolve_key(config, key)
+    except ConfigKeyError:
+        _print_key_error(config, key)
+        raise typer.Exit(1)
+
+    _ensure_scalar(key, current_value, field)
+    try:
+        reset_value = default_value(parent, field)
+    except ValueError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+    setattr(parent, field.name, reset_value)
+    config.save()
+    _warn_if_env_shadowed(parent, field, key)
+    typer.echo(f"{key} reset to default {_stringify_scalar(reset_value)}")
+    typer.echo(f"Saved to {config._config_file}")
+
+
+@app.command(name="edit")
+def edit(ctx: typer.Context) -> None:
+    """
+    Open ref.toml in the user's editor and warn if the result is invalid.
+
+    The editor is selected by Click from ``$VISUAL`` / ``$EDITOR``. If no config file exists yet,
+    run ``ref config init`` first.
+    """
+    _ensure_config_loaded(ctx)
+    config_file = _config_file(ctx)
+    if not config_file.is_file():
+        typer.secho(
+            f"No configuration file found at {config_file}. Run `ref config init` first.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    click.edit(filename=str(config_file))
+    errors = ctx.obj.config.collect_validation_errors(config_file)
+    if errors:
+        typer.secho(
+            f"Configuration at {config_file} is invalid after editing:",
+            fg=typer.colors.YELLOW,
+            err=True,
+        )
+        for error in errors:
+            typer.secho(f"  - {error}", fg=typer.colors.YELLOW, err=True)
+    else:
+        typer.echo(f"Edited {config_file}")
+
+
+@app.command(name="validate")
+def validate(
+    ctx: typer.Context,
+    output_format: Annotated[
+        ValidationFormat,
+        typer.Option("--format", help="Output format: 'text' (default) or machine-readable 'json'."),
+    ] = ValidationFormat.text,
+) -> None:
+    """
+    Validate that ref.toml parses and matches the REF configuration schema.
+
+    The exit code is the CI contract: 0 means valid and 1 means invalid. JSON output includes a
+    Terraform-style ``valid`` flag, error count and diagnostics list.
+    """
+    config_file = _config_file(ctx)
+    if not config_file.is_file():
+        if output_format == ValidationFormat.json:
+            payload = _validation_payload([f"No configuration file found at {config_file}."])
+            print(json.dumps(payload, indent=2))
+        else:
+            typer.secho(f"No configuration file found at {config_file}.", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    errors = ctx.obj.config.collect_validation_errors(config_file)
+    if output_format == ValidationFormat.json:
+        print(json.dumps(_validation_payload(errors), indent=2))
+    elif errors:
+        typer.secho(f"Configuration at {config_file} is invalid:", fg=typer.colors.RED)
+        for error in errors:
+            typer.echo(f"  - {error}")
+    else:
+        typer.secho(f"Configuration at {config_file} is valid.", fg=typer.colors.GREEN)
+
+    if errors:
+        raise typer.Exit(1)

--- a/packages/climate-ref/src/climate_ref/cli/config.py
+++ b/packages/climate-ref/src/climate_ref/cli/config.py
@@ -7,12 +7,16 @@ from __future__ import annotations
 import json
 import os
 import tomllib
+from collections.abc import Iterator, MutableMapping
+from contextlib import contextmanager
 from difflib import get_close_matches
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any, cast
 
+import attrs
 import click
+import tomlkit
 import typer
 from loguru import logger
 from tomlkit import TOMLDocument
@@ -118,6 +122,80 @@ def _validation_payload(errors: list[str]) -> dict[str, Any]:
     }
 
 
+def _config_env_vars(config: object) -> set[str]:
+    if not attrs.has(config.__class__):
+        return set()
+
+    env_vars: set[str] = set()
+    prefix = getattr(config, "_prefix", None)
+    for field in attrs.fields(config.__class__):
+        env_name = field.metadata.get("env")
+        if prefix and env_name:
+            env_vars.add(f"{prefix}_{env_name}")
+
+        if not field.name.startswith("_"):
+            value = getattr(config, field.name, None)
+            env_vars.update(_config_env_vars(value))
+
+    return env_vars
+
+
+@contextmanager
+def _without_config_env_overrides(config: object) -> Iterator[None]:
+    saved = {name: os.environ.get(name) for name in _config_env_vars(config)}
+    try:
+        for name in saved:
+            os.environ.pop(name, None)
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _load_config_document(config_file: Path) -> TOMLDocument:
+    if not config_file.is_file():
+        return TOMLDocument()
+    with config_file.open() as fh:
+        return tomlkit.load(fh)
+
+
+def _toml_scalar(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def _set_config_document_key(doc: TOMLDocument, dotted: str, value: Any) -> None:
+    node: MutableMapping[str, Any] = doc
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        child = node.get(part)
+        if not isinstance(child, MutableMapping):
+            child = tomlkit.table()
+            node[part] = child
+        node = child
+    node[parts[-1]] = _toml_scalar(value)
+
+
+def _unset_config_document_key(doc: TOMLDocument, dotted: str) -> None:
+    node: MutableMapping[str, Any] = doc
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        child = node.get(part)
+        if not isinstance(child, MutableMapping):
+            return
+        node = child
+    node.pop(parts[-1], None)
+
+
+def _write_config_document(config_file: Path, doc: TOMLDocument) -> None:
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(doc.as_string())
+
+
 @app.command(name="list")
 def list_(
     ctx: typer.Context,
@@ -170,11 +248,15 @@ def init(
         )
         raise typer.Exit(1)
 
+    with _without_config_env_overrides(config):
+        template_config = config.__class__()
+    template_config._config_file = config_file
+
     config_file.parent.mkdir(parents=True, exist_ok=True)
     if no_defaults:
-        config_file.write_text(config.dumps(defaults=False))
+        config_file.write_text(template_config.dumps(defaults=False))
     else:
-        config.save(config_file)
+        template_config.save(config_file)
 
     action = "Overwrote" if force else "Wrote"
     ctx.obj.console.print(f"{action} configuration file at {config_file}")
@@ -220,8 +302,8 @@ def set_(
     """
     Set one scalar configuration value and persist it to ref.toml.
 
-    This rewrites the whole configuration file from the in-memory model, so comments and custom key
-    ordering in a hand-edited file are not preserved.
+    The value is written to the file-backed configuration, even when environment variables shadow
+    the effective runtime value.
     """
     _ensure_config_loaded(ctx)
     config = ctx.obj.config
@@ -239,7 +321,10 @@ def set_(
         raise typer.Exit(1)
 
     setattr(parent, field.name, coerced)
-    config.save()
+    config_file = _config_file(ctx)
+    doc = _load_config_document(config_file)
+    _set_config_document_key(doc, key, coerced)
+    _write_config_document(config_file, doc)
     _warn_if_env_shadowed(parent, field, key)
     typer.echo(f"{key} = {_stringify_scalar(coerced)}")
     typer.echo(f"Saved to {config._config_file}")
@@ -271,7 +356,10 @@ def unset(
         raise typer.Exit(1)
 
     setattr(parent, field.name, reset_value)
-    config.save()
+    config_file = _config_file(ctx)
+    doc = _load_config_document(config_file)
+    _unset_config_document_key(doc, key)
+    _write_config_document(config_file, doc)
     _warn_if_env_shadowed(parent, field, key)
     typer.echo(f"{key} reset to default {_stringify_scalar(reset_value)}")
     typer.echo(f"Saved to {config._config_file}")
@@ -285,7 +373,6 @@ def edit(ctx: typer.Context) -> None:
     The editor is selected by Click from ``$VISUAL`` / ``$EDITOR``. If no config file exists yet,
     run ``ref config init`` first.
     """
-    _ensure_config_loaded(ctx)
     config_file = _config_file(ctx)
     if not config_file.is_file():
         typer.secho(

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -584,6 +584,8 @@ class Config:
         try:
             with config_file.open() as fh:
                 doc = tomlkit.load(fh)
+            if "ignore_datasets_file" not in doc:
+                doc["ignore_datasets_file"] = str(config_file.parent / "__validation_ignore_datasets.yaml")
             _converter_defaults.structure(doc, cls)
         except Exception as exc:
             return transform_error(exc, format_exception=_format_exception)

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -566,6 +566,29 @@ class Config:
         config._config_file = config_file
         return config
 
+    @classmethod
+    def collect_validation_errors(cls, config_file: Path) -> list[str]:
+        """
+        Collect strict validation errors for a configuration file.
+
+        Parameters
+        ----------
+        config_file
+            Path to the configuration file to validate.
+
+        Returns
+        -------
+        :
+            A list of validation errors. An empty list means the file is valid.
+        """
+        try:
+            with config_file.open() as fh:
+                doc = tomlkit.load(fh)
+            _converter_defaults.structure(doc, cls)
+        except Exception as exc:
+            return transform_error(exc, format_exception=_format_exception)
+        return []
+
     def refresh(self) -> "Config":
         """
         Refresh the configuration values

--- a/packages/climate-ref/tests/unit/cli/test_config.py
+++ b/packages/climate-ref/tests/unit/cli/test_config.py
@@ -1,3 +1,13 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from climate_ref.cli._config_access import coerce_value, resolve_key
+from climate_ref.config import Config
+from climate_ref.constants import CONFIG_FILENAME
+
+
 def test_without_subcommand(invoke_cli):
     # exit code 2 denotes a user error
     result = invoke_cli(["config"], expected_exit_code=2)
@@ -30,8 +40,6 @@ class TestConfigList:
         assert "Configuration file not found" in result.stdout
 
     def test_config_list_json(self, config, invoke_cli):
-        import json
-
         result = invoke_cli(["config", "list", "--format", "json"])
 
         # Output must be valid JSON (the TOML structure rendered as nested objects).
@@ -40,9 +48,245 @@ class TestConfigList:
         assert "sqlite://" in json.dumps(payload)
 
 
-# class TestConfigUpdate:
-#     def test_config_update(self, invoke_cli):
-#         result = invoke_cli(["config", "update"])
-#
-#         # TODO: actually implement this functionality
-#         assert "config" in result.stdout
+class TestConfigInit:
+    def test_init_create_from_scratch(self, tmp_path, invoke_cli):
+        config_dir = tmp_path / "new-config"
+
+        result = invoke_cli(["--configuration-directory", str(config_dir), "config", "init"])
+
+        assert (config_dir / CONFIG_FILENAME).is_file()
+        assert "Wrote configuration file" in result.stdout
+        assert "ref config validate" in result.stdout
+
+    def test_init_refuses_existing_file(self, config, invoke_cli):
+        result = invoke_cli(["config", "init"], expected_exit_code=1)
+
+        assert "Configuration already exists" in result.stdout
+        assert "--force" in result.stdout
+
+    def test_init_force_overwrites(self, config, invoke_cli):
+        assert config._config_file is not None
+        config._config_file.write_text("not valid toml")
+
+        result = invoke_cli(["config", "init", "--force"])
+
+        assert "Overwrote configuration file" in result.stdout
+        assert "not valid toml" not in config._config_file.read_text()
+
+    def test_init_no_defaults_writes_smaller_file(self, tmp_path, invoke_cli):
+        full_dir = tmp_path / "full"
+        minimal_dir = tmp_path / "minimal"
+
+        invoke_cli(["--configuration-directory", str(full_dir), "config", "init"])
+        invoke_cli(["--configuration-directory", str(minimal_dir), "config", "init", "--no-defaults"])
+
+        assert (minimal_dir / CONFIG_FILENAME).stat().st_size < (full_dir / CONFIG_FILENAME).stat().st_size
+
+    def test_init_output_validates(self, tmp_path, invoke_cli):
+        config_dir = tmp_path / "new-config"
+
+        invoke_cli(["--configuration-directory", str(config_dir), "config", "init"])
+        result = invoke_cli(["--configuration-directory", str(config_dir), "config", "validate"])
+
+        assert "is valid" in result.stdout
+
+
+class TestConfigGet:
+    def test_get_scalar(self, invoke_cli):
+        result = invoke_cli(["config", "get", "db.database_url"])
+
+        assert "sqlite://" in result.stdout
+        assert result.stdout.strip().startswith("sqlite://")
+
+    def test_get_top_level_scalar(self, invoke_cli):
+        result = invoke_cli(["config", "get", "log_level"])
+
+        assert result.stdout.strip() == "INFO"
+
+    def test_get_subtable_as_toml(self, invoke_cli):
+        result = invoke_cli(["config", "get", "paths"])
+
+        assert "[paths]" in result.stdout
+        assert "scratch" in result.stdout
+
+    def test_get_unknown_key(self, invoke_cli):
+        result = invoke_cli(["config", "get", "not.real"], expected_exit_code=1)
+
+        assert "Unknown configuration key: not.real" in result.stderr
+
+    def test_get_warns_when_env_overrides(self, monkeypatch, invoke_cli):
+        monkeypatch.setenv("REF_DATABASE_URL", "sqlite:///env.db")
+
+        result = invoke_cli(["config", "get", "db.database_url"])
+
+        assert result.stdout.strip() == "sqlite:///env.db"
+        assert "REF_DATABASE_URL" in result.stderr
+
+
+class TestConfigSet:
+    def test_set_scalar_and_persist(self, config, invoke_cli):
+        assert config._config_file is not None
+
+        invoke_cli(["config", "set", "log_level", "DEBUG"])
+        result = invoke_cli(["config", "get", "log_level"])
+
+        assert result.stdout.strip() == "DEBUG"
+        assert 'log_level = "DEBUG"' in config._config_file.read_text()
+
+    def test_set_invalid_literal(self, invoke_cli):
+        result = invoke_cli(["config", "set", "cmip6_parser", "bogus"], expected_exit_code=1)
+
+        assert "Invalid value for cmip6_parser" in result.stderr
+
+    def test_set_unknown_key(self, invoke_cli):
+        result = invoke_cli(["config", "set", "not.real", "x"], expected_exit_code=1)
+
+        assert "Unknown configuration key: not.real" in result.stderr
+
+    def test_set_rejects_structured_key(self, invoke_cli):
+        result = invoke_cli(["config", "set", "diagnostic_providers", "x"], expected_exit_code=1)
+
+        assert "Editing structured configuration values" in result.stderr
+
+    def test_set_warns_when_env_overrides(self, monkeypatch, invoke_cli):
+        monkeypatch.setenv("REF_DATABASE_URL", "sqlite:///env.db")
+
+        result = invoke_cli(["config", "set", "db.database_url", "sqlite:///file.db"])
+
+        assert "REF_DATABASE_URL" in result.stderr
+        assert "db.database_url = sqlite:///file.db" in result.stdout
+
+
+class TestConfigUnset:
+    def test_unset_resets_to_default(self, invoke_cli):
+        invoke_cli(["config", "set", "log_level", "DEBUG"])
+        invoke_cli(["config", "unset", "log_level"])
+        result = invoke_cli(["config", "get", "log_level"])
+
+        assert result.stdout.strip() == "INFO"
+
+    def test_unset_unknown_key(self, invoke_cli):
+        result = invoke_cli(["config", "unset", "not.real"], expected_exit_code=1)
+
+        assert "Unknown configuration key: not.real" in result.stderr
+
+    def test_unset_rejects_structured_key(self, invoke_cli):
+        result = invoke_cli(["config", "unset", "diagnostic_providers"], expected_exit_code=1)
+
+        assert "Editing structured configuration values" in result.stderr
+
+
+class TestConfigEdit:
+    def test_edit_runs_editor_and_validates(self, monkeypatch, config, invoke_cli):
+        assert config._config_file is not None
+        edited: list[str] = []
+
+        def fake_edit(*, filename: str) -> None:
+            edited.append(filename)
+
+        monkeypatch.setattr("climate_ref.cli.config.click.edit", fake_edit)
+
+        result = invoke_cli(["config", "edit"])
+
+        assert edited == [str(config._config_file)]
+        assert "Edited" in result.stdout
+
+    def test_edit_warns_when_result_invalid(self, monkeypatch, config, invoke_cli):
+        assert config._config_file is not None
+
+        def fake_edit(*, filename: str) -> None:
+            Path(filename).write_text("unknown = true\n")
+
+        monkeypatch.setattr("climate_ref.cli.config.click.edit", fake_edit)
+
+        result = invoke_cli(["config", "edit"])
+
+        assert result.exit_code == 0
+        assert "invalid after editing" in result.stderr
+        assert "unknown" in result.stderr
+
+
+class TestConfigValidate:
+    def test_validate_valid_config(self, invoke_cli):
+        result = invoke_cli(["config", "validate"])
+
+        assert "is valid" in result.stdout
+
+    def test_validate_invalid_config_runs_despite_bad_file(self, tmp_path, invoke_cli):
+        config_dir = tmp_path / "bad-config"
+        config_dir.mkdir()
+        (config_dir / CONFIG_FILENAME).write_text("unexpected = true\n")
+
+        result = invoke_cli(
+            ["--configuration-directory", str(config_dir), "config", "validate"],
+            expected_exit_code=1,
+        )
+
+        assert "is invalid" in result.stdout
+        assert "unexpected" in result.stdout
+
+    def test_validate_missing_config(self, tmp_path, invoke_cli):
+        result = invoke_cli(
+            ["--configuration-directory", str(tmp_path / "missing"), "config", "validate"],
+            expected_exit_code=1,
+        )
+
+        assert "No configuration file found" in result.stdout
+
+    def test_validate_valid_json(self, invoke_cli):
+        result = invoke_cli(["config", "validate", "--format", "json"])
+
+        payload = json.loads(result.stdout)
+        assert payload == {"valid": True, "error_count": 0, "diagnostics": []}
+
+    def test_validate_invalid_json(self, tmp_path, invoke_cli):
+        config_dir = tmp_path / "bad-config"
+        config_dir.mkdir()
+        (config_dir / CONFIG_FILENAME).write_text("unexpected = true\n")
+
+        result = invoke_cli(
+            ["--configuration-directory", str(config_dir), "config", "validate", "--format", "json"],
+            expected_exit_code=1,
+        )
+
+        payload = json.loads(result.stdout)
+        assert payload["valid"] is False
+        assert payload["error_count"] >= 1
+        assert "unexpected" in payload["diagnostics"][0]["message"]
+
+
+class TestConfigAccessHelpers:
+    def test_resolve_key(self):
+        config = Config()
+
+        parent, field, value = resolve_key(config, "paths.scratch")
+
+        assert field.name == "scratch"
+        assert getattr(parent, field.name) == value
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("false", False),
+            ("0", False),
+            ("yes", True),
+        ],
+    )
+    def test_coerce_bool(self, raw, expected):
+        config = Config()
+        _, field, _ = resolve_key(config, "db.run_migrations")
+
+        assert coerce_value(field, raw) is expected
+
+    def test_coerce_path(self):
+        config = Config()
+        _, field, _ = resolve_key(config, "paths.scratch")
+
+        assert coerce_value(field, "relative") == Path("relative").resolve()
+
+    def test_coerce_literal_rejects_unknown_value(self):
+        config = Config()
+        _, field, _ = resolve_key(config, "cmip6_parser")
+
+        with pytest.raises(Exception):
+            coerce_value(field, "bogus")

--- a/packages/climate-ref/tests/unit/cli/test_config.py
+++ b/packages/climate-ref/tests/unit/cli/test_config.py
@@ -1,9 +1,10 @@
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
-from climate_ref.cli._config_access import coerce_value, resolve_key
+from climate_ref.cli._config_access import available_keys, coerce_value, resolve_key
 from climate_ref.config import Config
 from climate_ref.constants import CONFIG_FILENAME
 
@@ -90,6 +91,14 @@ class TestConfigInit:
 
         assert "is valid" in result.stdout
 
+    def test_init_does_not_write_environment_overrides(self, monkeypatch, tmp_path, invoke_cli):
+        config_dir = tmp_path / "new-config"
+        monkeypatch.setenv("REF_DATABASE_URL", "sqlite:///env.db")
+
+        invoke_cli(["--configuration-directory", str(config_dir), "config", "init"])
+
+        assert "sqlite:///env.db" not in (config_dir / CONFIG_FILENAME).read_text()
+
 
 class TestConfigGet:
     def test_get_scalar(self, invoke_cli):
@@ -113,6 +122,11 @@ class TestConfigGet:
         result = invoke_cli(["config", "get", "not.real"], expected_exit_code=1)
 
         assert "Unknown configuration key: not.real" in result.stderr
+
+    def test_get_rejects_private_config_fields(self, invoke_cli):
+        result = invoke_cli(["config", "get", "_config_file"], expected_exit_code=1)
+
+        assert "Unknown configuration key: _config_file" in result.stderr
 
     def test_get_warns_when_env_overrides(self, monkeypatch, invoke_cli):
         monkeypatch.setenv("REF_DATABASE_URL", "sqlite:///env.db")
@@ -148,13 +162,27 @@ class TestConfigSet:
 
         assert "Editing structured configuration values" in result.stderr
 
-    def test_set_warns_when_env_overrides(self, monkeypatch, invoke_cli):
+    def test_set_warns_when_env_overrides(self, monkeypatch, config, invoke_cli):
+        assert config._config_file is not None
         monkeypatch.setenv("REF_DATABASE_URL", "sqlite:///env.db")
 
         result = invoke_cli(["config", "set", "db.database_url", "sqlite:///file.db"])
 
         assert "REF_DATABASE_URL" in result.stderr
         assert "db.database_url = sqlite:///file.db" in result.stdout
+        config_text = config._config_file.read_text()
+        assert "sqlite:///file.db" in config_text
+        assert "sqlite:///env.db" not in config_text
+
+    def test_set_does_not_write_unrelated_environment_overrides(self, monkeypatch, config, invoke_cli):
+        assert config._config_file is not None
+        monkeypatch.setenv("REF_DATABASE_URL", "sqlite:///env.db")
+
+        invoke_cli(["config", "set", "log_level", "DEBUG"])
+
+        config_text = config._config_file.read_text()
+        assert 'log_level = "DEBUG"' in config_text
+        assert "sqlite:///env.db" not in config_text
 
 
 class TestConfigUnset:
@@ -174,6 +202,14 @@ class TestConfigUnset:
         result = invoke_cli(["config", "unset", "diagnostic_providers"], expected_exit_code=1)
 
         assert "Editing structured configuration values" in result.stderr
+
+    def test_unset_does_not_write_unrelated_environment_overrides(self, monkeypatch, config, invoke_cli):
+        assert config._config_file is not None
+        monkeypatch.setenv("REF_DATABASE_URL", "sqlite:///env.db")
+
+        invoke_cli(["config", "unset", "log_level"])
+
+        assert "sqlite:///env.db" not in config._config_file.read_text()
 
 
 class TestConfigEdit:
@@ -204,6 +240,23 @@ class TestConfigEdit:
         assert result.exit_code == 0
         assert "invalid after editing" in result.stderr
         assert "unknown" in result.stderr
+
+    def test_edit_opens_malformed_file_for_repair(self, monkeypatch, tmp_path, invoke_cli):
+        config_dir = tmp_path / "bad-config"
+        config_dir.mkdir()
+        config_file = config_dir / CONFIG_FILENAME
+        config_file.write_text("not valid toml")
+
+        def fake_edit(*, filename: str) -> None:
+            Path(filename).write_text('log_level = "DEBUG"\n')
+
+        monkeypatch.setattr("climate_ref.cli.config.click.edit", fake_edit)
+
+        result = invoke_cli(["--configuration-directory", str(config_dir), "config", "edit"])
+
+        assert result.exit_code == 0
+        assert "Edited" in result.stdout
+        assert config_file.read_text() == 'log_level = "DEBUG"\n'
 
 
 class TestConfigValidate:
@@ -254,6 +307,16 @@ class TestConfigValidate:
         assert payload["error_count"] >= 1
         assert "unexpected" in payload["diagnostics"][0]["message"]
 
+    def test_validate_omitted_ignore_file_does_not_fetch_default(self, monkeypatch, tmp_path):
+        config_file = tmp_path / CONFIG_FILENAME
+        config_file.write_text('log_level = "INFO"\n')
+        request_get = Mock()
+        monkeypatch.setattr("climate_ref.config.platformdirs.user_cache_path", lambda _: tmp_path / "cache")
+        monkeypatch.setattr("climate_ref.config.requests.get", request_get)
+
+        assert Config.collect_validation_errors(config_file) == []
+        request_get.assert_not_called()
+
 
 class TestConfigAccessHelpers:
     def test_resolve_key(self):
@@ -263,6 +326,13 @@ class TestConfigAccessHelpers:
 
         assert field.name == "scratch"
         assert getattr(parent, field.name) == value
+
+    def test_private_fields_are_not_available(self):
+        config = Config()
+
+        assert "_config_file" not in available_keys(config)
+        with pytest.raises(Exception):
+            resolve_key(config, "_config_file")
 
     @pytest.mark.parametrize(
         "raw, expected",


### PR DESCRIPTION
## Description

Adds a fuller `ref config` management surface for onboarding and day-to-day configuration edits:

- `ref config init` creates a supported `ref.toml` template, with overwrite protection and `--no-defaults` support.
- `ref config get`, `set`, and `unset` support dotted scalar keys and environment override warnings.
- `ref config validate` validates the config file with text or JSON output and works even when the file is missing or malformed.
- `ref config edit` opens the active config file and reports post-edit validation issues.
- Updates configuration docs and getting-started onboarding to use `ref config init` / `validate`.

Validation performed:

- `uv run pytest packages/climate-ref/tests/unit/cli/test_config.py -q`
- `uv run pytest packages/climate-ref/tests/unit/cli -q`
- `uv run pytest packages/climate-ref/tests/unit/test_config.py -q`
- `uv run ruff check`
- `uv run ruff format --check`
- `make mypy`
- Manual smoke test for `init`, `validate`, `set`, `get`, and invalid-file validation.

Note: `uv run mkdocs build` currently fails on an existing notebook execution error in `docs/how-to-guides/running-diagnostics-locally.py`, unrelated to these changes.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ref config` CLI commands to initialise, view (`get`), change (`set`), reset (`unset`), edit (`edit`), and validate configuration (`validate`).
  * Added `validate` output options, including JSON suitable for scripting.
* **Bug Fixes**
  * Improved handling when configuration is missing or invalid, so more CLI commands fail gracefully.
  * Added clearer diagnostics for unknown keys/invalid edits and better visibility of environment-variable overrides.
* **Documentation**
  * Updated configuration guides with the new CLI workflow and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->