### PR TITLE
fix: widen contiguous-timerange tolerance for multi-file monthly data

### DIFF
--- a/changelog/774.fix.md
+++ b/changelog/774.fix.md
@@ -1,0 +1,1 @@
+Widened the contiguous-timerange tolerance so monthly datasets split across multiple files are no longer dropped as false-positive gaps.

--- a/packages/climate-ref-core/src/climate_ref_core/constraints.py
+++ b/packages/climate-ref-core/src/climate_ref_core/constraints.py
@@ -466,12 +466,10 @@ class RequireContiguousTimerange:
         """
         Check that all subgroups of the group have a contiguous timerange.
         """
-        # Maximum allowed time difference between the end of one file and the
-        # start of the next file.
-        max_timedelta = pd.Timedelta(
-            days=31,  # Maximum number of days in a month.
-            hours=1,  # Allow for potential rounding errors.
-        )
+        # Maximum allowed gap between the end of one file and the start of the
+        # next. Assumes monthly frequency: 45 days clears a monthly step while
+        # staying below two steps, so genuine month-sized holes still fail.
+        max_timedelta = pd.Timedelta(days=45)
 
         select = pd.Series(True, index=group.index)
 

--- a/packages/climate-ref-core/tests/unit/test_constraints.py
+++ b/packages/climate-ref-core/tests/unit/test_constraints.py
@@ -930,6 +930,40 @@ class TestContiguousTimerange:
         expected_data = data.loc[expected_rows]
         assert_frame_equal(self.constraint.apply(data, data.loc[[]]), expected_data)
 
+    def test_multi_file_monthly_wobbling_centers(self) -> None:
+        """Monthly data split across files with cell-centers on day 15 or 16 is accepted.
+
+        The 32-day gaps between consecutive file boundaries are contiguous
+        monthly data, not a real gap.
+        """
+        data = pd.DataFrame(
+            {
+                "variable_id": ["tas", "tas", "tas", "tas", "tas"],
+                "start_time": [
+                    datetime(500, 1, 16),
+                    datetime(600, 1, 16),
+                    datetime(700, 1, 16),
+                    datetime(800, 1, 16),
+                    datetime(900, 1, 16),
+                ],
+                "end_time": [
+                    datetime(599, 12, 15),
+                    datetime(699, 12, 16),
+                    datetime(799, 12, 15),
+                    datetime(899, 12, 15),
+                    datetime(999, 12, 16),
+                ],
+                "path": [
+                    "tas_Amon_NESM3_piControl_r1i1p1f1_gn_050001-059912.nc",
+                    "tas_Amon_NESM3_piControl_r1i1p1f1_gn_060001-069912.nc",
+                    "tas_Amon_NESM3_piControl_r1i1p1f1_gn_070001-079912.nc",
+                    "tas_Amon_NESM3_piControl_r1i1p1f1_gn_080001-089912.nc",
+                    "tas_Amon_NESM3_piControl_r1i1p1f1_gn_090001-099912.nc",
+                ],
+            }
+        )
+        assert_frame_equal(self.constraint.apply(data, data.loc[[]]), data)
+
     def test_cftime_same_calendar_contiguous(self) -> None:
         """Contiguous cftime dates with the same calendar are accepted."""
         data = pd.DataFrame(

--- a/packages/climate-ref-esmvaltool/tests/unit/test_solve_regression/test_solve_regression_equilibrium_climate_sensitivity_.yml
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_solve_regression/test_solve_regression_equilibrium_climate_sensitivity_.yml
@@ -357,6 +357,10 @@ cmip6_gn_r1i1p1f1_NESM3:
   - CMIP6.CMIP.NUIST.NESM3.abrupt-4xCO2.r1i1p1f1.Amon.rsdt.gn.v20190707
   - CMIP6.CMIP.NUIST.NESM3.abrupt-4xCO2.r1i1p1f1.Amon.rsut.gn.v20190707
   - CMIP6.CMIP.NUIST.NESM3.abrupt-4xCO2.r1i1p1f1.Amon.tas.gn.v20190707
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.rlut.gn.v20190708
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.rsdt.gn.v20190708
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.rsut.gn.v20190708
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.tas.gn.v20190708
 cmip6_gn_r1i1p1f1_NorCPM1:
   cmip6:
   - CMIP6.CMIP.NCC.NorCPM1.1pctCO2.r1i1p1f1.fx.areacella.gn.v20190914
@@ -1795,6 +1799,10 @@ cmip7_gn_NESM3_r1i1p1f1:
   - CMIP7.CMIP.NUIST.NESM3.abrupt-4xCO2.r1i1p1f1.glb.mon.rsdt.tavg-u-hxy-u.gn.v20190707
   - CMIP7.CMIP.NUIST.NESM3.abrupt-4xCO2.r1i1p1f1.glb.mon.rsut.tavg-u-hxy-u.gn.v20190707
   - CMIP7.CMIP.NUIST.NESM3.abrupt-4xCO2.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20190707
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.rlut.tavg-u-hxy-u.gn.v20190708
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.rsdt.tavg-u-hxy-u.gn.v20190708
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.rsut.tavg-u-hxy-u.gn.v20190708
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20190708
 cmip7_gn_NorCPM1_r1i1p1f1:
   cmip7:
   - CMIP7.CMIP.NCC.NorCPM1.abrupt-4xCO2.r1i1p1f1.glb.mon.rlut.tavg-u-hxy-u.gn.v20190914

--- a/packages/climate-ref-esmvaltool/tests/unit/test_solve_regression/test_solve_regression_global_mean_timeseries_.yml
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_solve_regression/test_solve_regression_global_mean_timeseries_.yml
@@ -1287,6 +1287,9 @@ cmip6_piControl_gn_r1i1p1f1_MRI-ESM2-0_Amon_tas:
   cmip6:
   - CMIP6.CMIP.MRI.MRI-ESM2-0.1pctCO2.r1i1p1f1.fx.areacella.gn.v20190603
   - CMIP6.CMIP.MRI.MRI-ESM2-0.piControl.r1i1p1f1.Amon.tas.gn.v20190222
+cmip6_piControl_gn_r1i1p1f1_NESM3_Amon_tas:
+  cmip6:
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.tas.gn.v20190708
 cmip6_piControl_gn_r1i1p1f1_NorCPM1_Amon_tas:
   cmip6:
   - CMIP6.CMIP.NCC.NorCPM1.1pctCO2.r1i1p1f1.fx.areacella.gn.v20190914
@@ -3488,6 +3491,9 @@ cmip7_piControl_gn_MRI-ESM2-0_tas_r1i2p1f1:
   cmip7:
   - CMIP7.CMIP.MRI.MRI-ESM2-0.1pctCO2.r1i1p1f1.glb.fx.areacella.ti-u-hxy-u.gn.v20190603
   - CMIP7.CMIP.MRI.MRI-ESM2-0.piControl.r1i2p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20191205
+cmip7_piControl_gn_NESM3_tas_r1i1p1f1:
+  cmip7:
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20190708
 cmip7_piControl_gn_NorCPM1_tas_r1i1p1f1:
   cmip7:
   - CMIP7.CMIP.NCC.NorCPM1.historical.r1i1p1f1.glb.fx.areacella.ti-u-hxy-u.gn.v20200724

--- a/packages/climate-ref-esmvaltool/tests/unit/test_solve_regression/test_solve_regression_transient_climate_response_.yml
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_solve_regression/test_solve_regression_transient_climate_response_.yml
@@ -155,6 +155,7 @@ cmip6_gn_r1i1p1f1_MRI-ESM2-0:
 cmip6_gn_r1i1p1f1_NESM3:
   cmip6:
   - CMIP6.CMIP.NUIST.NESM3.1pctCO2.r1i1p1f1.Amon.tas.gn.v20190707
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.tas.gn.v20190708
 cmip6_gn_r1i1p1f1_NorCPM1:
   cmip6:
   - CMIP6.CMIP.NCC.NorCPM1.1pctCO2.r1i1p1f1.Amon.tas.gn.v20190914
@@ -679,6 +680,7 @@ cmip7_gn_MRI-ESM2-0_r1i2p1f1:
 cmip7_gn_NESM3_r1i1p1f1:
   cmip7:
   - CMIP7.CMIP.NUIST.NESM3.1pctCO2.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20190707
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20190708
 cmip7_gn_NorCPM1_r1i1p1f1:
   cmip7:
   - CMIP7.CMIP.NCC.NorCPM1.1pctCO2.r1i1p1f1.glb.fx.areacella.ti-u-hxy-u.gn.v20190914

--- a/packages/climate-ref/tests/unit/test_solve_regression/test_solve_regression_global_mean_timeseries_.yml
+++ b/packages/climate-ref/tests/unit/test_solve_regression/test_solve_regression_global_mean_timeseries_.yml
@@ -2421,6 +2421,12 @@ cmip6_piControl_MRI-ESM2-0_tas_r1i2p1f1:
   cmip6:
   - CMIP6.CMIP.MRI.MRI-ESM2-0.1pctCO2.r1i1p1f1.fx.areacella.gn.v20190603
   - CMIP6.CMIP.MRI.MRI-ESM2-0.piControl.r1i2p1f1.Amon.tas.gn.v20191205
+cmip6_piControl_NESM3_rsut_r1i1p1f1:
+  cmip6:
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.rsut.gn.v20190708
+cmip6_piControl_NESM3_tas_r1i1p1f1:
+  cmip6:
+  - CMIP6.CMIP.NUIST.NESM3.piControl.r1i1p1f1.Amon.tas.gn.v20190708
 cmip6_piControl_NorCPM1_rsut_r1i1p1f1:
   cmip6:
   - CMIP6.CMIP.NCC.NorCPM1.1pctCO2.r1i1p1f1.fx.areacella.gn.v20190914
@@ -5611,6 +5617,12 @@ cmip7_piControl_MRI-ESM2-0_tas_r1i2p1f1:
   cmip7:
   - CMIP7.CMIP.MRI.MRI-ESM2-0.1pctCO2.r1i1p1f1.glb.fx.areacella.ti-u-hxy-u.gn.v20190603
   - CMIP7.CMIP.MRI.MRI-ESM2-0.piControl.r1i2p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20191205
+cmip7_piControl_NESM3_rsut_r1i1p1f1:
+  cmip7:
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.rsut.tavg-u-hxy-u.gn.v20190708
+cmip7_piControl_NESM3_tas_r1i1p1f1:
+  cmip7:
+  - CMIP7.CMIP.NUIST.NESM3.piControl.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v20190708
 cmip7_piControl_NorCPM1_rsut_r1i1p1f1:
   cmip7:
   - CMIP7.CMIP.NCC.NorCPM1.historical.r1i1p1f1.glb.fx.areacella.ti-u-hxy-u.gn.v20200724


### PR DESCRIPTION
`RequireContiguousTimerange` used a 31-day tolerance, but the gap between two consecutive monthly cell-centers spanning a long month is inherently ~31-32 days. Monthly parents split across multiple files (e.g. NESM3 `piControl`, which is century-chunked) were dropped as false-positive gaps, so downstream `AddSupplementaryDataset` had no parent to attach and the diagnostic failed with "no parent experiment."

Widen the tolerance to 45 days, which clears a full monthly step while staying below two steps so genuine month-sized holes still fail. This currently assumes monthly frequency; deriving the tolerance from dataset frequency (or comparing time bounds instead of cell-centers) is a follow-up.

Adds a regression test reproducing the NESM3 pattern (century-chunked monthly files with cell-centers wobbling between day 15 and 16).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Monthly datasets spanning multiple files are now less likely to be incorrectly rejected due to overly strict gap detection, improving contiguous time range checks.

* **Tests**
  * Added coverage for monthly multi-file datasets with boundary day wobble to confirm they’re treated as contiguous.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->