### PR TITLE
feat(pmp): key reference identity on reference_source_id and emit kind

### DIFF
--- a/changelog/775.feature.md
+++ b/changelog/775.feature.md
@@ -1,0 +1,7 @@
+Every PMP scalar metric value now keys its reference identity on `reference_source_id`
+and declares its role with the first-class `kind` of `model`.
+The ENSO diagnostics previously keyed reference identity on `reference_datasets`,
+so a consumer now reads reference identity the same way for every PMP diagnostic.
+ENSO references that the metrics package scores against two observation datasets jointly
+(for example `HadISST_GPCP-Monthly-3-2`) are kept as a single combined `reference_source_id` value,
+because the score is one value that depends on both references and cannot be split per reference.

--- a/changelog/775.fix.md
+++ b/changelog/775.fix.md
@@ -1,0 +1,5 @@
+Committed regression baselines no longer embed the machine-specific source-checkout path or the
+host operating system in provider command-line provenance.
+Both are now redacted to portable ``<SOURCE_DIR>`` and ``<OS>`` placeholders,
+so a baseline minted on one platform (for example macOS) reproduces one re-derived on another
+(for example Linux in CI) instead of drifting.

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/metric.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/metric.py
@@ -36,9 +36,13 @@ from pydantic.json_schema import GenerateJsonSchema, JsonSchemaMode, JsonSchemaV
 from pydantic_core import CoreSchema
 
 from climate_ref_core.env import env
-from climate_ref_core.metric_values import ScalarMetricValue
+from climate_ref_core.metric_values import MetricValueKind, ScalarMetricValue
 
 ALLOW_EXTRA_KEYS = env.bool("ALLOW_EXTRA_KEYS", default=True)
+
+# The CMEC dimension that carries a metric value's role. It is lifted out of the free
+# dimensions into ``ScalarMetricValue.kind`` (its own column) when a bundle declares it.
+_KIND_DIMENSION = "kind"
 
 
 class MetricCV(Enum):
@@ -535,6 +539,27 @@ class CMECMetric(BaseModel):
         yield from _walk_results(dimensions, self.RESULTS, {})
 
 
+def _build_scalar_value(metadata: dict[str, str], value: float, attributes: Any) -> ScalarMetricValue:
+    """
+    Build a scalar value, lifting ``kind`` out of the dimensions into its own field.
+
+    ``kind`` is carried as an ordinary CMEC dimension in the bundle so a producer can declare
+    a value's role inline, but on the value it is a first-class field with its own database
+    column. It is therefore removed from the free dimensions here. A bundle that does not carry
+    a ``kind`` dimension is unchanged: the field keeps its default, so existing baselines and
+    providers that predate the contract are unaffected.
+    """
+    kind = metadata.get(_KIND_DIMENSION)
+    dimensions = {k: v for k, v in metadata.items() if k != _KIND_DIMENSION}
+    if kind is None:
+        return ScalarMetricValue(dimensions=dimensions, value=value, attributes=attributes)
+    # ``kind`` comes from the untyped JSON dimensions; the model's Literal field still
+    # validates it at construction, so an unknown role is rejected rather than trusted.
+    return ScalarMetricValue(
+        dimensions=dimensions, value=value, kind=cast(MetricValueKind, kind), attributes=attributes
+    )
+
+
 def _walk_results(
     dimensions: list[str], results: dict[str, Any], metadata: dict[str, str]
 ) -> Generator[ScalarMetricValue]:
@@ -545,16 +570,12 @@ def _walk_results(
             continue
         metadata[dimension] = key
         if isinstance(value, float | int):
-            yield ScalarMetricValue(
-                dimensions=metadata, value=value, attributes=results.get(MetricCV.ATTRIBUTES.value)
-            )
+            yield _build_scalar_value(metadata, value, results.get(MetricCV.ATTRIBUTES.value))
         elif value is None:
             # Replace any None values with NaN
             # This translates null values in JSON to Python NaN's
             # Missing values are different from NaN values
-            yield ScalarMetricValue(
-                dimensions=metadata, value=np.nan, attributes=results.get(MetricCV.ATTRIBUTES.value)
-            )
+            yield _build_scalar_value(metadata, np.nan, results.get(MetricCV.ATTRIBUTES.value))
         else:
             yield from _walk_results(dimensions[1:], value, {**metadata})
 

--- a/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/capture.py
@@ -21,6 +21,7 @@ It produces two things:
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -53,22 +54,30 @@ _COMMITTED_JSON_DUMP_KWARGS: dict[str, object] = {
 # output bundle's lowercase ``provenance`` block; series.json never carries one.
 _PROVENANCE_BLOCK_KEYS: frozenset[str] = frozenset({"PROVENANCE", "provenance"})
 
-# Provenance fields redacted to stable placeholders so the committed bundle stays portable
-# (machine-independent) and reproducible: ``userId`` is the minting user and ``date`` is a
-# non-reproducible wall-clock timestamp. Absolute paths in ``commandLine`` are made portable
-# by path placeholdering (``<OUTPUT_DIR>`` / ``<SOFTWARE_ROOT_DIR>``), not by redaction.
+# Redacted to stable placeholders so committed bundles are machine-independent.
 _REDACTED_PROVENANCE_FIELDS: dict[str, str] = {
     "userId": "<USER>",
     "date": "<DATE>",
 }
 
-# Host fields in the provenance ``platform`` sub-block: ``Name`` (hostname) and ``Version`` (kernel)
-# leak host identity and churn the committed digest across machines, so they are redacted; the coarse
-# ``OS`` carries no host identity and is kept.
+# ``platform`` sub-block fields, redacted so a baseline is portable across hosts and OSes
+# (a ``Darwin`` mint must match a ``Linux`` CI execute).
 _REDACTED_PROVENANCE_PLATFORM_FIELDS: dict[str, str] = {
     "Name": "<HOSTNAME>",
     "Version": "<HOST_VERSION>",
+    "OS": "<OS>",
 }
+
+_SOURCE_DIR_PLACEHOLDER = "<SOURCE_DIR>"
+
+# Matches the machine-specific prefix before ``/packages/climate-ref-<pkg>/`` in in-repo paths.
+# Checkout-agnostic, so Linux and macOS checkouts redact to identical bytes.
+_SOURCE_PATH_RE = re.compile(r'(?:/[^\s"]*?)/packages/(climate-ref-[A-Za-z0-9_.-]+/)')
+
+
+def _redact_source_paths(text: str) -> str:
+    """Redact the checkout-root prefix of in-repo package paths (e.g. a provenance ``commandLine``)."""
+    return _SOURCE_PATH_RE.sub(rf"{_SOURCE_DIR_PLACEHOLDER}/packages/\1", text)
 
 
 def _redact_fields(block: dict[str, object], fields: dict[str, str]) -> bool:
@@ -118,7 +127,8 @@ def _canonicalise_committed_bundle(regression_dir: Path) -> None:
     For each file in :data:`COMMITTED_BUNDLE_FILES` that is present:
     round floats to a stable precision (:func:`~climate_ref_core.regression._quantise.round_floats`),
     redact host/user CMEC provenance (:func:`_redact_provenance_fields`),
-    then re-serialise with :data:`_COMMITTED_JSON_DUMP_KWARGS`.
+    re-serialise with :data:`_COMMITTED_JSON_DUMP_KWARGS`,
+    then redact the checkout-root prefix of in-repo command-line paths (:func:`_redact_source_paths`).
 
     The same transform runs on every file so the committed files are deterministic
     regardless of how the diagnostic originally serialised them,
@@ -137,10 +147,9 @@ def _canonicalise_committed_bundle(regression_dir: Path) -> None:
         _redact_provenance_fields(data)
         # Terminate with a newline so the committed bytes match the manifest serialisation
         # (Manifest.save) and satisfy POSIX/end-of-file-fixer conventions.
-        path.write_text(
-            json.dumps(data, **_COMMITTED_JSON_DUMP_KWARGS) + "\n",  # type: ignore[arg-type]
-            encoding="utf-8",
-        )
+        serialised = json.dumps(data, **_COMMITTED_JSON_DUMP_KWARGS) + "\n"  # type: ignore[arg-type]
+        # Text pass: the paths live inside string values, not their own JSON fields.
+        path.write_text(_redact_source_paths(serialised), encoding="utf-8")
 
 
 def write_committed_bundle(

--- a/packages/climate-ref-core/tests/unit/pycmec/test_cmec_metric.py
+++ b/packages/climate-ref-core/tests/unit/pycmec/test_cmec_metric.py
@@ -480,6 +480,44 @@ def test_iter_results(cmec_metric):
     assert list(cmec_metric.iter_results())
 
 
+def test_iter_results_lifts_kind():
+    # A ``kind`` dimension in the bundle is lifted onto the value's first-class ``kind``
+    # field and removed from the free dimensions (it has its own database column).
+    bundle = CMECMetric(
+        DIMENSIONS={
+            "json_structure": ["kind", "source_id", "metric"],
+            "kind": {"reference": {}},
+            "source_id": {"ACCESS-ESM1-5": {}},
+            "metric": {"rmse": {}},
+        },
+        RESULTS={"reference": {"ACCESS-ESM1-5": {"rmse": 1.5}}},
+    )
+
+    (value,) = list(bundle.iter_results())
+
+    assert value.kind == "reference"
+    assert "kind" not in value.dimensions
+    assert value.dimensions == {"source_id": "ACCESS-ESM1-5", "metric": "rmse"}
+
+
+def test_iter_results_without_kind_defaults_to_model():
+    # A bundle that predates the contract (no ``kind`` dimension) is unchanged: the value
+    # keeps the default role and its dimensions are untouched.
+    bundle = CMECMetric(
+        DIMENSIONS={
+            "json_structure": ["source_id", "metric"],
+            "source_id": {"ACCESS-ESM1-5": {}},
+            "metric": {"rmse": {}},
+        },
+        RESULTS={"ACCESS-ESM1-5": {"rmse": 2.0}},
+    )
+
+    (value,) = list(bundle.iter_results())
+
+    assert value.kind == "model"
+    assert value.dimensions == {"source_id": "ACCESS-ESM1-5", "metric": "rmse"}
+
+
 def test_iter_results_empty(cmec_right_metric_dict):
     cmec_metric = CMECMetric.model_validate(CMECMetric.create_template())
     assert not list(cmec_metric.iter_results())

--- a/packages/climate-ref-core/tests/unit/regression/test_capture.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_capture.py
@@ -14,6 +14,7 @@ from climate_ref_core.output_files import (
 )
 from climate_ref_core.pycmec.output import CMECOutput
 from climate_ref_core.regression.capture import (
+    _redact_source_paths,
     build_native_snapshot,
     capture_execution,
     materialise_native,
@@ -231,10 +232,10 @@ def test_write_committed_bundle_redacts_and_placeholders_provenance(tmp_path):
     diag = json.loads((regression_dir / "diagnostic.json").read_text())
     assert diag["PROVENANCE"]["userId"] == "<USER>"
     assert diag["PROVENANCE"]["date"] == "<DATE>"
-    # Host fields redacted; coarse OS kept as portable context.
+    # Host and platform fields redacted so a baseline stays portable across machines and OSes.
     assert diag["PROVENANCE"]["platform"]["Name"] == "<HOSTNAME>"
     assert diag["PROVENANCE"]["platform"]["Version"] == "<HOST_VERSION>"
-    assert diag["PROVENANCE"]["platform"]["OS"] == "Linux"
+    assert diag["PROVENANCE"]["platform"]["OS"] == "<OS>"
     assert diag["RESULTS"]["score"] == 1.234568
 
     # output.json is re-dumped canonically (sorted keys); every provenance key is still present.
@@ -267,6 +268,28 @@ def test_redaction_leaves_clean_provenance_untouched(tmp_path):
     # The committed file is valid canonical JSON with sorted keys.
     out = json.loads(text)
     assert list(out.keys()) == sorted(out.keys())
+
+
+def test_redact_source_paths_is_checkout_agnostic():
+    # A committed baseline minted on one machine and re-derived on another must redact the in-repo
+    # driver/param path prefix to the same token regardless of the checkout root.
+    suffix = "packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --mc ENSO"
+    mac = f"python /Users/jane/code/climate-ref/{suffix}"
+    linux = f"python /home/ci/work/climate-ref/{suffix}"
+    expected = f"python <SOURCE_DIR>/{suffix}"
+    assert _redact_source_paths(mac) == expected
+    assert _redact_source_paths(linux) == expected
+
+
+def test_redact_source_paths_leaves_other_tokens_untouched():
+    # Already-portable placeholders (conda software root, test data, output dir) are not in-repo
+    # package paths and must survive the source-path redaction unchanged.
+    for token_path in (
+        "<SOFTWARE_ROOT_DIR>/conda/pmp-abc/bin/mean_climate_driver",
+        "<TEST_DATA_DIR>/enso_tel/cmip6/regression",
+        "<OUTPUT_DIR>/input_ENSO.json",
+    ):
+        assert _redact_source_paths(token_path) == token_path
 
 
 def test_build_native_snapshot_digests_relpaths(tmp_path):

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/annual_cycle.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/annual_cycle.py
@@ -280,6 +280,7 @@ class AnnualCycle(CommandLineDiagnostic):
     name = "Annual Cycle"
     slug = "annual-cycle"
     facets = (
+        "kind",
         "mip_id",
         "source_id",
         "member_id",
@@ -290,7 +291,7 @@ class AnnualCycle(CommandLineDiagnostic):
         "statistic",
         "season",
     )
-    version = 2
+    version = 3
 
     _variable_obs_pairs = (
         # ERA-5 as reference dataset, spatial 2-D variables
@@ -413,7 +414,7 @@ class AnnualCycle(CommandLineDiagnostic):
         """
         model_source_type = get_model_source_type(definition)
         input_datasets = definition.datasets[model_source_type]
-        reference_datasets = definition.datasets[SourceDatasetType.PMPClimatology]
+        reference_collection = definition.datasets[SourceDatasetType.PMPClimatology]
 
         source_id = input_datasets["source_id"].unique()[0]
         experiment_id = input_datasets["experiment_id"].unique()[0]
@@ -435,10 +436,10 @@ class AnnualCycle(CommandLineDiagnostic):
         logger.debug(f"input_datasets: {input_datasets}")
         logger.debug(f"input_datasets.keys(): {input_datasets.keys()}")
 
-        reference_dataset_name = reference_datasets["source_id"].unique()[0]
-        reference_dataset_path = reference_datasets.datasets.iloc[0]["path"]
+        reference_dataset_name = reference_collection["source_id"].unique()[0]
+        reference_dataset_path = reference_collection.datasets.iloc[0]["path"]
 
-        logger.debug(f"reference_dataset.datasets: {reference_datasets.datasets}")
+        logger.debug(f"reference_dataset.datasets: {reference_collection.datasets}")
         logger.debug(f"reference_dataset_name: {reference_dataset_name}")
         logger.debug(f"reference_dataset_path: {reference_dataset_path}")
 
@@ -583,14 +584,17 @@ class AnnualCycle(CommandLineDiagnostic):
 
         # Add missing dimensions to the output
         member_id_col = "variant_label" if model_source_type == SourceDatasetType.CMIP7 else "member_id"
-        reference_datasets = definition.datasets[SourceDatasetType.PMPClimatology]
+        reference_collection = definition.datasets[SourceDatasetType.PMPClimatology]
         cmec_metric_bundle = cmec_metric_bundle.prepend_dimensions(
             {
+                # PMP scalars are model-performance scores against a reference, not reference
+                # (observation) values, so every value's role is ``model``.
+                "kind": "model",
                 "source_id": input_datasets["source_id"].unique()[0],
                 "member_id": input_datasets[member_id_col].unique()[0],
                 "experiment_id": input_datasets["experiment_id"].unique()[0],
                 "variable_id": input_datasets["variable_id"].unique()[0],
-                "reference_source_id": reference_datasets["source_id"].unique()[0],
+                "reference_source_id": reference_collection["source_id"].unique()[0],
             }
         )
 

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/enso.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/enso.py
@@ -43,14 +43,17 @@ class ENSO(CommandLineDiagnostic):
 
     reconstruction_inputs = PMP_RECONSTRUCTION_INPUTS
 
+    version = 2
+
     facets = (
+        "kind",
         "mip_id",
         "source_id",
         "member_id",
         "grid_label",
         "experiment_id",
         "metric",
-        "reference_datasets",
+        "reference_source_id",
     )
 
     def __init__(self, metrics_collection: str, experiments: Collection[str] = ("historical",)) -> None:
@@ -392,6 +395,9 @@ class ENSO(CommandLineDiagnostic):
             ],
         ).prepend_dimensions(
             {
+                # PMP scalars are model-performance scores against a reference, not reference
+                # (observation) values, so every value's role is ``model``.
+                "kind": "model",
                 "mip_id": model_source_type.value,
                 "source_id": source_id,
                 "member_id": member_id,

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
@@ -39,7 +39,10 @@ class ExtratropicalModesOfVariability(CommandLineDiagnostic):
     ts_modes = ("PDO", "NPGO", "AMO")
     psl_modes = ("NAO", "NAM", "PNA", "NPO", "SAM")
 
+    version = 2
+
     facets = (
+        "kind",
         "mip_id",
         "source_id",
         "member_id",
@@ -331,7 +334,7 @@ class ExtratropicalModesOfVariability(CommandLineDiagnostic):
 
         cmec_output_bundle, cmec_metric_bundle = process_json_result(results_files[0], png_files, data_files)
         input_datasets = definition.datasets[model_source_type]
-        reference_datasets = definition.datasets[SourceDatasetType.obs4MIPs]
+        reference_collection = definition.datasets[SourceDatasetType.obs4MIPs]
         member_id_col = "variant_label" if model_source_type == SourceDatasetType.CMIP7 else "member_id"
         cmec_metric_bundle = cmec_metric_bundle.remove_dimensions(
             [
@@ -341,11 +344,14 @@ class ExtratropicalModesOfVariability(CommandLineDiagnostic):
             ],
         ).prepend_dimensions(
             {
+                # PMP scalars are model-performance scores against a reference, not reference
+                # (observation) values, so every value's role is ``model``.
+                "kind": "model",
                 "mip_id": model_source_type.value,
                 "source_id": input_datasets["source_id"].unique()[0],
                 "member_id": input_datasets[member_id_col].unique()[0],
                 "experiment_id": input_datasets["experiment_id"].unique()[0],
-                "reference_source_id": reference_datasets["source_id"].unique()[0],
+                "reference_source_id": reference_collection["source_id"].unique()[0],
             }
         )
 

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py
@@ -140,11 +140,11 @@ def write_CMEC_json(json_file):
     ref_datasets_dict = {ref: {} for ref in ref_datasets}
 
     dimensions_dict = {
-        "json_structure": ["model", "realization", "metric", "reference_datasets"],
+        "json_structure": ["model", "realization", "metric", "reference_source_id"],
         "model": {mod: {}},
         "realization": {run: {}},
         "metric": metrics_dict,
-        "reference_datasets": ref_datasets_dict,
+        "reference_source_id": ref_datasets_dict,
     }
 
     results_dict = {}

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-pr/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-pr/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "326fc588c4f244b1efdeade4f781bc72b0c73ba6",
   "committed": {
-    "diagnostic.json": "d0180207e56d246e8ab54a8365b758ca1eabacf531585b1a8ac54d3cc5e4bd7a",
-    "output.json": "62f8d92c40e3a93b6f4feb4b4de84784a5feff3faf3279e4f5decb661543674a",
+    "diagnostic.json": "1f67589c2ae6da63345f6e86a5e81aac500bbc1f6b82a33103159212a31a0ada",
+    "output.json": "24584af7bc512091dbf454dc3aeff12bd11c36a7fe160ef2d0d5a610bff1cc6e",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 2,
+  "diagnostic_version": 3,
   "native": {
     "diagnostic.json": {
       "sha256": "f9bc138ec6090e97f4f42a5cc6e83bac2a2fb022178437698604b18721d027c9",
@@ -65,5 +65,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-pr/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-pr/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "source_id",
       "member_id",
       "experiment_id",
@@ -13,6 +14,9 @@
       "statistic",
       "season"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -58,7 +62,7 @@
   "DISCLAIMER": null,
   "NOTES": null,
   "PROVENANCE": {
-    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p /home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars pr --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260629.nc --metrics_output_path <OUTPUT_DIR> --cmec",
+    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p <SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars pr --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260629.nc --metrics_output_path <OUTPUT_DIR> --cmec",
     "conda": {
       "Platform": "linux-64"
     },
@@ -86,190 +90,192 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"
   },
   "RESULTS": {
-    "ACCESS-ESM1-5": {
-      "r1i1p1f1": {
-        "historical": {
-          "pr": {
-            "GPCP-3-3": {
-              "attributes": {
-                "InputClimatologyFileName": "pr_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260629.nc"
-              },
-              "doubleITCZ": {
-                "bias_xy": {
-                  "ann": 0.617292,
-                  "djf": 0.375146,
-                  "jja": 0.640895,
-                  "mam": 1.45997,
-                  "son": 0.0149542
+    "model": {
+      "ACCESS-ESM1-5": {
+        "r1i1p1f1": {
+          "historical": {
+            "pr": {
+              "GPCP-3-3": {
+                "attributes": {
+                  "InputClimatologyFileName": "pr_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260629.nc"
                 },
-                "cor_xy": {
-                  "ann": 0.835743,
-                  "djf": 0.820476,
-                  "jja": 0.743676,
-                  "mam": 0.637916,
-                  "son": 0.88643
+                "doubleITCZ": {
+                  "bias_xy": {
+                    "ann": 0.617292,
+                    "djf": 0.375146,
+                    "jja": 0.640895,
+                    "mam": 1.45997,
+                    "son": 0.0149542
+                  },
+                  "cor_xy": {
+                    "ann": 0.835743,
+                    "djf": 0.820476,
+                    "jja": 0.743676,
+                    "mam": 0.637916,
+                    "son": 0.88643
+                  },
+                  "mae_xy": {
+                    "ann": 1.49815,
+                    "djf": 2.16068,
+                    "jja": 1.59744,
+                    "mam": 2.89403,
+                    "son": 1.1084
+                  },
+                  "mean-obs_xy": {
+                    "ann": 5.7314,
+                    "djf": 7.99055,
+                    "jja": 4.2183,
+                    "mam": 6.43456,
+                    "son": 4.26846
+                  },
+                  "mean_xy": {
+                    "ann": 6.34869,
+                    "djf": 8.3657,
+                    "jja": 4.8592,
+                    "mam": 7.89453,
+                    "son": 4.28342
+                  },
+                  "rms_devzm": {
+                    "ann": 1.59806
+                  },
+                  "rms_xy": {
+                    "ann": 1.90323,
+                    "djf": 2.76397,
+                    "jja": 2.36995,
+                    "mam": 3.50686,
+                    "son": 1.57105
+                  },
+                  "rms_xyt": {
+                    "ann": 2.85766
+                  },
+                  "rms_y": {
+                    "ann": 1.03368
+                  },
+                  "rmsc_xy": {
+                    "ann": 1.80035,
+                    "djf": 2.73839,
+                    "jja": 2.28164,
+                    "mam": 3.18851,
+                    "son": 1.57098
+                  },
+                  "std-obs_xy": {
+                    "ann": 2.66277,
+                    "djf": 2.92499,
+                    "jja": 3.13868,
+                    "mam": 2.58091,
+                    "son": 3.01462
+                  },
+                  "std-obs_xy_devzm": {
+                    "ann": 2.28695
+                  },
+                  "std-obs_xyt": {
+                    "ann": 3.49613
+                  },
+                  "std_xy": {
+                    "ann": 3.27576,
+                    "djf": 4.56845,
+                    "jja": 3.2302,
+                    "mam": 4.13962,
+                    "son": 3.39404
+                  },
+                  "std_xy_devzm": {
+                    "ann": 2.78207
+                  },
+                  "std_xyt": {
+                    "ann": 4.59793
+                  }
                 },
-                "mae_xy": {
-                  "ann": 1.49815,
-                  "djf": 2.16068,
-                  "jja": 1.59744,
-                  "mam": 2.89403,
-                  "son": 1.1084
-                },
-                "mean-obs_xy": {
-                  "ann": 5.7314,
-                  "djf": 7.99055,
-                  "jja": 4.2183,
-                  "mam": 6.43456,
-                  "son": 4.26846
-                },
-                "mean_xy": {
-                  "ann": 6.34869,
-                  "djf": 8.3657,
-                  "jja": 4.8592,
-                  "mam": 7.89453,
-                  "son": 4.28342
-                },
-                "rms_devzm": {
-                  "ann": 1.59806
-                },
-                "rms_xy": {
-                  "ann": 1.90323,
-                  "djf": 2.76397,
-                  "jja": 2.36995,
-                  "mam": 3.50686,
-                  "son": 1.57105
-                },
-                "rms_xyt": {
-                  "ann": 2.85766
-                },
-                "rms_y": {
-                  "ann": 1.03368
-                },
-                "rmsc_xy": {
-                  "ann": 1.80035,
-                  "djf": 2.73839,
-                  "jja": 2.28164,
-                  "mam": 3.18851,
-                  "son": 1.57098
-                },
-                "std-obs_xy": {
-                  "ann": 2.66277,
-                  "djf": 2.92499,
-                  "jja": 3.13868,
-                  "mam": 2.58091,
-                  "son": 3.01462
-                },
-                "std-obs_xy_devzm": {
-                  "ann": 2.28695
-                },
-                "std-obs_xyt": {
-                  "ann": 3.49613
-                },
-                "std_xy": {
-                  "ann": 3.27576,
-                  "djf": 4.56845,
-                  "jja": 3.2302,
-                  "mam": 4.13962,
-                  "son": 3.39404
-                },
-                "std_xy_devzm": {
-                  "ann": 2.78207
-                },
-                "std_xyt": {
-                  "ann": 4.59793
-                }
-              },
-              "global": {
-                "bias_xy": {
-                  "ann": 0.134453,
-                  "djf": 0.108109,
-                  "jja": 0.134438,
-                  "mam": 0.184029,
-                  "son": 0.111656
-                },
-                "cor_xy": {
-                  "ann": 0.884577,
-                  "djf": 0.869223,
-                  "jja": 0.847999,
-                  "mam": 0.800443,
-                  "son": 0.857329
-                },
-                "mae_xy": {
-                  "ann": 0.74189,
-                  "djf": 0.935212,
-                  "jja": 0.973126,
-                  "mam": 1.03243,
-                  "son": 0.879828
-                },
-                "mean-obs_xy": {
-                  "ann": 3.06641,
-                  "djf": 3.0722,
-                  "jja": 3.14274,
-                  "mam": 2.9961,
-                  "son": 3.05433
-                },
-                "mean_xy": {
-                  "ann": 3.20087,
-                  "djf": 3.18031,
-                  "jja": 3.27718,
-                  "mam": 3.18013,
-                  "son": 3.16598
-                },
-                "rms_devzm": {
-                  "ann": 1.00828
-                },
-                "rms_xy": {
-                  "ann": 1.11869,
-                  "djf": 1.60154,
-                  "jja": 1.6033,
-                  "mam": 1.63726,
-                  "son": 1.48283
-                },
-                "rms_xyt": {
-                  "ann": 1.81248
-                },
-                "rms_y": {
-                  "ann": 0.484602
-                },
-                "rmsc_xy": {
-                  "ann": 1.11058,
-                  "djf": 1.59788,
-                  "jja": 1.59766,
-                  "mam": 1.62688,
-                  "son": 1.47862
-                },
-                "std-obs_xy": {
-                  "ann": 2.21258,
-                  "djf": 2.68512,
-                  "jja": 2.84905,
-                  "mam": 2.30235,
-                  "son": 2.52549
-                },
-                "std-obs_xy_devzm": {
-                  "ann": 1.79807
-                },
-                "std-obs_xyt": {
-                  "ann": 2.71915
-                },
-                "std_xy": {
-                  "ann": 2.36769,
-                  "djf": 3.22322,
-                  "jja": 2.93795,
-                  "mam": 2.70442,
-                  "son": 2.86959
-                },
-                "std_xy_devzm": {
-                  "ann": 1.93
-                },
-                "std_xyt": {
-                  "ann": 3.13848
+                "global": {
+                  "bias_xy": {
+                    "ann": 0.134453,
+                    "djf": 0.108109,
+                    "jja": 0.134438,
+                    "mam": 0.184029,
+                    "son": 0.111656
+                  },
+                  "cor_xy": {
+                    "ann": 0.884577,
+                    "djf": 0.869223,
+                    "jja": 0.847999,
+                    "mam": 0.800443,
+                    "son": 0.857329
+                  },
+                  "mae_xy": {
+                    "ann": 0.74189,
+                    "djf": 0.935212,
+                    "jja": 0.973126,
+                    "mam": 1.03243,
+                    "son": 0.879828
+                  },
+                  "mean-obs_xy": {
+                    "ann": 3.06641,
+                    "djf": 3.0722,
+                    "jja": 3.14274,
+                    "mam": 2.9961,
+                    "son": 3.05433
+                  },
+                  "mean_xy": {
+                    "ann": 3.20087,
+                    "djf": 3.18031,
+                    "jja": 3.27718,
+                    "mam": 3.18013,
+                    "son": 3.16598
+                  },
+                  "rms_devzm": {
+                    "ann": 1.00828
+                  },
+                  "rms_xy": {
+                    "ann": 1.11869,
+                    "djf": 1.60154,
+                    "jja": 1.6033,
+                    "mam": 1.63726,
+                    "son": 1.48283
+                  },
+                  "rms_xyt": {
+                    "ann": 1.81248
+                  },
+                  "rms_y": {
+                    "ann": 0.484602
+                  },
+                  "rmsc_xy": {
+                    "ann": 1.11058,
+                    "djf": 1.59788,
+                    "jja": 1.59766,
+                    "mam": 1.62688,
+                    "son": 1.47862
+                  },
+                  "std-obs_xy": {
+                    "ann": 2.21258,
+                    "djf": 2.68512,
+                    "jja": 2.84905,
+                    "mam": 2.30235,
+                    "son": 2.52549
+                  },
+                  "std-obs_xy_devzm": {
+                    "ann": 1.79807
+                  },
+                  "std-obs_xyt": {
+                    "ann": 2.71915
+                  },
+                  "std_xy": {
+                    "ann": 2.36769,
+                    "djf": 3.22322,
+                    "jja": 2.93795,
+                    "mam": 2.70442,
+                    "son": 2.86959
+                  },
+                  "std_xy_devzm": {
+                    "ann": 1.93
+                  },
+                  "std_xyt": {
+                    "ann": 3.13848
+                  }
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-pr/regression/output.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-pr/regression/output.json
@@ -67,7 +67,7 @@
     }
   },
   "provenance": {
-    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p /home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars pr --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260629.nc --metrics_output_path <OUTPUT_DIR> --cmec",
+    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p <SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars pr --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260629.nc --metrics_output_path <OUTPUT_DIR> --cmec",
     "conda": {
       "Platform": "linux-64"
     },
@@ -99,7 +99,7 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-ts/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-ts/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "8fe7eddb18ede3fe8ed9689e02e4b11cf40da1ab",
   "committed": {
-    "diagnostic.json": "8477ccc8a8d5c7304d68406ba5b8e363d12fd233802f3f620a615945053ac3b6",
-    "output.json": "e46ca7fa84827e863165dc002b50f0a4a476fdc2ae4c228cbaeddbad86c5d9f7",
+    "diagnostic.json": "d742deb13da7732713e3aab757042d47f6c7aced2b2a949b2d9073c49cd9c6d9",
+    "output.json": "4c98ac227f4b6d1686707cedc00922f45c091bc0179fc3a7f802e9047b82d983",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 2,
+  "diagnostic_version": 3,
   "native": {
     "diagnostic.json": {
       "sha256": "c4d890859f86fb60560a013fc3327d8e05762e88c4a3e51cab4e1378f4220e8a",
@@ -45,5 +45,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-ts/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-ts/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "source_id",
       "member_id",
       "experiment_id",
@@ -13,6 +14,9 @@
       "statistic",
       "season"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -57,7 +61,7 @@
   "DISCLAIMER": null,
   "NOTES": null,
   "PROVENANCE": {
-    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p /home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
+    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p <SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
     "conda": {
       "Platform": "linux-64"
     },
@@ -85,104 +89,106 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"
   },
   "RESULTS": {
-    "ACCESS-ESM1-5": {
-      "r1i1p1f1": {
-        "historical": {
-          "ts": {
-            "ERA-5": {
-              "attributes": {
-                "InputClimatologyFileName": "ts_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc"
-              },
-              "global": {
-                "bias_xy": {
-                  "ann": 0.863938,
-                  "djf": 0.86649,
-                  "jja": 0.833289,
-                  "mam": 0.899996,
-                  "son": 0.854721
+    "model": {
+      "ACCESS-ESM1-5": {
+        "r1i1p1f1": {
+          "historical": {
+            "ts": {
+              "ERA-5": {
+                "attributes": {
+                  "InputClimatologyFileName": "ts_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc"
                 },
-                "cor_xy": {
-                  "ann": 0.994559,
-                  "djf": 0.992555,
-                  "jja": 0.99348,
-                  "mam": 0.993776,
-                  "son": 0.993477
-                },
-                "mae_xy": {
-                  "ann": 1.33182,
-                  "djf": 1.59215,
-                  "jja": 1.44173,
-                  "mam": 1.46336,
-                  "son": 1.39756
-                },
-                "mean-obs_xy": {
-                  "ann": 288.038,
-                  "djf": 286.212,
-                  "jja": 289.845,
-                  "mam": 288.055,
-                  "son": 288.057
-                },
-                "mean_xy": {
-                  "ann": 288.902,
-                  "djf": 287.078,
-                  "jja": 290.678,
-                  "mam": 288.955,
-                  "son": 288.912
-                },
-                "rms_devzm": {
-                  "ann": 1.35937
-                },
-                "rms_xy": {
-                  "ann": 1.78071,
-                  "djf": 2.22548,
-                  "jja": 1.96993,
-                  "mam": 1.96606,
-                  "son": 1.91305
-                },
-                "rms_xyt": {
-                  "ann": 2.12142
-                },
-                "rms_y": {
-                  "ann": 1.15023
-                },
-                "rmsc_xy": {
-                  "ann": 1.55709,
-                  "djf": 2.04987,
-                  "jja": 1.78501,
-                  "mam": 1.74797,
-                  "son": 1.71149
-                },
-                "std-obs_xy": {
-                  "ann": 14.7479,
-                  "djf": 16.7278,
-                  "jja": 14.677,
-                  "mam": 15.5647,
-                  "son": 14.8687
-                },
-                "std-obs_xy_devzm": {
-                  "ann": 4.15782
-                },
-                "std-obs_xyt": {
-                  "ann": 15.7057
-                },
-                "std_xy": {
-                  "ann": 14.9211,
-                  "djf": 16.8294,
-                  "jja": 15.2027,
-                  "mam": 15.6896,
-                  "son": 15.005
-                },
-                "std_xy_devzm": {
-                  "ann": 3.83272
-                },
-                "std_xyt": {
-                  "ann": 15.9241
+                "global": {
+                  "bias_xy": {
+                    "ann": 0.863938,
+                    "djf": 0.86649,
+                    "jja": 0.833289,
+                    "mam": 0.899996,
+                    "son": 0.854721
+                  },
+                  "cor_xy": {
+                    "ann": 0.994559,
+                    "djf": 0.992555,
+                    "jja": 0.99348,
+                    "mam": 0.993776,
+                    "son": 0.993477
+                  },
+                  "mae_xy": {
+                    "ann": 1.33182,
+                    "djf": 1.59215,
+                    "jja": 1.44173,
+                    "mam": 1.46336,
+                    "son": 1.39756
+                  },
+                  "mean-obs_xy": {
+                    "ann": 288.038,
+                    "djf": 286.212,
+                    "jja": 289.845,
+                    "mam": 288.055,
+                    "son": 288.057
+                  },
+                  "mean_xy": {
+                    "ann": 288.902,
+                    "djf": 287.078,
+                    "jja": 290.678,
+                    "mam": 288.955,
+                    "son": 288.912
+                  },
+                  "rms_devzm": {
+                    "ann": 1.35937
+                  },
+                  "rms_xy": {
+                    "ann": 1.78071,
+                    "djf": 2.22548,
+                    "jja": 1.96993,
+                    "mam": 1.96606,
+                    "son": 1.91305
+                  },
+                  "rms_xyt": {
+                    "ann": 2.12142
+                  },
+                  "rms_y": {
+                    "ann": 1.15023
+                  },
+                  "rmsc_xy": {
+                    "ann": 1.55709,
+                    "djf": 2.04987,
+                    "jja": 1.78501,
+                    "mam": 1.74797,
+                    "son": 1.71149
+                  },
+                  "std-obs_xy": {
+                    "ann": 14.7479,
+                    "djf": 16.7278,
+                    "jja": 14.677,
+                    "mam": 15.5647,
+                    "son": 14.8687
+                  },
+                  "std-obs_xy_devzm": {
+                    "ann": 4.15782
+                  },
+                  "std-obs_xyt": {
+                    "ann": 15.7057
+                  },
+                  "std_xy": {
+                    "ann": 14.9211,
+                    "djf": 16.8294,
+                    "jja": 15.2027,
+                    "mam": 15.6896,
+                    "son": 15.005
+                  },
+                  "std_xy_devzm": {
+                    "ann": 3.83272
+                  },
+                  "std_xyt": {
+                    "ann": 15.9241
+                  }
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-ts/regression/output.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-ts/regression/output.json
@@ -37,7 +37,7 @@
     }
   },
   "provenance": {
-    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p /home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
+    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p <SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
     "conda": {
       "Platform": "linux-64"
     },
@@ -69,7 +69,7 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip7-ts/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip7-ts/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "7c0f423b556b302e110a519c997d8a3d0b9e3f59",
   "committed": {
-    "diagnostic.json": "8477ccc8a8d5c7304d68406ba5b8e363d12fd233802f3f620a615945053ac3b6",
-    "output.json": "e46ca7fa84827e863165dc002b50f0a4a476fdc2ae4c228cbaeddbad86c5d9f7",
+    "diagnostic.json": "d742deb13da7732713e3aab757042d47f6c7aced2b2a949b2d9073c49cd9c6d9",
+    "output.json": "4c98ac227f4b6d1686707cedc00922f45c091bc0179fc3a7f802e9047b82d983",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 2,
+  "diagnostic_version": 3,
   "native": {
     "diagnostic.json": {
       "sha256": "644722f87a8eaaf6c39449d1cce2963222d4547a37007e84941aab75057b53da",
@@ -45,5 +45,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip7-ts/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip7-ts/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "source_id",
       "member_id",
       "experiment_id",
@@ -13,6 +14,9 @@
       "statistic",
       "season"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -57,7 +61,7 @@
   "DISCLAIMER": null,
   "NOTES": null,
   "PROVENANCE": {
-    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p /home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
+    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p <SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
     "conda": {
       "Platform": "linux-64"
     },
@@ -85,104 +89,106 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"
   },
   "RESULTS": {
-    "ACCESS-ESM1-5": {
-      "r1i1p1f1": {
-        "historical": {
-          "ts": {
-            "ERA-5": {
-              "attributes": {
-                "InputClimatologyFileName": "ts_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc"
-              },
-              "global": {
-                "bias_xy": {
-                  "ann": 0.863938,
-                  "djf": 0.86649,
-                  "jja": 0.833289,
-                  "mam": 0.899996,
-                  "son": 0.854721
+    "model": {
+      "ACCESS-ESM1-5": {
+        "r1i1p1f1": {
+          "historical": {
+            "ts": {
+              "ERA-5": {
+                "attributes": {
+                  "InputClimatologyFileName": "ts_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc"
                 },
-                "cor_xy": {
-                  "ann": 0.994559,
-                  "djf": 0.992555,
-                  "jja": 0.99348,
-                  "mam": 0.993776,
-                  "son": 0.993477
-                },
-                "mae_xy": {
-                  "ann": 1.33182,
-                  "djf": 1.59215,
-                  "jja": 1.44173,
-                  "mam": 1.46336,
-                  "son": 1.39756
-                },
-                "mean-obs_xy": {
-                  "ann": 288.038,
-                  "djf": 286.212,
-                  "jja": 289.845,
-                  "mam": 288.055,
-                  "son": 288.057
-                },
-                "mean_xy": {
-                  "ann": 288.902,
-                  "djf": 287.078,
-                  "jja": 290.678,
-                  "mam": 288.955,
-                  "son": 288.912
-                },
-                "rms_devzm": {
-                  "ann": 1.35937
-                },
-                "rms_xy": {
-                  "ann": 1.78071,
-                  "djf": 2.22548,
-                  "jja": 1.96993,
-                  "mam": 1.96606,
-                  "son": 1.91305
-                },
-                "rms_xyt": {
-                  "ann": 2.12142
-                },
-                "rms_y": {
-                  "ann": 1.15023
-                },
-                "rmsc_xy": {
-                  "ann": 1.55709,
-                  "djf": 2.04987,
-                  "jja": 1.78501,
-                  "mam": 1.74797,
-                  "son": 1.71149
-                },
-                "std-obs_xy": {
-                  "ann": 14.7479,
-                  "djf": 16.7278,
-                  "jja": 14.677,
-                  "mam": 15.5647,
-                  "son": 14.8687
-                },
-                "std-obs_xy_devzm": {
-                  "ann": 4.15782
-                },
-                "std-obs_xyt": {
-                  "ann": 15.7057
-                },
-                "std_xy": {
-                  "ann": 14.9211,
-                  "djf": 16.8294,
-                  "jja": 15.2027,
-                  "mam": 15.6896,
-                  "son": 15.005
-                },
-                "std_xy_devzm": {
-                  "ann": 3.83272
-                },
-                "std_xyt": {
-                  "ann": 15.9241
+                "global": {
+                  "bias_xy": {
+                    "ann": 0.863938,
+                    "djf": 0.86649,
+                    "jja": 0.833289,
+                    "mam": 0.899996,
+                    "son": 0.854721
+                  },
+                  "cor_xy": {
+                    "ann": 0.994559,
+                    "djf": 0.992555,
+                    "jja": 0.99348,
+                    "mam": 0.993776,
+                    "son": 0.993477
+                  },
+                  "mae_xy": {
+                    "ann": 1.33182,
+                    "djf": 1.59215,
+                    "jja": 1.44173,
+                    "mam": 1.46336,
+                    "son": 1.39756
+                  },
+                  "mean-obs_xy": {
+                    "ann": 288.038,
+                    "djf": 286.212,
+                    "jja": 289.845,
+                    "mam": 288.055,
+                    "son": 288.057
+                  },
+                  "mean_xy": {
+                    "ann": 288.902,
+                    "djf": 287.078,
+                    "jja": 290.678,
+                    "mam": 288.955,
+                    "son": 288.912
+                  },
+                  "rms_devzm": {
+                    "ann": 1.35937
+                  },
+                  "rms_xy": {
+                    "ann": 1.78071,
+                    "djf": 2.22548,
+                    "jja": 1.96993,
+                    "mam": 1.96606,
+                    "son": 1.91305
+                  },
+                  "rms_xyt": {
+                    "ann": 2.12142
+                  },
+                  "rms_y": {
+                    "ann": 1.15023
+                  },
+                  "rmsc_xy": {
+                    "ann": 1.55709,
+                    "djf": 2.04987,
+                    "jja": 1.78501,
+                    "mam": 1.74797,
+                    "son": 1.71149
+                  },
+                  "std-obs_xy": {
+                    "ann": 14.7479,
+                    "djf": 16.7278,
+                    "jja": 14.677,
+                    "mam": 15.5647,
+                    "son": 14.8687
+                  },
+                  "std-obs_xy_devzm": {
+                    "ann": 4.15782
+                  },
+                  "std-obs_xyt": {
+                    "ann": 15.7057
+                  },
+                  "std_xy": {
+                    "ann": 14.9211,
+                    "djf": 16.8294,
+                    "jja": 15.2027,
+                    "mam": 15.6896,
+                    "son": 15.005
+                  },
+                  "std_xy_devzm": {
+                    "ann": 3.83272
+                  },
+                  "std_xyt": {
+                    "ann": 15.9241
+                  }
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip7-ts/regression/output.json
+++ b/packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip7-ts/regression/output.json
@@ -37,7 +37,7 @@
     }
   },
   "provenance": {
-    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p /home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
+    "commandLine": "<SOFTWARE_ROOT_DIR>/conda/pmp-a0cd98ec96f7c858f788439a4f0b4951fe2d7a55/bin/mean_climate_driver.py -p <SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/params/pmp_param_annualcycle_2-metrics.py --vars ts --custom_observations <OUTPUT_DIR>/obs_dict.json --test_data_path <OUTPUT_DIR> --test_data_set ACCESS-ESM1-5 --realization r1i1p1f1 --filename_template %(variable)_ACCESS-ESM1-5_historical_r1i1p1f1_clims.198101-200512.AC.v20260628.nc --metrics_output_path <OUTPUT_DIR> --cmec",
     "conda": {
       "Platform": "linux-64"
     },
@@ -69,7 +69,7 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"

--- a/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip6/manifest.json
@@ -1,39 +1,39 @@
 {
   "catalog_hash": "a0d4fb8b825319f85055f6cb440e6accec4b1424",
   "committed": {
-    "diagnostic.json": "798eb29959ef9add47cfddab4c2b74c00ca1dec34bbb0750dffd3dbef82dcbc5",
-    "output.json": "e5f199fbf35da8f9f4e2608474e8c711e93a8b2b429abfafc9e3c5b04a221efd",
+    "diagnostic.json": "4c377a132d5b56e56a54e8c468c2c0589423c11a417e78623b3e7d33bcc580fc",
+    "output.json": "7fd446bc2ca9ce0614f9b7c21dfd2ecaea4376e702c7503b356d8303673411d4",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasSstLonRmse.nc": {
-      "sha256": "bb8f6c971556094b55f6b1adcc111cee0f504ed7c1564364c431dcd73aca7462",
-      "size": 98836
+      "sha256": "4a9d7911fd0721e62b0699681dc012154d79c138c9b69b5154dca6294806521c",
+      "size": 98819
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasSstLonRmse_diagnostic_divedown01.png": {
       "sha256": "7f94ffa6adaa480534c9c193f7f8d27f109ccb1485addc494213691407794911",
       "size": 37180
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasSstLonRmse_diagnostic_divedown02.png": {
-      "sha256": "6f3c4901ce02ce97e0c56f5d60a4e2e9459640cf18137ca88b8503e8c7d5eed7",
-      "size": 44673
+      "sha256": "7072e939debb93600d5bafcb1d9a94d73b6a3c6b8c40d7f89d38c2804ad108d1",
+      "size": 44686
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasTauxLonRmse.nc": {
-      "sha256": "e8f29e448f671a8a7d09c6b9f3653df465aa8918ec7ddf707f50e83e8159b5ac",
-      "size": 78282
+      "sha256": "216b09509037d21d7321d45c903edda63184a1f087c3b056430713bf01ca270e",
+      "size": 78270
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasTauxLonRmse_diagnostic_divedown01.png": {
-      "sha256": "60585a4a9f53410f4dfc57a5c4824809d647c3874af72b461cdb482db4ccf238",
-      "size": 40821
+      "sha256": "45d707ed2761d4f0ba1d20acd9072298b74c2cb7bddf102c783046146ce093e8",
+      "size": 40822
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasTauxLonRmse_diagnostic_divedown02.png": {
       "sha256": "5002a6802216fee335bc924da231453a69731d72828901c5f78834f9bc981051",
       "size": 52225
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl.nc": {
-      "sha256": "e9eff2c8b11fa104237eb92d0df592878eba1dde1d338343fdad17d395b23a12",
-      "size": 107766
+      "sha256": "e88f7f11cf4221a5c075e1ce158871d4b59e0ec152ce9afdd28b54bd780369f2",
+      "size": 107762
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown01.png": {
       "sha256": "e27a94438889df6757bde18c01673ff5b9d7b9182f28d38e719cc72212249f26",
@@ -44,11 +44,11 @@
       "size": 38743
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown03.png": {
-      "sha256": "2e0b7aeddbee351669fcb1def415a2605ffaf4d57b9101c195573363cc3ae2f8",
-      "size": 50311
+      "sha256": "f142e3db3caf3d2d42b04b19cf6fbade02484066ea1b826ab09e7788a4583b2d",
+      "size": 50307
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoFbSstTaux.nc": {
-      "sha256": "7a5278093dca9230d29ad72863a536fdf1972ce49fe8c89acc483d0cf4a5613c",
+      "sha256": "f46cd6feac8ef43a2bc8de9f25a19062ce6fd112d6281916a31dad326d6a6083",
       "size": 258563
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoFbSstTaux_diagnostic_divedown01.png": {
@@ -68,8 +68,8 @@
       "size": 78454
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality.nc": {
-      "sha256": "c8297eba33fcd80f605d24240d4355ebfdee067007709b6d881df757b78c6021",
-      "size": 221685
+      "sha256": "ecb6bf1ba2903fa883c06e48f2f2a82f7a89739d063218a52968af8b1de27024",
+      "size": 221674
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown01.png": {
       "sha256": "43af1568794a3b6900ec3f53d4622a467e911d9f90ce750743c43327ed8452f7",
@@ -88,31 +88,31 @@
       "size": 42994
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown05.png": {
-      "sha256": "31aa7aa6c51982ab05ffdebf0825a641d5187163abd4a15b2a05f8dd53a0e666",
+      "sha256": "882016fdd48f0546f24626c2a664e553570f84d8bdcbc26bd2cf1d7c78b461c7",
       "size": 84487
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse.nc": {
-      "sha256": "22d8f1decbc17979627f8c83f635edb182c4d5dbfaca28bd0548147ca85b5f19",
-      "size": 248969
+      "sha256": "2b12d8b4a1382a0635993ca6abb575f8e0649efabf8b3a083ee59ae3b010cd21",
+      "size": 248937
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown01.png": {
       "sha256": "062f611b4eb3d930250d758677dfed2c5f39bf025c53f8b0fd991a6c8aabeda2",
       "size": 36659
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown02.png": {
-      "sha256": "7b0387120fb9a9e5d274b7df7701f3effdeccd3d1d8183de97796244f349e6a3",
-      "size": 51257
+      "sha256": "95cf93652e8ff907ed987c25299ed8537695174b3b8cc4f2bbaf9065b624dc34",
+      "size": 51264
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown03.png": {
       "sha256": "ee42a9a486796a8754cfc5264dd3dfa4f0bac6343aad96fbc9a7cc941876e574",
       "size": 41976
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown04.png": {
-      "sha256": "9518e448bd2078e63f880dd7288686515ca977f267daae7ee127cc72cf0fd111",
-      "size": 80935
+      "sha256": "80f27577f7492396f2f15c07f421bdf7cbab0d64392dde0512b36c79d68e81fb",
+      "size": 80932
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstSkew.nc": {
-      "sha256": "9adf116b91eced1945acc3fd846fd1d4fa38fcb55fcacc87b9eef14afe97b05f",
+      "sha256": "c00e84687c0a6dd592c3d9cc01840a0dfdf1f526c6ee116a457d188d21d0dfa8",
       "size": 109132
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstSkew_diagnostic_divedown01.png": {
@@ -128,16 +128,16 @@
       "size": 55379
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_cmec.json": {
-      "sha256": "9f54ceee477b75ab1e5eb09a7708d5ed534142f3b293ead91237e73d334284a3",
-      "size": 8480
+      "sha256": "fea5b7ca13d518c3c777312af2602e7ee245f61d8b20f6b3615e5ee7cf5fc5bf",
+      "size": 8481
     },
     "diagnostic.json": {
-      "sha256": "eb3119ee6e8b51add10bbde4e3c25320b46c658aff35a65a08a9f6135928f56a",
-      "size": 3015
+      "sha256": "c55aba4612d44b7b65b66c81d708ca3f3e1737468eecf26bbfb6edab6045a4d6",
+      "size": 3173
     },
     "output.json": {
-      "sha256": "86729f2822c4296ec9c0c7ade2235b266623279bab69ceaaef07b61ce8d070b7",
-      "size": 10367
+      "sha256": "6843d85c050d371f21c32ad8f537c3e306c633dcfd3e08dd0d9e0360e160def0",
+      "size": 10374
     },
     "series.json": {
       "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
@@ -145,5 +145,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip6/regression/diagnostic.json
@@ -7,14 +7,18 @@
       "gn": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
       "grid_label",
       "experiment_id",
       "metric",
-      "reference_datasets"
+      "reference_source_id"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -30,7 +34,7 @@
     "mip_id": {
       "cmip6": {}
     },
-    "reference_datasets": {
+    "reference_source_id": {
       "HadISST": {},
       "HadISST_Tropflux": {},
       "Tropflux": {},
@@ -43,9 +47,9 @@
   "DISCLAIMER": null,
   "NOTES": null,
   "PROVENANCE": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "openGL": {
@@ -71,43 +75,45 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"
   },
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "gn": {
-            "historical": {
-              "BiasSstLonRmse": {
-                "HadISST": 0.5024881,
-                "Tropflux": 0.5861183
-              },
-              "BiasTauxLonRmse": {
-                "Tropflux": 7.546285
-              },
-              "EnsoAmpl": {
-                "HadISST": 4.523476,
-                "Tropflux": 11.96119
-              },
-              "EnsoFbSstTaux": {
-                "HadISST_Tropflux": 72.75427,
-                "Tropflux_Tropflux": 71.91334
-              },
-              "EnsoSeasonality": {
-                "HadISST": 32.72831,
-                "Tropflux": 45.59915
-              },
-              "EnsoSstLonRmse": {
-                "HadISST": 0.2041643,
-                "Tropflux": 0.2053258
-              },
-              "EnsoSstSkew": {
-                "HadISST": 217.1324,
-                "Tropflux": 223.0274
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "gn": {
+              "historical": {
+                "BiasSstLonRmse": {
+                  "HadISST": 0.5024881,
+                  "Tropflux": 0.5861183
+                },
+                "BiasTauxLonRmse": {
+                  "Tropflux": 7.546285
+                },
+                "EnsoAmpl": {
+                  "HadISST": 4.523476,
+                  "Tropflux": 11.96119
+                },
+                "EnsoFbSstTaux": {
+                  "HadISST_Tropflux": 72.75427,
+                  "Tropflux_Tropflux": 71.91334
+                },
+                "EnsoSeasonality": {
+                  "HadISST": 32.72831,
+                  "Tropflux": 45.59915
+                },
+                "EnsoSstLonRmse": {
+                  "HadISST": 0.2041643,
+                  "Tropflux": 0.2053258
+                },
+                "EnsoSstSkew": {
+                  "HadISST": 217.1324,
+                  "Tropflux": 223.0274
+                }
               }
             }
           }

--- a/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip6/regression/output.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip6/regression/output.json
@@ -188,9 +188,9 @@
     }
   },
   "provenance": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "environment": {},
@@ -220,7 +220,7 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"

--- a/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip7/manifest.json
@@ -1,39 +1,39 @@
 {
   "catalog_hash": "5c385e1d58b72eca3d1def8eae70ad8142593c54",
   "committed": {
-    "diagnostic.json": "5a1418ddfbfd1aae1530898b61d1851b9251c66cbf0aef537b41b99f5cadf33d",
-    "output.json": "e5f199fbf35da8f9f4e2608474e8c711e93a8b2b429abfafc9e3c5b04a221efd",
+    "diagnostic.json": "6998ab50b33dedcdd2c94671c18e6206c1ab41386072ff995c33528cb59ac336",
+    "output.json": "7fd446bc2ca9ce0614f9b7c21dfd2ecaea4376e702c7503b356d8303673411d4",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasSstLonRmse.nc": {
-      "sha256": "9af94d6d15996e558e57986efa127381f413354b832c694236fb74f18fad77cb",
-      "size": 98830
+      "sha256": "0c229b7e9ea308d302f77397cb97e83430a35c3f358b9cdb06d9e3cd8306258b",
+      "size": 98818
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasSstLonRmse_diagnostic_divedown01.png": {
       "sha256": "b6be409e6c472149480e82e50a8b46e8885c70a2bd7638ef72385248f4505d31",
       "size": 37177
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasSstLonRmse_diagnostic_divedown02.png": {
-      "sha256": "6f3c4901ce02ce97e0c56f5d60a4e2e9459640cf18137ca88b8503e8c7d5eed7",
-      "size": 44673
+      "sha256": "7072e939debb93600d5bafcb1d9a94d73b6a3c6b8c40d7f89d38c2804ad108d1",
+      "size": 44686
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasTauxLonRmse.nc": {
-      "sha256": "74b13f2fd4578b52fa63e98c04de2f9b6301051c323f0c23a629b696d405b65e",
-      "size": 78275
+      "sha256": "d94e28932f16692adde99adf4d236336f45da9ca3c246ce5581596aa6e48f634",
+      "size": 78265
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasTauxLonRmse_diagnostic_divedown01.png": {
-      "sha256": "9c1dbb727a575b11b9fd8c8f3d10fe6800f5a4f65e433afad334f6fc5a5a36a4",
-      "size": 40792
+      "sha256": "ed63c529469acfa2f73143adffd2cbd1c3d846650a96d4406d3584daf4a1419c",
+      "size": 40796
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_BiasTauxLonRmse_diagnostic_divedown02.png": {
       "sha256": "2f5328510b85626d943b395bc032af3c8b1abb26fae50d4a5d870352e11fc085",
       "size": 52224
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl.nc": {
-      "sha256": "cc2458e45806d117169a1b96f523daf5a1a8d56489eefacdf118379d855db5f7",
-      "size": 107772
+      "sha256": "cded5b8c9fb4ccfd61b7857c3f4423b1b2362969c58f535e153175eb6ceb0b04",
+      "size": 107771
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown01.png": {
       "sha256": "e27a94438889df6757bde18c01673ff5b9d7b9182f28d38e719cc72212249f26",
@@ -44,11 +44,11 @@
       "size": 38746
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown03.png": {
-      "sha256": "7509b6a5ef519e7fc19a92e645ab0386664da89c81d36fa83001906bb3ded66b",
-      "size": 50314
+      "sha256": "053958c714fda8f085ce2ac9719eca440bf987e692517a2f73083d5fcb3afe6d",
+      "size": 50311
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoFbSstTaux.nc": {
-      "sha256": "ad4c2eccaad5ee0581e16a7935c2b36cd63f748f456084b892fd3398e321f2d3",
+      "sha256": "87d7f130168dac2067093e158d5132dcc0469262b65dbbaf559d52eedabbf965",
       "size": 258554
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoFbSstTaux_diagnostic_divedown01.png": {
@@ -68,8 +68,8 @@
       "size": 78514
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality.nc": {
-      "sha256": "3b818b05dd93feb6600b7adfafa5c257d086db4e218120640f1a203bd4083ec4",
-      "size": 221713
+      "sha256": "68bff8460c07293cc78b9e80737ea377d3bf71c7d288705c447f5d83f25fb42d",
+      "size": 221707
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown01.png": {
       "sha256": "43af1568794a3b6900ec3f53d4622a467e911d9f90ce750743c43327ed8452f7",
@@ -88,31 +88,31 @@
       "size": 43008
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown05.png": {
-      "sha256": "11d163f69d6934003656f60de8f5e6b13bf64fe702d1e6d72addf6edd0920c7c",
+      "sha256": "1d47f8e8740d5c7426d3c1c4d19d20f325502e8119bf1e4fbf6a57442200f16b",
       "size": 84486
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse.nc": {
-      "sha256": "3c624cd84d9e40d551d4a8c5a3e69a152fcce7452fb8d4efc6e5bc1cb4232d4e",
-      "size": 248985
+      "sha256": "1162b656507cdbbed5401423c2a1e119ff5433660f84618b2b14207cf513c79f",
+      "size": 248950
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown01.png": {
       "sha256": "67b582c3b47b7d876e5992f7b4a2f83a0f07c6a4ee005f9713007911aa6ff0e2",
       "size": 36654
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown02.png": {
-      "sha256": "d8df12f997d8872dbe053739b1afcf586234b6cca24884a00f1ff51628af1eed",
-      "size": 51263
+      "sha256": "857670fdfb84d8039d06c97bb8950908157e4d68efa8ee0a64172cb3f692660f",
+      "size": 51270
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown03.png": {
       "sha256": "6341f7604417bde669f62de88fe034c39486b0922792f00c9ad8031cf880b2a2",
       "size": 41988
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown04.png": {
-      "sha256": "9518e448bd2078e63f880dd7288686515ca977f267daae7ee127cc72cf0fd111",
-      "size": 80935
+      "sha256": "80f27577f7492396f2f15c07f421bdf7cbab0d64392dde0512b36c79d68e81fb",
+      "size": 80932
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstSkew.nc": {
-      "sha256": "028b51cd145b48c176b9cdd96f6dd46ae30b254f54191976e959603590449f1d",
+      "sha256": "a9acdb455e1ac1a6216627f33b547ffe58ac3ab2ec5d6e1a2c4fd9970694f862",
       "size": 109112
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstSkew_diagnostic_divedown01.png": {
@@ -128,16 +128,16 @@
       "size": 55375
     },
     "ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1_cmec.json": {
-      "sha256": "d7d64985c2f106f0d11747ce8a34365b2690c651ed68f5d2d1217cd55ee81839",
-      "size": 8480
+      "sha256": "b22b2ab806f2ab1914f73c214d92e0e3fd854c28eae9883d367b4bf81fc16c32",
+      "size": 8552
     },
     "diagnostic.json": {
-      "sha256": "b2e5f1346a419493c3c42a0016f3dc0daca3c0dc4acedeb6f97d896cd66a9d20",
-      "size": 3015
+      "sha256": "290200993a87434616201dd606da268bdd29576143478bede72f93a4b002a39c",
+      "size": 3172
     },
     "output.json": {
-      "sha256": "503e5890e20509d534903bec9153d2d2fc98601f2172a818b0c812a0dc31116e",
-      "size": 10367
+      "sha256": "aa3ff7b5309b952ad9671ef9ec6baaef8d0b79d116dc391e3048e2925838f57d",
+      "size": 10374
     },
     "series.json": {
       "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
@@ -145,5 +145,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip7/regression/diagnostic.json
@@ -7,14 +7,18 @@
       "gn": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
       "grid_label",
       "experiment_id",
       "metric",
-      "reference_datasets"
+      "reference_source_id"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -30,7 +34,7 @@
     "mip_id": {
       "cmip7": {}
     },
-    "reference_datasets": {
+    "reference_source_id": {
       "HadISST": {},
       "HadISST_Tropflux": {},
       "Tropflux": {},
@@ -43,9 +47,9 @@
   "DISCLAIMER": null,
   "NOTES": null,
   "PROVENANCE": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "openGL": {
@@ -71,43 +75,45 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"
   },
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "gn": {
-            "historical": {
-              "BiasSstLonRmse": {
-                "HadISST": 0.5024878,
-                "Tropflux": 0.5861182
-              },
-              "BiasTauxLonRmse": {
-                "Tropflux": 7.546189
-              },
-              "EnsoAmpl": {
-                "HadISST": 4.52348,
-                "Tropflux": 11.96119
-              },
-              "EnsoFbSstTaux": {
-                "HadISST_Tropflux": 72.7547,
-                "Tropflux_Tropflux": 71.91379
-              },
-              "EnsoSeasonality": {
-                "HadISST": 32.72842,
-                "Tropflux": 45.59924
-              },
-              "EnsoSstLonRmse": {
-                "HadISST": 0.2041627,
-                "Tropflux": 0.2053245
-              },
-              "EnsoSstSkew": {
-                "HadISST": 217.1323,
-                "Tropflux": 223.0273
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "gn": {
+              "historical": {
+                "BiasSstLonRmse": {
+                  "HadISST": 0.5024878,
+                  "Tropflux": 0.5861182
+                },
+                "BiasTauxLonRmse": {
+                  "Tropflux": 7.546189
+                },
+                "EnsoAmpl": {
+                  "HadISST": 4.52348,
+                  "Tropflux": 11.96119
+                },
+                "EnsoFbSstTaux": {
+                  "HadISST_Tropflux": 72.7547,
+                  "Tropflux_Tropflux": 71.91379
+                },
+                "EnsoSeasonality": {
+                  "HadISST": 32.72842,
+                  "Tropflux": 45.59924
+                },
+                "EnsoSstLonRmse": {
+                  "HadISST": 0.2041627,
+                  "Tropflux": 0.2053245
+                },
+                "EnsoSstSkew": {
+                  "HadISST": 217.1323,
+                  "Tropflux": 223.0273
+                }
               }
             }
           }

--- a/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip7/regression/output.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_proc/cmip7/regression/output.json
@@ -188,9 +188,9 @@
     }
   },
   "provenance": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_proc --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_proc_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "environment": {},
@@ -220,7 +220,7 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"

--- a/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip6/manifest.json
@@ -1,15 +1,15 @@
 {
   "catalog_hash": "ca7dd5b245c639e149d52467e6f2ec79899f665a",
   "committed": {
-    "diagnostic.json": "bd11b46f58b1724eac03f59fc0f3087d428dd1516cefd81efd5c9367f466564f",
-    "output.json": "c62a83a4a1fd9a05e038666a26220d0f8dbaa25bd24d31445073fd21e01706d8",
+    "diagnostic.json": "9384ee9dd74d72dc5650b700620af0131934f8027737ab77e2d15727b77b09b0",
+    "output.json": "b36a6dbda6b6371af011fbd621b5ea90ab6472c5c0a11f484e37a766cd555312",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl.nc": {
-      "sha256": "e9eff2c8b11fa104237eb92d0df592878eba1dde1d338343fdad17d395b23a12",
-      "size": 107766
+      "sha256": "e88f7f11cf4221a5c075e1ce158871d4b59e0ec152ce9afdd28b54bd780369f2",
+      "size": 107762
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown01.png": {
       "sha256": "e27a94438889df6757bde18c01673ff5b9d7b9182f28d38e719cc72212249f26",
@@ -20,12 +20,12 @@
       "size": 38743
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown03.png": {
-      "sha256": "2e0b7aeddbee351669fcb1def415a2605ffaf4d57b9101c195573363cc3ae2f8",
-      "size": 50311
+      "sha256": "f142e3db3caf3d2d42b04b19cf6fbade02484066ea1b826ab09e7788a4583b2d",
+      "size": 50307
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf.nc": {
-      "sha256": "f6911fd5d6a66f7b1e7e966ec0134f999c281d465389503a768663439a5e3226",
-      "size": 1868213
+      "sha256": "7b28dfefcc28dcd025c3460dbe7220820afca89c5658ccfac8a54bcf33948a92",
+      "size": 1868102
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown01.png": {
       "sha256": "46fc6986517fb4495f12b7a26f7bb9e8e4f0e9f4f3d8f94dfdfe41c712499b5e",
@@ -40,8 +40,8 @@
       "size": 74235
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown04.png": {
-      "sha256": "3c300f7498b86e4c05f60f92354df7319e3a0d916da86634898254c809fb8e19",
-      "size": 86464
+      "sha256": "4e15de6205c1830ad2ca33dadb6ce220a82c2d13618a8753312772e96d419b00",
+      "size": 86508
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown05.png": {
       "sha256": "920026c9ec5cc0372a264a5a3e22a5882e18a473e465be325939075a3b608ad6",
@@ -52,16 +52,16 @@
       "size": 86797
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown07.png": {
-      "sha256": "48caad49a558e4008b91a7c16170b45f2fae490707ab7c535bf8e9c305852c37",
-      "size": 82311
+      "sha256": "b9e3fa88864060a65e4caa10631f74bc3dfa33f352e2554babbe4b5204e50ca6",
+      "size": 82316
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown08.png": {
       "sha256": "1f3fc3beecd9d658411992fafd77cfa718e94f2b476934a7817a3d0d7ffceff2",
       "size": 112383
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown09.png": {
-      "sha256": "30d5f16c6496e2cf11763397b0024234ee7c9967b2411ed3b830dbace6fdddf6",
-      "size": 144763
+      "sha256": "b7a883a79aa752fec513c1df1c14e6f55b5ea694b4ae235f4867ac37d299acdc",
+      "size": 144544
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown10.png": {
       "sha256": "63f5aa29423fe74d99d02a2f4473f3cc2e66aae222a4ebbadf720478b716c8b7",
@@ -72,12 +72,12 @@
       "size": 149340
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown12.png": {
-      "sha256": "4ed38d176c9678b6bb440dd5ea8eeb0af9595d057ef013af7fc66dc19898f3e6",
-      "size": 140667
+      "sha256": "05336b8bd9f0470816f2b88171bfe1a2d41cda27a3061b97427c6c9b6caa507d",
+      "size": 140657
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja.nc": {
-      "sha256": "eb7cc7fb2363887db6b29e4a70321a2fc35ddcd97363f71938ecbd9f6366a970",
-      "size": 1866745
+      "sha256": "f24824a8ccc947fdee8187e44925317d8c51743530b990cd410a8f0f18eabcb0",
+      "size": 1866627
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown01.png": {
       "sha256": "dc5ac335a28a76c12d5c7552469ee2064ffd19c3973334ad5208fa7b4b17c3a9",
@@ -92,8 +92,8 @@
       "size": 73994
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown04.png": {
-      "sha256": "034757dfcdfa3eb83b639a46099fd5ae29a7a2ade5b26b2ff07d7035796364ae",
-      "size": 91891
+      "sha256": "5db25576a2553a3fe4a326220a0f97d085ce00a8c8742f8799d97004ecd59848",
+      "size": 91843
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown05.png": {
       "sha256": "107f765addcc277086774bfbbee946f243e6105b7219a8719d7ae9cf2ae6c064",
@@ -104,16 +104,16 @@
       "size": 95229
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown07.png": {
-      "sha256": "bda133c931a0c98675b6022096bba0c43364a47d40deef4a99014ab4bd71aaa2",
-      "size": 80118
+      "sha256": "af03d122a8760272cfad402438c05aa6b8bcea339e6275569899cf0678b0afa6",
+      "size": 80117
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown08.png": {
       "sha256": "13b29d1e384c2ba05ba4a787d6ffa50fdf46eb6530f5634f805389c48f53d2be",
       "size": 121895
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown09.png": {
-      "sha256": "0bc85001e3333c31eca6f31e89b707813c24f2e132d96432434a8af587660c41",
-      "size": 166075
+      "sha256": "d494a1df5defcf19e895cbb00888ba460bf5298a9dd0575f80606ad4b96ff6a1",
+      "size": 165952
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown10.png": {
       "sha256": "b5b4b7cc668a4cf2d5c17c7d53c28f5adc7f386f421c7b5cf5f832c1d153b258",
@@ -124,12 +124,12 @@
       "size": 171119
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown12.png": {
-      "sha256": "cc5535328c9a8f1d33551bbd598ef0bc007663c9ecfc1f6e504ff74543d4b7bb",
-      "size": 139211
+      "sha256": "c19f71c763de60713c4db09d1cfe19eed974f8ee4c87f27ade4613f657121485",
+      "size": 139140
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality.nc": {
-      "sha256": "c8297eba33fcd80f605d24240d4355ebfdee067007709b6d881df757b78c6021",
-      "size": 221685
+      "sha256": "ecb6bf1ba2903fa883c06e48f2f2a82f7a89739d063218a52968af8b1de27024",
+      "size": 221674
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown01.png": {
       "sha256": "43af1568794a3b6900ec3f53d4622a467e911d9f90ce750743c43327ed8452f7",
@@ -148,40 +148,40 @@
       "size": 42994
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown05.png": {
-      "sha256": "31aa7aa6c51982ab05ffdebf0825a641d5187163abd4a15b2a05f8dd53a0e666",
+      "sha256": "882016fdd48f0546f24626c2a664e553570f84d8bdcbc26bd2cf1d7c78b461c7",
       "size": 84487
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse.nc": {
-      "sha256": "22d8f1decbc17979627f8c83f635edb182c4d5dbfaca28bd0548147ca85b5f19",
-      "size": 248969
+      "sha256": "2b12d8b4a1382a0635993ca6abb575f8e0649efabf8b3a083ee59ae3b010cd21",
+      "size": 248937
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown01.png": {
       "sha256": "062f611b4eb3d930250d758677dfed2c5f39bf025c53f8b0fd991a6c8aabeda2",
       "size": 36659
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown02.png": {
-      "sha256": "7b0387120fb9a9e5d274b7df7701f3effdeccd3d1d8183de97796244f349e6a3",
-      "size": 51257
+      "sha256": "95cf93652e8ff907ed987c25299ed8537695174b3b8cc4f2bbaf9065b624dc34",
+      "size": 51264
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown03.png": {
       "sha256": "ee42a9a486796a8754cfc5264dd3dfa4f0bac6343aad96fbc9a7cc941876e574",
       "size": 41976
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown04.png": {
-      "sha256": "9518e448bd2078e63f880dd7288686515ca977f267daae7ee127cc72cf0fd111",
-      "size": 80935
+      "sha256": "80f27577f7492396f2f15c07f421bdf7cbab0d64392dde0512b36c79d68e81fb",
+      "size": 80932
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_cmec.json": {
-      "sha256": "d034ffe5eadd5f06351c936e849ecb60648ddee7da022f4f86ddcaf202d8387a",
-      "size": 5608
+      "sha256": "b336f074251dea3eb09040a277ba77e6d225252c1e4800bc57d49f28b7d10952",
+      "size": 5615
     },
     "diagnostic.json": {
-      "sha256": "7ddd31d0e2138352814fcc008f4a76c45dd5e8507d6407fdade6dd8a5525fd74",
-      "size": 3638
+      "sha256": "b508ffc1a2274ef012163eb4808d0bee96ce4f9a75347236fe1d03ed82cb6835",
+      "size": 3814
     },
     "output.json": {
-      "sha256": "4705bd794a970e7ce40634131b1ccfa82602a0cd07c6f432ca11c4372dbfed85",
-      "size": 13750
+      "sha256": "8e94c268efcc8aa9da25f18cff9a2fef15ab06497e4db8b88025bc74473bbf67",
+      "size": 13757
     },
     "series.json": {
       "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
@@ -189,5 +189,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip6/regression/diagnostic.json
@@ -7,14 +7,18 @@
       "gn": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
       "grid_label",
       "experiment_id",
       "metric",
-      "reference_datasets"
+      "reference_source_id"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -32,7 +36,7 @@
     "mip_id": {
       "cmip6": {}
     },
-    "reference_datasets": {
+    "reference_source_id": {
       "HadISST": {},
       "HadISST_GPCP-Monthly-3-2": {},
       "Tropflux": {},
@@ -45,9 +49,9 @@
   "DISCLAIMER": null,
   "NOTES": null,
   "PROVENANCE": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "openGL": {
@@ -73,52 +77,54 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"
   },
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "gn": {
-            "historical": {
-              "EnsoAmpl": {
-                "HadISST": 4.523476,
-                "Tropflux": 11.96119
-              },
-              "EnsoPrMapDjfCorr": {
-                "HadISST_GPCP-Monthly-3-2": 0.4519817,
-                "Tropflux_GPCP-Monthly-3-2": 0.4513125
-              },
-              "EnsoPrMapDjfRmse": {
-                "HadISST_GPCP-Monthly-3-2": 0.2905137,
-                "Tropflux_GPCP-Monthly-3-2": 0.2843175
-              },
-              "EnsoPrMapDjfStd": {
-                "HadISST_GPCP-Monthly-3-2": 0.8674358,
-                "Tropflux_GPCP-Monthly-3-2": 0.8962471
-              },
-              "EnsoPrMapJjaCorr": {
-                "HadISST_GPCP-Monthly-3-2": 0.6199641,
-                "Tropflux_GPCP-Monthly-3-2": 0.6203502
-              },
-              "EnsoPrMapJjaRmse": {
-                "HadISST_GPCP-Monthly-3-2": 0.3951534,
-                "Tropflux_GPCP-Monthly-3-2": 0.3815532
-              },
-              "EnsoPrMapJjaStd": {
-                "HadISST_GPCP-Monthly-3-2": 0.8849127,
-                "Tropflux_GPCP-Monthly-3-2": 0.9411801
-              },
-              "EnsoSeasonality": {
-                "HadISST": 32.72831,
-                "Tropflux": 45.59915
-              },
-              "EnsoSstLonRmse": {
-                "HadISST": 0.2041643,
-                "Tropflux": 0.2053258
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "gn": {
+              "historical": {
+                "EnsoAmpl": {
+                  "HadISST": 4.523476,
+                  "Tropflux": 11.96119
+                },
+                "EnsoPrMapDjfCorr": {
+                  "HadISST_GPCP-Monthly-3-2": 0.4519817,
+                  "Tropflux_GPCP-Monthly-3-2": 0.4513125
+                },
+                "EnsoPrMapDjfRmse": {
+                  "HadISST_GPCP-Monthly-3-2": 0.2905137,
+                  "Tropflux_GPCP-Monthly-3-2": 0.2843175
+                },
+                "EnsoPrMapDjfStd": {
+                  "HadISST_GPCP-Monthly-3-2": 0.8674358,
+                  "Tropflux_GPCP-Monthly-3-2": 0.8962471
+                },
+                "EnsoPrMapJjaCorr": {
+                  "HadISST_GPCP-Monthly-3-2": 0.6199641,
+                  "Tropflux_GPCP-Monthly-3-2": 0.6203502
+                },
+                "EnsoPrMapJjaRmse": {
+                  "HadISST_GPCP-Monthly-3-2": 0.3951534,
+                  "Tropflux_GPCP-Monthly-3-2": 0.3815532
+                },
+                "EnsoPrMapJjaStd": {
+                  "HadISST_GPCP-Monthly-3-2": 0.8849127,
+                  "Tropflux_GPCP-Monthly-3-2": 0.9411801
+                },
+                "EnsoSeasonality": {
+                  "HadISST": 32.72831,
+                  "Tropflux": 45.59915
+                },
+                "EnsoSstLonRmse": {
+                  "HadISST": 0.2041643,
+                  "Tropflux": 0.2053258
+                }
               }
             }
           }

--- a/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip6/regression/output.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip6/regression/output.json
@@ -254,9 +254,9 @@
     }
   },
   "provenance": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "environment": {},
@@ -286,7 +286,7 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"

--- a/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip7/manifest.json
@@ -1,15 +1,15 @@
 {
   "catalog_hash": "503795d9f7c37f880ec82390dd660463ec7a5cc0",
   "committed": {
-    "diagnostic.json": "42920d1bab0c13987ba32dfe65b08ded4be44e49e08a03a28c22e4e73c1abbe4",
-    "output.json": "c62a83a4a1fd9a05e038666a26220d0f8dbaa25bd24d31445073fd21e01706d8",
+    "diagnostic.json": "fd3c4e0bbfdaf622d3e929243f9ec62e9e8fd0689371e4c4be37b5a24729a098",
+    "output.json": "b36a6dbda6b6371af011fbd621b5ea90ab6472c5c0a11f484e37a766cd555312",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl.nc": {
-      "sha256": "cc2458e45806d117169a1b96f523daf5a1a8d56489eefacdf118379d855db5f7",
-      "size": 107772
+      "sha256": "cded5b8c9fb4ccfd61b7857c3f4423b1b2362969c58f535e153175eb6ceb0b04",
+      "size": 107771
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown01.png": {
       "sha256": "e27a94438889df6757bde18c01673ff5b9d7b9182f28d38e719cc72212249f26",
@@ -20,28 +20,28 @@
       "size": 38746
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoAmpl_diagnostic_divedown03.png": {
-      "sha256": "7509b6a5ef519e7fc19a92e645ab0386664da89c81d36fa83001906bb3ded66b",
-      "size": 50314
+      "sha256": "053958c714fda8f085ce2ac9719eca440bf987e692517a2f73083d5fcb3afe6d",
+      "size": 50311
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf.nc": {
-      "sha256": "50b807370f3f791aa40534c02a97669291638656af86c7f19d99281e38caf881",
-      "size": 1399064
+      "sha256": "5f441c7f2251ef9d9774348fc6c9ca2f3bfbf3e0157d324dff05895d5f84af80",
+      "size": 1398946
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown01.png": {
-      "sha256": "71d67340694bbb5bf6e9251920c7e09208a3e90a1ecb01f9e7dcc33ae5f0f82d",
-      "size": 123946
+      "sha256": "73af1bd31f4f58b4bb6c7428c40ed0364ac8587c28c1790da5894be91673a130",
+      "size": 123943
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown02.png": {
-      "sha256": "fa1082b77b17ed8ee73d5ad6944b9d43005dec1bd2ca39f0e5b0d54eec2056f8",
-      "size": 215932
+      "sha256": "e2cec750dfc24979d89745e8bbbcbbb3e6c16fa039bc2ed520b0695be0c19ad1",
+      "size": 215922
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown03.png": {
       "sha256": "028c59276f0a1411ebb6efc4e416f59185a0ba34dae446cfbe72c1719c5b23f0",
       "size": 69397
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown04.png": {
-      "sha256": "f693e4b0a205f2f2da8d08599866425f105a4348025cd7ab58949aa30a10b75c",
-      "size": 83669
+      "sha256": "9939dfc20681817875b44ee07dd1c4ce685233a3fde7186aa04fe2cc4f300c6e",
+      "size": 83636
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown05.png": {
       "sha256": "4dad91279ea92ea75b80058e566e7c174b4dd44828bcee7adb39be4ddde1bf8e",
@@ -52,16 +52,16 @@
       "size": 85495
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown07.png": {
-      "sha256": "6a92e9e97b8c2d3da7e61c721cd5be5c3c3bf29e82d0eb938c179a9e3ed59287",
-      "size": 80573
+      "sha256": "3a82ed7fa83190e127b751a6cf61bc2ac132e7ba9bace49b0556a3fde36beb45",
+      "size": 80624
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown08.png": {
       "sha256": "8721479fccf473f88e0e8e2980cf71a88234ebf6608f798689db5fc6ccf8aaf9",
       "size": 105917
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown09.png": {
-      "sha256": "bda9e250652f1adf3ac1af1cd51205d9f70ac829a53f57043e0077fc91baa2cd",
-      "size": 141388
+      "sha256": "9847e884e2b14e543a155351ac260c27bb1fb6364d4e229c58e2236d84883c46",
+      "size": 141285
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown10.png": {
       "sha256": "d8a0a507e68df3f81382c0c87d9c6ce93dfe8616914b343c1d049fce4363411a",
@@ -72,28 +72,28 @@
       "size": 147303
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapDjf_diagnostic_divedown12.png": {
-      "sha256": "615854a335c96ac0f2b0c7cdd85d9622fe9f1967876053f48e61f9748199b1e4",
-      "size": 136728
+      "sha256": "470548e3f00b3ae2d8c2723a83fb90cd4fdf8c7d9aea6eea1e79d0c771f0cbc4",
+      "size": 136692
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja.nc": {
-      "sha256": "8d26b070606cd98f7dc9f2767316cdc8c85b427972e9b284d1558c0be167f19d",
-      "size": 1397977
+      "sha256": "158f989b9efb87911b0d621bd840c2fde1526968ca95e9db61bbb361589da03b",
+      "size": 1397892
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown01.png": {
-      "sha256": "63f28a17787d949c54d81565c50977af038a8adccb5c43bd25befb65aafb9f21",
-      "size": 134055
+      "sha256": "eee0dc94097dad5fcf94d7ac39ed5323aaa17b17737eb510ab31d967ca34f0ba",
+      "size": 134058
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown02.png": {
-      "sha256": "169b4c407a14fa1450ea1601ebdd117af63378e93049a6dc80bef5e754d08039",
-      "size": 253613
+      "sha256": "2f3d706c0d17d60c4259cab129567fd53af6079de83c9633c7c08d0301b71722",
+      "size": 253601
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown03.png": {
       "sha256": "fb4d3d74f9ce5cb31e41188a2ba459beb34a5537ef36a01b7956da427cf405bc",
       "size": 68939
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown04.png": {
-      "sha256": "fef88aa8f4eb35c5bd0f998a25780c4825b1e178a18105cd500aa8885f9d64d1",
-      "size": 88436
+      "sha256": "ece329a5fb035daa3ca81bb31ab2f1178a751afa9c5411b8bdd578074eb4d62a",
+      "size": 88399
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown05.png": {
       "sha256": "39947e912bab8c5f62fa7accb707e55af351da6b3ccebe255bce849840c498a9",
@@ -104,16 +104,16 @@
       "size": 91312
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown07.png": {
-      "sha256": "bbf6a2161766e794e51af962f1af56d440685d0c7219ac84e2239c24b3d64283",
-      "size": 77977
+      "sha256": "1b63e2708272af065ec25137cab1921475436af9b070e164cf82cf27ea64276f",
+      "size": 77979
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown08.png": {
       "sha256": "51fbd3f57063b6bca3578a478b609ef3f0038f3585015461460afd3adc8e3965",
       "size": 112494
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown09.png": {
-      "sha256": "941974e48114f52d139a9a3ec9e0ea020561a1aeea066ed83da73261f3ed30eb",
-      "size": 155892
+      "sha256": "6567b0d49caa19bb967258a168533b5e16b23e3c5997a082bfa6e4f99549304f",
+      "size": 155799
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown10.png": {
       "sha256": "f3f38169266aa853295184133c3cd89227860b4097be525c4a6ffdeecc99e087",
@@ -124,12 +124,12 @@
       "size": 163127
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoPrMapJja_diagnostic_divedown12.png": {
-      "sha256": "791269e78c3ea45aa1e27383384b76f519d500362fc4f6547764c75f87154cb4",
-      "size": 134912
+      "sha256": "ed78d81889a65579279b2121de9587880989d788a0699ee7004ea1d6e5a15479",
+      "size": 134859
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality.nc": {
-      "sha256": "3b818b05dd93feb6600b7adfafa5c257d086db4e218120640f1a203bd4083ec4",
-      "size": 221713
+      "sha256": "68bff8460c07293cc78b9e80737ea377d3bf71c7d288705c447f5d83f25fb42d",
+      "size": 221707
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown01.png": {
       "sha256": "43af1568794a3b6900ec3f53d4622a467e911d9f90ce750743c43327ed8452f7",
@@ -148,40 +148,40 @@
       "size": 43008
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSeasonality_diagnostic_divedown05.png": {
-      "sha256": "11d163f69d6934003656f60de8f5e6b13bf64fe702d1e6d72addf6edd0920c7c",
+      "sha256": "1d47f8e8740d5c7426d3c1c4d19d20f325502e8119bf1e4fbf6a57442200f16b",
       "size": 84486
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse.nc": {
-      "sha256": "3c624cd84d9e40d551d4a8c5a3e69a152fcce7452fb8d4efc6e5bc1cb4232d4e",
-      "size": 248985
+      "sha256": "1162b656507cdbbed5401423c2a1e119ff5433660f84618b2b14207cf513c79f",
+      "size": 248950
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown01.png": {
       "sha256": "67b582c3b47b7d876e5992f7b4a2f83a0f07c6a4ee005f9713007911aa6ff0e2",
       "size": 36654
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown02.png": {
-      "sha256": "d8df12f997d8872dbe053739b1afcf586234b6cca24884a00f1ff51628af1eed",
-      "size": 51263
+      "sha256": "857670fdfb84d8039d06c97bb8950908157e4d68efa8ee0a64172cb3f692660f",
+      "size": 51270
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown03.png": {
       "sha256": "6341f7604417bde669f62de88fe034c39486b0922792f00c9ad8031cf880b2a2",
       "size": 41988
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_EnsoSstLonRmse_diagnostic_divedown04.png": {
-      "sha256": "9518e448bd2078e63f880dd7288686515ca977f267daae7ee127cc72cf0fd111",
-      "size": 80935
+      "sha256": "80f27577f7492396f2f15c07f421bdf7cbab0d64392dde0512b36c79d68e81fb",
+      "size": 80932
     },
     "ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1_cmec.json": {
-      "sha256": "8b20c0b78db686ad9a9dae654929d88dc6717a36a07dff54d439fd1a2baed1da",
-      "size": 5611
+      "sha256": "6a1a12482f17582e126b07b5c077000103600f0d1c5608b45b77c1b1b6d873f9",
+      "size": 5640
     },
     "diagnostic.json": {
-      "sha256": "1e6ea55932fde719c8298375abb58dfca714fb0c85a8654b68398c1626aeac35",
-      "size": 3641
+      "sha256": "85e20a10b39a10b22111ef2e2bdb61617edf39ee7800747cfdc2aa6b11e0ed66",
+      "size": 3815
     },
     "output.json": {
-      "sha256": "ffe3a11cfec48afadb62de6e7c35a4dcfe2165be3ab7f0f844019d6e6a027f61",
-      "size": 13750
+      "sha256": "e6f5981057456d0799160b184f6c67b653c99b237ab6ea4baa214cae89615814",
+      "size": 13757
     },
     "series.json": {
       "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
@@ -189,5 +189,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip7/regression/diagnostic.json
@@ -7,14 +7,18 @@
       "gn": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
       "grid_label",
       "experiment_id",
       "metric",
-      "reference_datasets"
+      "reference_source_id"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -32,7 +36,7 @@
     "mip_id": {
       "cmip7": {}
     },
-    "reference_datasets": {
+    "reference_source_id": {
       "HadISST": {},
       "HadISST_GPCP-Monthly-3-2": {},
       "Tropflux": {},
@@ -45,9 +49,9 @@
   "DISCLAIMER": null,
   "NOTES": null,
   "PROVENANCE": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "openGL": {
@@ -73,52 +77,54 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"
   },
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "gn": {
-            "historical": {
-              "EnsoAmpl": {
-                "HadISST": 4.52348,
-                "Tropflux": 11.96119
-              },
-              "EnsoPrMapDjfCorr": {
-                "HadISST_GPCP-Monthly-3-2": 0.9896444,
-                "Tropflux_GPCP-Monthly-3-2": 0.992659
-              },
-              "EnsoPrMapDjfRmse": {
-                "HadISST_GPCP-Monthly-3-2": 0.3324479,
-                "Tropflux_GPCP-Monthly-3-2": 0.3224907
-              },
-              "EnsoPrMapDjfStd": {
-                "HadISST_GPCP-Monthly-3-2": 0.2176367,
-                "Tropflux_GPCP-Monthly-3-2": 0.2248654
-              },
-              "EnsoPrMapJjaCorr": {
-                "HadISST_GPCP-Monthly-3-2": 0.9429559,
-                "Tropflux_GPCP-Monthly-3-2": 0.9243506
-              },
-              "EnsoPrMapJjaRmse": {
-                "HadISST_GPCP-Monthly-3-2": 0.3930524,
-                "Tropflux_GPCP-Monthly-3-2": 0.3698306
-              },
-              "EnsoPrMapJjaStd": {
-                "HadISST_GPCP-Monthly-3-2": 0.3488679,
-                "Tropflux_GPCP-Monthly-3-2": 0.3710508
-              },
-              "EnsoSeasonality": {
-                "HadISST": 32.72842,
-                "Tropflux": 45.59924
-              },
-              "EnsoSstLonRmse": {
-                "HadISST": 0.2041627,
-                "Tropflux": 0.2053245
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "gn": {
+              "historical": {
+                "EnsoAmpl": {
+                  "HadISST": 4.52348,
+                  "Tropflux": 11.96119
+                },
+                "EnsoPrMapDjfCorr": {
+                  "HadISST_GPCP-Monthly-3-2": 0.9896444,
+                  "Tropflux_GPCP-Monthly-3-2": 0.992659
+                },
+                "EnsoPrMapDjfRmse": {
+                  "HadISST_GPCP-Monthly-3-2": 0.3324479,
+                  "Tropflux_GPCP-Monthly-3-2": 0.3224907
+                },
+                "EnsoPrMapDjfStd": {
+                  "HadISST_GPCP-Monthly-3-2": 0.2176367,
+                  "Tropflux_GPCP-Monthly-3-2": 0.2248654
+                },
+                "EnsoPrMapJjaCorr": {
+                  "HadISST_GPCP-Monthly-3-2": 0.9429559,
+                  "Tropflux_GPCP-Monthly-3-2": 0.9243506
+                },
+                "EnsoPrMapJjaRmse": {
+                  "HadISST_GPCP-Monthly-3-2": 0.3930524,
+                  "Tropflux_GPCP-Monthly-3-2": 0.3698306
+                },
+                "EnsoPrMapJjaStd": {
+                  "HadISST_GPCP-Monthly-3-2": 0.3488679,
+                  "Tropflux_GPCP-Monthly-3-2": 0.3710508
+                },
+                "EnsoSeasonality": {
+                  "HadISST": 32.72842,
+                  "Tropflux": 45.59924
+                },
+                "EnsoSstLonRmse": {
+                  "HadISST": 0.2041627,
+                  "Tropflux": 0.2053245
+                }
               }
             }
           }

--- a/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip7/regression/output.json
+++ b/packages/climate-ref-pmp/tests/test-data/enso_tel/cmip7/regression/output.json
@@ -254,9 +254,9 @@
     }
   },
   "provenance": {
-    "commandLine": "/home/jared/code/climate-ref/climate-ref/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
+    "commandLine": "<SOURCE_DIR>/packages/climate-ref-pmp/src/climate_ref_pmp/drivers/enso_driver.py --metrics_collection ENSO_tel --experiment_id historical --input_json_path <OUTPUT_DIR>/input_ENSO_tel_ACCESS-ESM1-5_historical_r1i1p1f1.json --output_directory <OUTPUT_DIR>",
     "conda": {
-      "Platform": "linux-64"
+      "Platform": "osx-64"
     },
     "date": "<DATE>",
     "environment": {},
@@ -286,7 +286,7 @@
     },
     "platform": {
       "Name": "<HOSTNAME>",
-      "OS": "Linux",
+      "OS": "<OS>",
       "Version": "<HOST_VERSION>"
     },
     "userId": "<USER>"

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip6/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "97fbf6c3eafe72779d017d41744a0f69504f6128",
   "committed": {
-    "diagnostic.json": "45aa7f6d1899f09338c22fa738e6d73cd48738ffa9e45fdd3dfcba68f022f3d5",
+    "diagnostic.json": "474b4d381ca108722cc03438aa76dbe66ecbe9e761b33699b7c97e6c94d20472",
     "output.json": "1904facfa2f658600751747cfab2d2e6fbcc603ecb40de975d5e6af793c44300",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NAM_DJF_20CR_1900-2005.png": {
       "sha256": "14de2e777b2c8b9c46c9743c6e8ae3273612e1c95aab68d05ab59d6f550f9e7d",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip6/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "NAM": {
-                "DJF": {
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "NAM": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.001614665,
+                      "bias_glo": -0.07374438,
+                      "cor": 0.9122557,
+                      "cor_glo": 0.8959437,
+                      "frac": 0.2672991,
+                      "frac_cbf_regrid": 0.2409953,
+                      "mean": -5.039542e-16,
+                      "mean_glo": 0.01314797,
+                      "rms": 0.6257416,
+                      "rms_glo": 0.4072847,
+                      "rmsc": 0.4189135,
+                      "rmsc_glo": 0.4561935,
+                      "stdv_pc": 1.301092,
+                      "stdv_pc_ratio_to_obs": 0.8530489
+                    },
+                    "eof1": {
+                      "bias": 0.0004279631,
+                      "bias_glo": -0.1620439,
+                      "cor": 0.8256633,
+                      "cor_glo": 0.8041839,
+                      "frac": 0.2856316,
+                      "mean": 4.605447e-16,
+                      "mean_glo": -0.07515149,
+                      "rms": 0.8812765,
+                      "rms_glo": 0.5734021,
+                      "rmsc": 0.5904858,
+                      "rmsc_glo": 0.6258053,
+                      "stdv_pc": 1.483128,
+                      "stdv_pc_ratio_to_obs": 0.9723986
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.0006930083,
+                      "bias_glo": 0.01087053,
+                      "cor": 0.8989167,
+                      "cor_glo": 0.5829342,
+                      "frac": 0.1779587,
+                      "frac_cbf_regrid": 0.1535958,
+                      "mean": -6.276353e-16,
+                      "mean_glo": 0.08656026,
+                      "rms": 0.2613816,
+                      "rms_glo": 0.3678671,
+                      "rmsc": 0.4496295,
+                      "rmsc_glo": 0.913308,
+                      "stdv_pc": 0.5240269,
+                      "stdv_pc_ratio_to_obs": 0.9041266
+                    },
+                    "eof1": {
+                      "bias": -3.341587e-05,
+                      "bias_glo": 0.004174872,
+                      "cor": 0.7952055,
+                      "cor_glo": 0.5352145,
+                      "frac": 0.1943858,
+                      "mean": -5.131265e-16,
+                      "mean_glo": 0.0798646,
+                      "rms": 0.3814648,
+                      "rms_glo": 0.3894894,
+                      "rmsc": 0.6399913,
+                      "rmsc_glo": 0.9641426,
+                      "stdv_pc": 0.6134163,
+                      "stdv_pc_ratio_to_obs": 1.058354
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.001001263,
+                      "bias_glo": -0.00795875,
+                      "cor": 0.8982052,
+                      "cor_glo": 0.8428057,
+                      "frac": 0.2811495,
+                      "frac_cbf_regrid": 0.2457336,
+                      "mean": -5.501039e-16,
+                      "mean_glo": 0.09398052,
+                      "rms": 0.4921456,
+                      "rms_glo": 0.3614432,
+                      "rmsc": 0.4512089,
+                      "rmsc_glo": 0.5607037,
+                      "stdv_pc": 1.002294,
+                      "stdv_pc_ratio_to_obs": 1.041496
+                    },
+                    "eof1": {
+                      "bias": 0.001170515,
+                      "bias_glo": 0.0100802,
+                      "cor": 0.8562952,
+                      "cor_glo": 0.8117233,
+                      "frac": 0.2930142,
+                      "mean": -6.349616e-16,
+                      "mean_glo": 0.1120195,
+                      "rms": 0.5885357,
+                      "rms_glo": 0.4012126,
+                      "rmsc": 0.536106,
+                      "rmsc_glo": 0.6136395,
+                      "stdv_pc": 1.146558,
+                      "stdv_pc_ratio_to_obs": 1.191403
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.000681538,
+                      "bias_glo": 0.03935749,
+                      "cor": 0.9050808,
+                      "cor_glo": 0.7937909,
+                      "frac": 0.133584,
+                      "frac_cbf_regrid": 0.1233912,
+                      "mean": -3.544294e-16,
+                      "mean_glo": 0.03253027,
+                      "rms": 0.3128833,
+                      "rms_glo": 0.2971667,
+                      "rmsc": 0.4357046,
+                      "rmsc_glo": 0.6421979,
+                      "stdv_pc": 0.6373932,
+                      "stdv_pc_ratio_to_obs": 0.875526
+                    },
+                    "eof1": {
+                      "bias": -0.0004262385,
+                      "bias_glo": -0.04572016,
+                      "cor": 0.4348217,
+                      "cor_glo": 0.3456728,
+                      "frac": 0.2051465,
+                      "mean": 2.681872e-16,
+                      "mean_glo": -0.05254739,
+                      "rms": 0.8594933,
+                      "rms_glo": 0.572704,
+                      "rmsc": 1.063182,
+                      "rmsc_glo": 1.143964,
+                      "stdv_pc": 0.8782916,
+                      "stdv_pc_ratio_to_obs": 1.206425
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.001614665,
-                    "bias_glo": -0.07374438,
-                    "cor": 0.9122557,
-                    "cor_glo": 0.8959437,
-                    "frac": 0.2672991,
-                    "frac_cbf_regrid": 0.2409953,
-                    "mean": -5.039542e-16,
-                    "mean_glo": 0.01314797,
-                    "rms": 0.6257416,
-                    "rms_glo": 0.4072847,
-                    "rmsc": 0.4189135,
-                    "rmsc_glo": 0.4561935,
-                    "stdv_pc": 1.301092,
-                    "stdv_pc_ratio_to_obs": 0.8530489
-                  },
-                  "eof1": {
-                    "bias": 0.0004279631,
-                    "bias_glo": -0.1620439,
-                    "cor": 0.8256633,
-                    "cor_glo": 0.8041839,
-                    "frac": 0.2856316,
-                    "mean": 4.605447e-16,
-                    "mean_glo": -0.07515149,
-                    "rms": 0.8812765,
-                    "rms_glo": 0.5734021,
-                    "rmsc": 0.5904858,
-                    "rmsc_glo": 0.6258053,
-                    "stdv_pc": 1.483128,
-                    "stdv_pc_ratio_to_obs": 0.9723986
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.0006930083,
-                    "bias_glo": 0.01087053,
-                    "cor": 0.8989167,
-                    "cor_glo": 0.5829342,
-                    "frac": 0.1779587,
-                    "frac_cbf_regrid": 0.1535958,
-                    "mean": -6.276353e-16,
-                    "mean_glo": 0.08656026,
-                    "rms": 0.2613816,
-                    "rms_glo": 0.3678671,
-                    "rmsc": 0.4496295,
-                    "rmsc_glo": 0.913308,
-                    "stdv_pc": 0.5240269,
-                    "stdv_pc_ratio_to_obs": 0.9041266
-                  },
-                  "eof1": {
-                    "bias": -3.341587e-05,
-                    "bias_glo": 0.004174872,
-                    "cor": 0.7952055,
-                    "cor_glo": 0.5352145,
-                    "frac": 0.1943858,
-                    "mean": -5.131265e-16,
-                    "mean_glo": 0.0798646,
-                    "rms": 0.3814648,
-                    "rms_glo": 0.3894894,
-                    "rmsc": 0.6399913,
-                    "rmsc_glo": 0.9641426,
-                    "stdv_pc": 0.6134163,
-                    "stdv_pc_ratio_to_obs": 1.058354
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.001001263,
-                    "bias_glo": -0.00795875,
-                    "cor": 0.8982052,
-                    "cor_glo": 0.8428057,
-                    "frac": 0.2811495,
-                    "frac_cbf_regrid": 0.2457336,
-                    "mean": -5.501039e-16,
-                    "mean_glo": 0.09398052,
-                    "rms": 0.4921456,
-                    "rms_glo": 0.3614432,
-                    "rmsc": 0.4512089,
-                    "rmsc_glo": 0.5607037,
-                    "stdv_pc": 1.002294,
-                    "stdv_pc_ratio_to_obs": 1.041496
-                  },
-                  "eof1": {
-                    "bias": 0.001170515,
-                    "bias_glo": 0.0100802,
-                    "cor": 0.8562952,
-                    "cor_glo": 0.8117233,
-                    "frac": 0.2930142,
-                    "mean": -6.349616e-16,
-                    "mean_glo": 0.1120195,
-                    "rms": 0.5885357,
-                    "rms_glo": 0.4012126,
-                    "rmsc": 0.536106,
-                    "rmsc_glo": 0.6136395,
-                    "stdv_pc": 1.146558,
-                    "stdv_pc_ratio_to_obs": 1.191403
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.000681538,
-                    "bias_glo": 0.03935749,
-                    "cor": 0.9050808,
-                    "cor_glo": 0.7937909,
-                    "frac": 0.133584,
-                    "frac_cbf_regrid": 0.1233912,
-                    "mean": -3.544294e-16,
-                    "mean_glo": 0.03253027,
-                    "rms": 0.3128833,
-                    "rms_glo": 0.2971667,
-                    "rmsc": 0.4357046,
-                    "rmsc_glo": 0.6421979,
-                    "stdv_pc": 0.6373932,
-                    "stdv_pc_ratio_to_obs": 0.875526
-                  },
-                  "eof1": {
-                    "bias": -0.0004262385,
-                    "bias_glo": -0.04572016,
-                    "cor": 0.4348217,
-                    "cor_glo": 0.3456728,
-                    "frac": 0.2051465,
-                    "mean": 2.681872e-16,
-                    "mean_glo": -0.05254739,
-                    "rms": 0.8594933,
-                    "rms_glo": 0.572704,
-                    "rmsc": 1.063182,
-                    "rmsc_glo": 1.143964,
-                    "stdv_pc": 0.8782916,
-                    "stdv_pc_ratio_to_obs": 1.206425
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip7/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "d8fe04e12ce8e9b2a628bc79d539f17e62478ab1",
   "committed": {
-    "diagnostic.json": "110267bd03f67a383e90ce781976749964311279585abb8f8fa794d9155c1055",
+    "diagnostic.json": "ebc58d4d0b6c13550ff0dc378293601a691283bb42a26b789201fe349677c85c",
     "output.json": "dd8293b4698a4332c2137e87b6f3550eb6fb388aa60c5f06fbc662b4ec7f6edd",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NAM_DJF_20CR_1900-2005.png": {
       "sha256": "14de2e777b2c8b9c46c9743c6e8ae3273612e1c95aab68d05ab59d6f550f9e7d",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nam/cmip7/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "NAM": {
-                "DJF": {
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "NAM": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.001614665,
+                      "bias_glo": -0.07374438,
+                      "cor": 0.9122557,
+                      "cor_glo": 0.8959437,
+                      "frac": 0.2672991,
+                      "frac_cbf_regrid": 0.2409953,
+                      "mean": -5.039542e-16,
+                      "mean_glo": 0.01314797,
+                      "rms": 0.6257416,
+                      "rms_glo": 0.4072847,
+                      "rmsc": 0.4189135,
+                      "rmsc_glo": 0.4561935,
+                      "stdv_pc": 1.301092,
+                      "stdv_pc_ratio_to_obs": 0.8530489
+                    },
+                    "eof1": {
+                      "bias": 0.0004279631,
+                      "bias_glo": -0.1620439,
+                      "cor": 0.8256633,
+                      "cor_glo": 0.8041839,
+                      "frac": 0.2856316,
+                      "mean": 4.605447e-16,
+                      "mean_glo": -0.07515149,
+                      "rms": 0.8812765,
+                      "rms_glo": 0.5734021,
+                      "rmsc": 0.5904858,
+                      "rmsc_glo": 0.6258053,
+                      "stdv_pc": 1.483128,
+                      "stdv_pc_ratio_to_obs": 0.9723986
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.0006930083,
+                      "bias_glo": 0.01087053,
+                      "cor": 0.8989167,
+                      "cor_glo": 0.5829342,
+                      "frac": 0.1779587,
+                      "frac_cbf_regrid": 0.1535958,
+                      "mean": -6.276353e-16,
+                      "mean_glo": 0.08656026,
+                      "rms": 0.2613816,
+                      "rms_glo": 0.3678671,
+                      "rmsc": 0.4496295,
+                      "rmsc_glo": 0.913308,
+                      "stdv_pc": 0.5240269,
+                      "stdv_pc_ratio_to_obs": 0.9041266
+                    },
+                    "eof1": {
+                      "bias": -3.341587e-05,
+                      "bias_glo": 0.004174872,
+                      "cor": 0.7952055,
+                      "cor_glo": 0.5352145,
+                      "frac": 0.1943858,
+                      "mean": -5.131265e-16,
+                      "mean_glo": 0.0798646,
+                      "rms": 0.3814648,
+                      "rms_glo": 0.3894894,
+                      "rmsc": 0.6399913,
+                      "rmsc_glo": 0.9641426,
+                      "stdv_pc": 0.6134163,
+                      "stdv_pc_ratio_to_obs": 1.058354
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.001001263,
+                      "bias_glo": -0.00795875,
+                      "cor": 0.8982052,
+                      "cor_glo": 0.8428057,
+                      "frac": 0.2811495,
+                      "frac_cbf_regrid": 0.2457336,
+                      "mean": -5.501039e-16,
+                      "mean_glo": 0.09398052,
+                      "rms": 0.4921456,
+                      "rms_glo": 0.3614432,
+                      "rmsc": 0.4512089,
+                      "rmsc_glo": 0.5607037,
+                      "stdv_pc": 1.002294,
+                      "stdv_pc_ratio_to_obs": 1.041496
+                    },
+                    "eof1": {
+                      "bias": 0.001170515,
+                      "bias_glo": 0.0100802,
+                      "cor": 0.8562952,
+                      "cor_glo": 0.8117233,
+                      "frac": 0.2930142,
+                      "mean": -6.349616e-16,
+                      "mean_glo": 0.1120195,
+                      "rms": 0.5885357,
+                      "rms_glo": 0.4012126,
+                      "rmsc": 0.536106,
+                      "rmsc_glo": 0.6136395,
+                      "stdv_pc": 1.146558,
+                      "stdv_pc_ratio_to_obs": 1.191403
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.000681538,
+                      "bias_glo": 0.03935749,
+                      "cor": 0.9050808,
+                      "cor_glo": 0.7937909,
+                      "frac": 0.133584,
+                      "frac_cbf_regrid": 0.1233912,
+                      "mean": -3.544294e-16,
+                      "mean_glo": 0.03253027,
+                      "rms": 0.3128833,
+                      "rms_glo": 0.2971667,
+                      "rmsc": 0.4357046,
+                      "rmsc_glo": 0.6421979,
+                      "stdv_pc": 0.6373932,
+                      "stdv_pc_ratio_to_obs": 0.875526
+                    },
+                    "eof1": {
+                      "bias": -0.0004262385,
+                      "bias_glo": -0.04572016,
+                      "cor": 0.4348217,
+                      "cor_glo": 0.3456728,
+                      "frac": 0.2051465,
+                      "mean": 2.681872e-16,
+                      "mean_glo": -0.05254739,
+                      "rms": 0.8594933,
+                      "rms_glo": 0.572704,
+                      "rmsc": 1.063182,
+                      "rmsc_glo": 1.143964,
+                      "stdv_pc": 0.8782916,
+                      "stdv_pc_ratio_to_obs": 1.206425
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.001614665,
-                    "bias_glo": -0.07374438,
-                    "cor": 0.9122557,
-                    "cor_glo": 0.8959437,
-                    "frac": 0.2672991,
-                    "frac_cbf_regrid": 0.2409953,
-                    "mean": -5.039542e-16,
-                    "mean_glo": 0.01314797,
-                    "rms": 0.6257416,
-                    "rms_glo": 0.4072847,
-                    "rmsc": 0.4189135,
-                    "rmsc_glo": 0.4561935,
-                    "stdv_pc": 1.301092,
-                    "stdv_pc_ratio_to_obs": 0.8530489
-                  },
-                  "eof1": {
-                    "bias": 0.0004279631,
-                    "bias_glo": -0.1620439,
-                    "cor": 0.8256633,
-                    "cor_glo": 0.8041839,
-                    "frac": 0.2856316,
-                    "mean": 4.605447e-16,
-                    "mean_glo": -0.07515149,
-                    "rms": 0.8812765,
-                    "rms_glo": 0.5734021,
-                    "rmsc": 0.5904858,
-                    "rmsc_glo": 0.6258053,
-                    "stdv_pc": 1.483128,
-                    "stdv_pc_ratio_to_obs": 0.9723986
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.0006930083,
-                    "bias_glo": 0.01087053,
-                    "cor": 0.8989167,
-                    "cor_glo": 0.5829342,
-                    "frac": 0.1779587,
-                    "frac_cbf_regrid": 0.1535958,
-                    "mean": -6.276353e-16,
-                    "mean_glo": 0.08656026,
-                    "rms": 0.2613816,
-                    "rms_glo": 0.3678671,
-                    "rmsc": 0.4496295,
-                    "rmsc_glo": 0.913308,
-                    "stdv_pc": 0.5240269,
-                    "stdv_pc_ratio_to_obs": 0.9041266
-                  },
-                  "eof1": {
-                    "bias": -3.341587e-05,
-                    "bias_glo": 0.004174872,
-                    "cor": 0.7952055,
-                    "cor_glo": 0.5352145,
-                    "frac": 0.1943858,
-                    "mean": -5.131265e-16,
-                    "mean_glo": 0.0798646,
-                    "rms": 0.3814648,
-                    "rms_glo": 0.3894894,
-                    "rmsc": 0.6399913,
-                    "rmsc_glo": 0.9641426,
-                    "stdv_pc": 0.6134163,
-                    "stdv_pc_ratio_to_obs": 1.058354
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.001001263,
-                    "bias_glo": -0.00795875,
-                    "cor": 0.8982052,
-                    "cor_glo": 0.8428057,
-                    "frac": 0.2811495,
-                    "frac_cbf_regrid": 0.2457336,
-                    "mean": -5.501039e-16,
-                    "mean_glo": 0.09398052,
-                    "rms": 0.4921456,
-                    "rms_glo": 0.3614432,
-                    "rmsc": 0.4512089,
-                    "rmsc_glo": 0.5607037,
-                    "stdv_pc": 1.002294,
-                    "stdv_pc_ratio_to_obs": 1.041496
-                  },
-                  "eof1": {
-                    "bias": 0.001170515,
-                    "bias_glo": 0.0100802,
-                    "cor": 0.8562952,
-                    "cor_glo": 0.8117233,
-                    "frac": 0.2930142,
-                    "mean": -6.349616e-16,
-                    "mean_glo": 0.1120195,
-                    "rms": 0.5885357,
-                    "rms_glo": 0.4012126,
-                    "rmsc": 0.536106,
-                    "rmsc_glo": 0.6136395,
-                    "stdv_pc": 1.146558,
-                    "stdv_pc_ratio_to_obs": 1.191403
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.000681538,
-                    "bias_glo": 0.03935749,
-                    "cor": 0.9050808,
-                    "cor_glo": 0.7937909,
-                    "frac": 0.133584,
-                    "frac_cbf_regrid": 0.1233912,
-                    "mean": -3.544294e-16,
-                    "mean_glo": 0.03253027,
-                    "rms": 0.3128833,
-                    "rms_glo": 0.2971667,
-                    "rmsc": 0.4357046,
-                    "rmsc_glo": 0.6421979,
-                    "stdv_pc": 0.6373932,
-                    "stdv_pc_ratio_to_obs": 0.875526
-                  },
-                  "eof1": {
-                    "bias": -0.0004262385,
-                    "bias_glo": -0.04572016,
-                    "cor": 0.4348217,
-                    "cor_glo": 0.3456728,
-                    "frac": 0.2051465,
-                    "mean": 2.681872e-16,
-                    "mean_glo": -0.05254739,
-                    "rms": 0.8594933,
-                    "rms_glo": 0.572704,
-                    "rmsc": 1.063182,
-                    "rmsc_glo": 1.143964,
-                    "stdv_pc": 0.8782916,
-                    "stdv_pc_ratio_to_obs": 1.206425
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip6/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "97fbf6c3eafe72779d017d41744a0f69504f6128",
   "committed": {
-    "diagnostic.json": "11498f739b5b928b05b1399c572c4724ce356e2a365650dc9e5e9c79f0aedb48",
+    "diagnostic.json": "14a255f0a133e2132cbcc38d45418d886291df7807119c02e06f613347ad6857",
     "output.json": "bb89fc63c1a99abc12eb1a558ac088a1671620d3db6b132af7add1bf502e3ea8",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NAO_DJF_20CR_1900-2005.png": {
       "sha256": "474dc87d541ce4787d56ac7b7a93adc6f337607a759f62c0902efa3992a433f8",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip6/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "NAO": {
-                "DJF": {
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "NAO": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.003535991,
+                      "bias_glo": 0.2481177,
+                      "cor": 0.9478816,
+                      "cor_glo": 0.9001196,
+                      "frac": 0.3573224,
+                      "frac_cbf_regrid": 0.3059213,
+                      "mean": -1.629923e-15,
+                      "mean_glo": 0.0423566,
+                      "rms": 0.7344818,
+                      "rms_glo": 0.451817,
+                      "rmsc": 0.3228572,
+                      "rmsc_glo": 0.4469461,
+                      "stdv_pc": 1.476155,
+                      "stdv_pc_ratio_to_obs": 0.7316154
+                    },
+                    "eof1": {
+                      "bias": -0.001796032,
+                      "bias_glo": 0.3021184,
+                      "cor": 0.9019265,
+                      "cor_glo": 0.8612123,
+                      "frac": 0.3724301,
+                      "mean": -3.451251e-15,
+                      "mean_glo": 0.09635729,
+                      "rms": 0.9123797,
+                      "rms_glo": 0.530953,
+                      "rmsc": 0.4428848,
+                      "rmsc_glo": 0.5268542,
+                      "stdv_pc": 1.597582,
+                      "stdv_pc_ratio_to_obs": 0.7917977
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.002315952,
+                      "bias_glo": -0.02235276,
+                      "cor": 0.9632798,
+                      "cor_glo": 0.5855201,
+                      "frac": 0.3417913,
+                      "frac_cbf_regrid": 0.2978093,
+                      "mean": -2.575098e-16,
+                      "mean_glo": 0.005801836,
+                      "rms": 0.2074231,
+                      "rms_glo": 0.3532361,
+                      "rmsc": 0.2709989,
+                      "rmsc_glo": 0.9104723,
+                      "stdv_pc": 0.7321769,
+                      "stdv_pc_ratio_to_obs": 0.9519071
+                    },
+                    "eof1": {
+                      "bias": -0.0025762,
+                      "bias_glo": -0.02333224,
+                      "cor": 0.9208113,
+                      "cor_glo": 0.5694428,
+                      "frac": 0.3527152,
+                      "mean": -2.221613e-16,
+                      "mean_glo": 0.004822357,
+                      "rms": 0.3066624,
+                      "rms_glo": 0.3606522,
+                      "rmsc": 0.3979665,
+                      "rmsc_glo": 0.9279625,
+                      "stdv_pc": 0.7768803,
+                      "stdv_pc_ratio_to_obs": 1.010026
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.00248991,
+                      "bias_glo": 0.0231904,
+                      "cor": 0.9270912,
+                      "cor_glo": 0.8614613,
+                      "frac": 0.3074101,
+                      "frac_cbf_regrid": 0.2702566,
+                      "mean": 2.361029e-15,
+                      "mean_glo": -0.06388831,
+                      "rms": 0.4534005,
+                      "rms_glo": 0.2799566,
+                      "rmsc": 0.3818607,
+                      "rmsc_glo": 0.5263814,
+                      "stdv_pc": 1.05355,
+                      "stdv_pc_ratio_to_obs": 0.8715333
+                    },
+                    "eof1": {
+                      "bias": -0.00335879,
+                      "bias_glo": 0.01344627,
+                      "cor": 0.8521499,
+                      "cor_glo": 0.8228065,
+                      "frac": 0.3288034,
+                      "mean": 2.864848e-15,
+                      "mean_glo": -0.07363245,
+                      "rms": 0.6493031,
+                      "rms_glo": 0.3324537,
+                      "rmsc": 0.5437833,
+                      "rmsc_glo": 0.5953041,
+                      "stdv_pc": 1.180007,
+                      "stdv_pc_ratio_to_obs": 0.9761427
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.0009616269,
+                      "bias_glo": -0.06049222,
+                      "cor": 0.9631301,
+                      "cor_glo": 0.832207,
+                      "frac": 0.2797529,
+                      "frac_cbf_regrid": 0.2401756,
+                      "mean": -2.355964e-15,
+                      "mean_glo": 0.05979277,
+                      "rms": 0.2613694,
+                      "rms_glo": 0.2297715,
+                      "rmsc": 0.2715508,
+                      "rmsc_glo": 0.5792979,
+                      "stdv_pc": 0.9343373,
+                      "stdv_pc_ratio_to_obs": 0.9852872
+                    },
+                    "eof1": {
+                      "bias": -0.002291474,
+                      "bias_glo": -0.1315455,
+                      "cor": 0.8355018,
+                      "cor_glo": 0.6730703,
+                      "frac": 0.2983196,
+                      "mean": 3.487416e-16,
+                      "mean_glo": -0.01126055,
+                      "rms": 0.5621296,
+                      "rms_glo": 0.3547179,
+                      "rmsc": 0.573582,
+                      "rmsc_glo": 0.8086157,
+                      "stdv_pc": 1.008613,
+                      "stdv_pc_ratio_to_obs": 1.063613
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.003535991,
-                    "bias_glo": 0.2481177,
-                    "cor": 0.9478816,
-                    "cor_glo": 0.9001196,
-                    "frac": 0.3573224,
-                    "frac_cbf_regrid": 0.3059213,
-                    "mean": -1.629923e-15,
-                    "mean_glo": 0.0423566,
-                    "rms": 0.7344818,
-                    "rms_glo": 0.451817,
-                    "rmsc": 0.3228572,
-                    "rmsc_glo": 0.4469461,
-                    "stdv_pc": 1.476155,
-                    "stdv_pc_ratio_to_obs": 0.7316154
-                  },
-                  "eof1": {
-                    "bias": -0.001796032,
-                    "bias_glo": 0.3021184,
-                    "cor": 0.9019265,
-                    "cor_glo": 0.8612123,
-                    "frac": 0.3724301,
-                    "mean": -3.451251e-15,
-                    "mean_glo": 0.09635729,
-                    "rms": 0.9123797,
-                    "rms_glo": 0.530953,
-                    "rmsc": 0.4428848,
-                    "rmsc_glo": 0.5268542,
-                    "stdv_pc": 1.597582,
-                    "stdv_pc_ratio_to_obs": 0.7917977
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.002315952,
-                    "bias_glo": -0.02235276,
-                    "cor": 0.9632798,
-                    "cor_glo": 0.5855201,
-                    "frac": 0.3417913,
-                    "frac_cbf_regrid": 0.2978093,
-                    "mean": -2.575098e-16,
-                    "mean_glo": 0.005801836,
-                    "rms": 0.2074231,
-                    "rms_glo": 0.3532361,
-                    "rmsc": 0.2709989,
-                    "rmsc_glo": 0.9104723,
-                    "stdv_pc": 0.7321769,
-                    "stdv_pc_ratio_to_obs": 0.9519071
-                  },
-                  "eof1": {
-                    "bias": -0.0025762,
-                    "bias_glo": -0.02333224,
-                    "cor": 0.9208113,
-                    "cor_glo": 0.5694428,
-                    "frac": 0.3527152,
-                    "mean": -2.221613e-16,
-                    "mean_glo": 0.004822357,
-                    "rms": 0.3066624,
-                    "rms_glo": 0.3606522,
-                    "rmsc": 0.3979665,
-                    "rmsc_glo": 0.9279625,
-                    "stdv_pc": 0.7768803,
-                    "stdv_pc_ratio_to_obs": 1.010026
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.00248991,
-                    "bias_glo": 0.0231904,
-                    "cor": 0.9270912,
-                    "cor_glo": 0.8614613,
-                    "frac": 0.3074101,
-                    "frac_cbf_regrid": 0.2702566,
-                    "mean": 2.361029e-15,
-                    "mean_glo": -0.06388831,
-                    "rms": 0.4534005,
-                    "rms_glo": 0.2799566,
-                    "rmsc": 0.3818607,
-                    "rmsc_glo": 0.5263814,
-                    "stdv_pc": 1.05355,
-                    "stdv_pc_ratio_to_obs": 0.8715333
-                  },
-                  "eof1": {
-                    "bias": -0.00335879,
-                    "bias_glo": 0.01344627,
-                    "cor": 0.8521499,
-                    "cor_glo": 0.8228065,
-                    "frac": 0.3288034,
-                    "mean": 2.864848e-15,
-                    "mean_glo": -0.07363245,
-                    "rms": 0.6493031,
-                    "rms_glo": 0.3324537,
-                    "rmsc": 0.5437833,
-                    "rmsc_glo": 0.5953041,
-                    "stdv_pc": 1.180007,
-                    "stdv_pc_ratio_to_obs": 0.9761427
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.0009616269,
-                    "bias_glo": -0.06049222,
-                    "cor": 0.9631301,
-                    "cor_glo": 0.832207,
-                    "frac": 0.2797529,
-                    "frac_cbf_regrid": 0.2401756,
-                    "mean": -2.355964e-15,
-                    "mean_glo": 0.05979277,
-                    "rms": 0.2613694,
-                    "rms_glo": 0.2297715,
-                    "rmsc": 0.2715508,
-                    "rmsc_glo": 0.5792979,
-                    "stdv_pc": 0.9343373,
-                    "stdv_pc_ratio_to_obs": 0.9852872
-                  },
-                  "eof1": {
-                    "bias": -0.002291474,
-                    "bias_glo": -0.1315455,
-                    "cor": 0.8355018,
-                    "cor_glo": 0.6730703,
-                    "frac": 0.2983196,
-                    "mean": 3.487416e-16,
-                    "mean_glo": -0.01126055,
-                    "rms": 0.5621296,
-                    "rms_glo": 0.3547179,
-                    "rmsc": 0.573582,
-                    "rmsc_glo": 0.8086157,
-                    "stdv_pc": 1.008613,
-                    "stdv_pc_ratio_to_obs": 1.063613
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip7/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "d8fe04e12ce8e9b2a628bc79d539f17e62478ab1",
   "committed": {
-    "diagnostic.json": "900d8eba639c75803adb04ed9c6d944829ed4d9609d680b1d2a8a8f0b6a416f6",
+    "diagnostic.json": "ff91cdb4ce730ca36a8a6feb8244f802c7edcda03ee71d3de3ade20ccd2c3bd5",
     "output.json": "5ce2d3227e91bdc787fd693e2c57eb4638e179df493045f0af032448f3592246",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NAO_DJF_20CR_1900-2005.png": {
       "sha256": "474dc87d541ce4787d56ac7b7a93adc6f337607a759f62c0902efa3992a433f8",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-nao/cmip7/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "NAO": {
-                "DJF": {
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "NAO": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.003535991,
+                      "bias_glo": 0.2481177,
+                      "cor": 0.9478816,
+                      "cor_glo": 0.9001196,
+                      "frac": 0.3573224,
+                      "frac_cbf_regrid": 0.3059213,
+                      "mean": -1.629923e-15,
+                      "mean_glo": 0.0423566,
+                      "rms": 0.7344818,
+                      "rms_glo": 0.451817,
+                      "rmsc": 0.3228572,
+                      "rmsc_glo": 0.4469461,
+                      "stdv_pc": 1.476155,
+                      "stdv_pc_ratio_to_obs": 0.7316154
+                    },
+                    "eof1": {
+                      "bias": -0.001796032,
+                      "bias_glo": 0.3021184,
+                      "cor": 0.9019265,
+                      "cor_glo": 0.8612123,
+                      "frac": 0.3724301,
+                      "mean": -3.451251e-15,
+                      "mean_glo": 0.09635729,
+                      "rms": 0.9123797,
+                      "rms_glo": 0.530953,
+                      "rmsc": 0.4428848,
+                      "rmsc_glo": 0.5268542,
+                      "stdv_pc": 1.597582,
+                      "stdv_pc_ratio_to_obs": 0.7917977
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.002315952,
+                      "bias_glo": -0.02235276,
+                      "cor": 0.9632798,
+                      "cor_glo": 0.5855201,
+                      "frac": 0.3417913,
+                      "frac_cbf_regrid": 0.2978093,
+                      "mean": -2.575098e-16,
+                      "mean_glo": 0.005801836,
+                      "rms": 0.2074231,
+                      "rms_glo": 0.3532361,
+                      "rmsc": 0.2709989,
+                      "rmsc_glo": 0.9104723,
+                      "stdv_pc": 0.7321769,
+                      "stdv_pc_ratio_to_obs": 0.9519071
+                    },
+                    "eof1": {
+                      "bias": -0.0025762,
+                      "bias_glo": -0.02333224,
+                      "cor": 0.9208113,
+                      "cor_glo": 0.5694428,
+                      "frac": 0.3527152,
+                      "mean": -2.221613e-16,
+                      "mean_glo": 0.004822357,
+                      "rms": 0.3066624,
+                      "rms_glo": 0.3606522,
+                      "rmsc": 0.3979665,
+                      "rmsc_glo": 0.9279625,
+                      "stdv_pc": 0.7768803,
+                      "stdv_pc_ratio_to_obs": 1.010026
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.00248991,
+                      "bias_glo": 0.0231904,
+                      "cor": 0.9270912,
+                      "cor_glo": 0.8614613,
+                      "frac": 0.3074101,
+                      "frac_cbf_regrid": 0.2702566,
+                      "mean": 2.361029e-15,
+                      "mean_glo": -0.06388831,
+                      "rms": 0.4534005,
+                      "rms_glo": 0.2799566,
+                      "rmsc": 0.3818607,
+                      "rmsc_glo": 0.5263814,
+                      "stdv_pc": 1.05355,
+                      "stdv_pc_ratio_to_obs": 0.8715333
+                    },
+                    "eof1": {
+                      "bias": -0.00335879,
+                      "bias_glo": 0.01344627,
+                      "cor": 0.8521499,
+                      "cor_glo": 0.8228065,
+                      "frac": 0.3288034,
+                      "mean": 2.864848e-15,
+                      "mean_glo": -0.07363245,
+                      "rms": 0.6493031,
+                      "rms_glo": 0.3324537,
+                      "rmsc": 0.5437833,
+                      "rmsc_glo": 0.5953041,
+                      "stdv_pc": 1.180007,
+                      "stdv_pc_ratio_to_obs": 0.9761427
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.0009616269,
+                      "bias_glo": -0.06049222,
+                      "cor": 0.9631301,
+                      "cor_glo": 0.832207,
+                      "frac": 0.2797529,
+                      "frac_cbf_regrid": 0.2401756,
+                      "mean": -2.355964e-15,
+                      "mean_glo": 0.05979277,
+                      "rms": 0.2613694,
+                      "rms_glo": 0.2297715,
+                      "rmsc": 0.2715508,
+                      "rmsc_glo": 0.5792979,
+                      "stdv_pc": 0.9343373,
+                      "stdv_pc_ratio_to_obs": 0.9852872
+                    },
+                    "eof1": {
+                      "bias": -0.002291474,
+                      "bias_glo": -0.1315455,
+                      "cor": 0.8355018,
+                      "cor_glo": 0.6730703,
+                      "frac": 0.2983196,
+                      "mean": 3.487416e-16,
+                      "mean_glo": -0.01126055,
+                      "rms": 0.5621296,
+                      "rms_glo": 0.3547179,
+                      "rmsc": 0.573582,
+                      "rmsc_glo": 0.8086157,
+                      "stdv_pc": 1.008613,
+                      "stdv_pc_ratio_to_obs": 1.063613
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.003535991,
-                    "bias_glo": 0.2481177,
-                    "cor": 0.9478816,
-                    "cor_glo": 0.9001196,
-                    "frac": 0.3573224,
-                    "frac_cbf_regrid": 0.3059213,
-                    "mean": -1.629923e-15,
-                    "mean_glo": 0.0423566,
-                    "rms": 0.7344818,
-                    "rms_glo": 0.451817,
-                    "rmsc": 0.3228572,
-                    "rmsc_glo": 0.4469461,
-                    "stdv_pc": 1.476155,
-                    "stdv_pc_ratio_to_obs": 0.7316154
-                  },
-                  "eof1": {
-                    "bias": -0.001796032,
-                    "bias_glo": 0.3021184,
-                    "cor": 0.9019265,
-                    "cor_glo": 0.8612123,
-                    "frac": 0.3724301,
-                    "mean": -3.451251e-15,
-                    "mean_glo": 0.09635729,
-                    "rms": 0.9123797,
-                    "rms_glo": 0.530953,
-                    "rmsc": 0.4428848,
-                    "rmsc_glo": 0.5268542,
-                    "stdv_pc": 1.597582,
-                    "stdv_pc_ratio_to_obs": 0.7917977
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.002315952,
-                    "bias_glo": -0.02235276,
-                    "cor": 0.9632798,
-                    "cor_glo": 0.5855201,
-                    "frac": 0.3417913,
-                    "frac_cbf_regrid": 0.2978093,
-                    "mean": -2.575098e-16,
-                    "mean_glo": 0.005801836,
-                    "rms": 0.2074231,
-                    "rms_glo": 0.3532361,
-                    "rmsc": 0.2709989,
-                    "rmsc_glo": 0.9104723,
-                    "stdv_pc": 0.7321769,
-                    "stdv_pc_ratio_to_obs": 0.9519071
-                  },
-                  "eof1": {
-                    "bias": -0.0025762,
-                    "bias_glo": -0.02333224,
-                    "cor": 0.9208113,
-                    "cor_glo": 0.5694428,
-                    "frac": 0.3527152,
-                    "mean": -2.221613e-16,
-                    "mean_glo": 0.004822357,
-                    "rms": 0.3066624,
-                    "rms_glo": 0.3606522,
-                    "rmsc": 0.3979665,
-                    "rmsc_glo": 0.9279625,
-                    "stdv_pc": 0.7768803,
-                    "stdv_pc_ratio_to_obs": 1.010026
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.00248991,
-                    "bias_glo": 0.0231904,
-                    "cor": 0.9270912,
-                    "cor_glo": 0.8614613,
-                    "frac": 0.3074101,
-                    "frac_cbf_regrid": 0.2702566,
-                    "mean": 2.361029e-15,
-                    "mean_glo": -0.06388831,
-                    "rms": 0.4534005,
-                    "rms_glo": 0.2799566,
-                    "rmsc": 0.3818607,
-                    "rmsc_glo": 0.5263814,
-                    "stdv_pc": 1.05355,
-                    "stdv_pc_ratio_to_obs": 0.8715333
-                  },
-                  "eof1": {
-                    "bias": -0.00335879,
-                    "bias_glo": 0.01344627,
-                    "cor": 0.8521499,
-                    "cor_glo": 0.8228065,
-                    "frac": 0.3288034,
-                    "mean": 2.864848e-15,
-                    "mean_glo": -0.07363245,
-                    "rms": 0.6493031,
-                    "rms_glo": 0.3324537,
-                    "rmsc": 0.5437833,
-                    "rmsc_glo": 0.5953041,
-                    "stdv_pc": 1.180007,
-                    "stdv_pc_ratio_to_obs": 0.9761427
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.0009616269,
-                    "bias_glo": -0.06049222,
-                    "cor": 0.9631301,
-                    "cor_glo": 0.832207,
-                    "frac": 0.2797529,
-                    "frac_cbf_regrid": 0.2401756,
-                    "mean": -2.355964e-15,
-                    "mean_glo": 0.05979277,
-                    "rms": 0.2613694,
-                    "rms_glo": 0.2297715,
-                    "rmsc": 0.2715508,
-                    "rmsc_glo": 0.5792979,
-                    "stdv_pc": 0.9343373,
-                    "stdv_pc_ratio_to_obs": 0.9852872
-                  },
-                  "eof1": {
-                    "bias": -0.002291474,
-                    "bias_glo": -0.1315455,
-                    "cor": 0.8355018,
-                    "cor_glo": 0.6730703,
-                    "frac": 0.2983196,
-                    "mean": 3.487416e-16,
-                    "mean_glo": -0.01126055,
-                    "rms": 0.5621296,
-                    "rms_glo": 0.3547179,
-                    "rmsc": 0.573582,
-                    "rmsc_glo": 0.8086157,
-                    "stdv_pc": 1.008613,
-                    "stdv_pc_ratio_to_obs": 1.063613
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip6/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "8f3a4713d6af9bf6fbac2c17dfc468151d122fb5",
   "committed": {
-    "diagnostic.json": "16c1a520a6aed7e2ae30491c0aba071021fa2d0dc94997a0ad1deb621e256075",
+    "diagnostic.json": "3ce9983da16036524ee2474cccd9f91533a76cca4a1fa32f8c51a55e97aa71b5",
     "output.json": "e36bf1d06d3635f2047609530f9da8d0dc048f352df424f0168d5bb913145079",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NPGO_monthly_HadISST-1-1_1900-2005.png": {
       "sha256": "f7e720e3115fd6cd39e57144a4aaf3cc427944c761436b87e96f752a351c9ddc",
@@ -85,5 +85,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip6/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -58,67 +62,69 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "HadISST-1-1": {
-              "NPGO": {
-                "attributes": {
-                  "target_model_eofs": 2
-                },
-                "monthly": {
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "HadISST-1-1": {
+                "NPGO": {
                   "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
+                    "target_model_eofs": 2
                   },
-                  "cbf": {
-                    "bias": 0.002721996,
-                    "bias_glo": 0.005024369,
-                    "cor": 0.8527454,
-                    "cor_glo": 0.6949935,
-                    "frac": 0.09980431,
-                    "frac_cbf_regrid": 0.1771883,
-                    "mean": -8.428902e-16,
-                    "mean_glo": 0.0524414,
-                    "rms": 0.1551412,
-                    "rms_glo": 0.08805765,
-                    "rmsc": 0.5688539,
-                    "rmsc_glo": 0.824039,
-                    "stdv_pc": 0.1771279,
-                    "stdv_pc_ratio_to_obs": 1.162984
-                  },
-                  "eof1": {
-                    "bias": 0.01766398,
-                    "bias_glo": -0.08198712,
-                    "cor": 0.1773933,
-                    "cor_glo": 0.1636136,
-                    "frac": 0.2065719,
-                    "mean": -6.013302e-17,
-                    "mean_glo": -0.03476321,
-                    "rms": 0.4021689,
-                    "rms_glo": 0.1884392,
-                    "rmsc": 1.291321,
-                    "rmsc_glo": 1.320243,
-                    "stdv_pc": 0.3114757,
-                    "stdv_pc_ratio_to_obs": 2.045084
-                  },
-                  "eof2": {
-                    "bias": 0.001959521,
-                    "bias_glo": 0.01491575,
-                    "cor": 0.6879323,
-                    "cor_glo": 0.6004924,
-                    "frac": 0.1055683,
-                    "mean": -1.021519e-15,
-                    "mean_glo": 0.06201272,
-                    "rms": 0.2080476,
-                    "rms_glo": 0.09836151,
-                    "rmsc": 0.8079302,
-                    "rmsc_glo": 0.9303123,
-                    "stdv_pc": 0.2226667,
-                    "stdv_pc_ratio_to_obs": 1.461983
+                  "monthly": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.002721996,
+                      "bias_glo": 0.005024369,
+                      "cor": 0.8527454,
+                      "cor_glo": 0.6949935,
+                      "frac": 0.09980431,
+                      "frac_cbf_regrid": 0.1771883,
+                      "mean": -8.428902e-16,
+                      "mean_glo": 0.0524414,
+                      "rms": 0.1551412,
+                      "rms_glo": 0.08805765,
+                      "rmsc": 0.5688539,
+                      "rmsc_glo": 0.824039,
+                      "stdv_pc": 0.1771279,
+                      "stdv_pc_ratio_to_obs": 1.162984
+                    },
+                    "eof1": {
+                      "bias": 0.01766398,
+                      "bias_glo": -0.08198712,
+                      "cor": 0.1773933,
+                      "cor_glo": 0.1636136,
+                      "frac": 0.2065719,
+                      "mean": -6.013302e-17,
+                      "mean_glo": -0.03476321,
+                      "rms": 0.4021689,
+                      "rms_glo": 0.1884392,
+                      "rmsc": 1.291321,
+                      "rmsc_glo": 1.320243,
+                      "stdv_pc": 0.3114757,
+                      "stdv_pc_ratio_to_obs": 2.045084
+                    },
+                    "eof2": {
+                      "bias": 0.001959521,
+                      "bias_glo": 0.01491575,
+                      "cor": 0.6879323,
+                      "cor_glo": 0.6004924,
+                      "frac": 0.1055683,
+                      "mean": -1.021519e-15,
+                      "mean_glo": 0.06201272,
+                      "rms": 0.2080476,
+                      "rms_glo": 0.09836151,
+                      "rmsc": 0.8079302,
+                      "rmsc_glo": 0.9303123,
+                      "stdv_pc": 0.2226667,
+                      "stdv_pc_ratio_to_obs": 1.461983
+                    }
                   }
                 }
               }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip7/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "f08a7aebd0f75f6aee658e536ee9de9f28317bba",
   "committed": {
-    "diagnostic.json": "dda1d8491cebe45855457a7b978ea8915b839bd2db6cf994531213e8fb0d55db",
+    "diagnostic.json": "78a72ee396e53cbd41317ec13d5a85c80991483a5be7401ce0e26853bae180c1",
     "output.json": "000fe71a4613185d864720121db10eaadb1a312e5e20199346421223a804999e",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NPGO_monthly_HadISST-1-1_1900-2005.png": {
       "sha256": "f7e720e3115fd6cd39e57144a4aaf3cc427944c761436b87e96f752a351c9ddc",
@@ -85,5 +85,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npgo/cmip7/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -58,67 +62,69 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "HadISST-1-1": {
-              "NPGO": {
-                "attributes": {
-                  "target_model_eofs": 2
-                },
-                "monthly": {
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "HadISST-1-1": {
+                "NPGO": {
                   "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
+                    "target_model_eofs": 2
                   },
-                  "cbf": {
-                    "bias": 0.002721972,
-                    "bias_glo": 0.005024456,
-                    "cor": 0.8527462,
-                    "cor_glo": 0.6949938,
-                    "frac": 0.09980412,
-                    "frac_cbf_regrid": 0.1771865,
-                    "mean": -8.804662e-16,
-                    "mean_glo": 0.05244148,
-                    "rms": 0.1551407,
-                    "rms_glo": 0.08805752,
-                    "rmsc": 0.5688525,
-                    "rmsc_glo": 0.8240385,
-                    "stdv_pc": 0.1771278,
-                    "stdv_pc_ratio_to_obs": 1.162984
-                  },
-                  "eof1": {
-                    "bias": 0.01766399,
-                    "bias_glo": -0.08198719,
-                    "cor": 0.1773931,
-                    "cor_glo": 0.1636135,
-                    "frac": 0.2065715,
-                    "mean": -5.150996e-17,
-                    "mean_glo": -0.0347633,
-                    "rms": 0.4021686,
-                    "rms_glo": 0.1884391,
-                    "rmsc": 1.291321,
-                    "rmsc_glo": 1.320243,
-                    "stdv_pc": 0.3114754,
-                    "stdv_pc_ratio_to_obs": 2.045082
-                  },
-                  "eof2": {
-                    "bias": 0.001959493,
-                    "bias_glo": 0.0149159,
-                    "cor": 0.6879325,
-                    "cor_glo": 0.6004919,
-                    "frac": 0.1055681,
-                    "mean": -1.074971e-15,
-                    "mean_glo": 0.06201285,
-                    "rms": 0.2080474,
-                    "rms_glo": 0.09836157,
-                    "rmsc": 0.80793,
-                    "rmsc_glo": 0.9303129,
-                    "stdv_pc": 0.2226666,
-                    "stdv_pc_ratio_to_obs": 1.461982
+                  "monthly": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.002721972,
+                      "bias_glo": 0.005024456,
+                      "cor": 0.8527462,
+                      "cor_glo": 0.6949938,
+                      "frac": 0.09980412,
+                      "frac_cbf_regrid": 0.1771865,
+                      "mean": -8.804662e-16,
+                      "mean_glo": 0.05244148,
+                      "rms": 0.1551407,
+                      "rms_glo": 0.08805752,
+                      "rmsc": 0.5688525,
+                      "rmsc_glo": 0.8240385,
+                      "stdv_pc": 0.1771278,
+                      "stdv_pc_ratio_to_obs": 1.162984
+                    },
+                    "eof1": {
+                      "bias": 0.01766399,
+                      "bias_glo": -0.08198719,
+                      "cor": 0.1773931,
+                      "cor_glo": 0.1636135,
+                      "frac": 0.2065715,
+                      "mean": -5.150996e-17,
+                      "mean_glo": -0.0347633,
+                      "rms": 0.4021686,
+                      "rms_glo": 0.1884391,
+                      "rmsc": 1.291321,
+                      "rmsc_glo": 1.320243,
+                      "stdv_pc": 0.3114754,
+                      "stdv_pc_ratio_to_obs": 2.045082
+                    },
+                    "eof2": {
+                      "bias": 0.001959493,
+                      "bias_glo": 0.0149159,
+                      "cor": 0.6879325,
+                      "cor_glo": 0.6004919,
+                      "frac": 0.1055681,
+                      "mean": -1.074971e-15,
+                      "mean_glo": 0.06201285,
+                      "rms": 0.2080474,
+                      "rms_glo": 0.09836157,
+                      "rmsc": 0.80793,
+                      "rmsc_glo": 0.9303129,
+                      "stdv_pc": 0.2226666,
+                      "stdv_pc_ratio_to_obs": 1.461982
+                    }
                   }
                 }
               }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip6/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "97fbf6c3eafe72779d017d41744a0f69504f6128",
   "committed": {
-    "diagnostic.json": "8b265dfd6e608ecc19d25e5df3c17e59aa9398f2374925e4837fbf51c1aa6b2f",
+    "diagnostic.json": "1fba82283b870d074acc91801fe3033b2a98acebd634c43f0a78747909fe58c5",
     "output.json": "bf0dedc8a6242551d92ae91c1bcc8424341c46cec150edb7600f58783ec49108",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NPO_DJF_20CR_1900-2005.png": {
       "sha256": "cd7d18a767f9e3563783b655ab9a248b6d61bc3ac25e7a075bb631fca29d75bf",
@@ -265,5 +265,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip6/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -61,230 +65,232 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "NPO": {
-                "DJF": {
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "NPO": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.003231994,
+                      "bias_glo": -0.4095763,
+                      "cor": 0.9247022,
+                      "cor_glo": 0.7810496,
+                      "frac": 0.1934667,
+                      "frac_cbf_regrid": 0.1495934,
+                      "mean": 3.601233e-15,
+                      "mean_glo": -0.1088049,
+                      "rms": 0.4796899,
+                      "rms_glo": 0.5523216,
+                      "rmsc": 0.3880666,
+                      "rmsc_glo": 0.6617407,
+                      "stdv_pc": 1.136463,
+                      "stdv_pc_ratio_to_obs": 0.914857
+                    },
+                    "eof1": {
+                      "bias": -0.007512416,
+                      "bias_glo": -1.416634,
+                      "cor": 0.1054597,
+                      "cor_glo": 0.1067177,
+                      "frac": 0.4459002,
+                      "mean": 3.842821e-14,
+                      "mean_glo": -1.115863,
+                      "rms": 2.113898,
+                      "rms_glo": 1.693602,
+                      "rmsc": 1.337565,
+                      "rmsc_glo": 1.336624,
+                      "stdv_pc": 1.879116,
+                      "stdv_pc_ratio_to_obs": 1.512695
+                    },
+                    "eof2": {
+                      "bias": 0.001927344,
+                      "bias_glo": -0.3526828,
+                      "cor": 0.8272324,
+                      "cor_glo": 0.6752448,
+                      "frac": 0.2027935,
+                      "mean": 1.320555e-15,
+                      "mean_glo": -0.05191146,
+                      "rms": 0.7346259,
+                      "rms_glo": 0.5618944,
+                      "rmsc": 0.5878223,
+                      "rmsc_glo": 0.805922,
+                      "stdv_pc": 1.267248,
+                      "stdv_pc_ratio_to_obs": 1.02014
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.001965422,
+                      "bias_glo": 0.05806837,
+                      "cor": 0.9122083,
+                      "cor_glo": 0.7775047,
+                      "frac": 0.224873,
+                      "frac_cbf_regrid": 0.1821159,
+                      "mean": 2.75475e-15,
+                      "mean_glo": -0.08074314,
+                      "rms": 0.3137266,
+                      "rms_glo": 0.2196611,
+                      "rmsc": 0.4190266,
+                      "rmsc_glo": 0.6670762,
+                      "stdv_pc": 0.6222273,
+                      "stdv_pc_ratio_to_obs": 1.297093
+                    },
+                    "eof1": {
+                      "bias": 2.688043e-05,
+                      "bias_glo": 0.07285189,
+                      "cor": 0.6527494,
+                      "cor_glo": 0.5431576,
+                      "frac": 0.2736954,
+                      "mean": 2.184495e-15,
+                      "mean_glo": -0.06595961,
+                      "rms": 0.5690407,
+                      "rms_glo": 0.3083463,
+                      "rmsc": 0.8333674,
+                      "rmsc_glo": 0.9558686,
+                      "stdv_pc": 0.7589778,
+                      "stdv_pc_ratio_to_obs": 1.582163
+                    },
+                    "eof2": {
+                      "bias": -0.004090241,
+                      "bias_glo": 0.1720103,
+                      "cor": 0.6076769,
+                      "cor_glo": 0.4886326,
+                      "frac": 0.1587845,
+                      "mean": -9.457472e-16,
+                      "mean_glo": 0.03319881,
+                      "rms": 0.4758642,
+                      "rms_glo": 0.3203243,
+                      "rmsc": 0.8858026,
+                      "rmsc_glo": 1.011304,
+                      "stdv_pc": 0.5780952,
+                      "stdv_pc_ratio_to_obs": 1.205096
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.00220391,
+                      "bias_glo": 0.05499773,
+                      "cor": 0.9191628,
+                      "cor_glo": 0.7269497,
+                      "frac": 0.1825753,
+                      "frac_cbf_regrid": 0.1512343,
+                      "mean": 5.832621e-16,
+                      "mean_glo": -0.01736389,
+                      "rms": 0.3585589,
+                      "rms_glo": 0.2698424,
+                      "rmsc": 0.4020874,
+                      "rmsc_glo": 0.7389862,
+                      "stdv_pc": 0.8363425,
+                      "stdv_pc_ratio_to_obs": 0.9872479
+                    },
+                    "eof1": {
+                      "bias": 0.002017288,
+                      "bias_glo": -0.1209493,
+                      "cor": 0.2131215,
+                      "cor_glo": 0.1757718,
+                      "frac": 0.4079202,
+                      "mean": 6.476127e-15,
+                      "mean_glo": -0.193311,
+                      "rms": 1.434592,
+                      "rms_glo": 0.673587,
+                      "rmsc": 1.254495,
+                      "rmsc_glo": 1.283922,
+                      "stdv_pc": 1.369149,
+                      "stdv_pc_ratio_to_obs": 1.616192
+                    },
+                    "eof2": {
+                      "bias": 0.002455991,
+                      "bias_glo": 0.2023852,
+                      "cor": 0.913807,
+                      "cor_glo": 0.6952528,
+                      "frac": 0.1555162,
+                      "mean": -4.375151e-15,
+                      "mean_glo": 0.1300236,
+                      "rms": 0.3502364,
+                      "rms_glo": 0.3310062,
+                      "rmsc": 0.4151939,
+                      "rmsc_glo": 0.7807013,
+                      "stdv_pc": 0.8453782,
+                      "stdv_pc_ratio_to_obs": 0.997914
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.003380835,
+                      "bias_glo": 0.0598824,
+                      "cor": 0.9680575,
+                      "cor_glo": 0.7428952,
+                      "frac": 0.1729541,
+                      "frac_cbf_regrid": 0.1399775,
+                      "mean": 3.968767e-15,
+                      "mean_glo": -0.1192024,
+                      "rms": 0.2116899,
+                      "rms_glo": 0.2458417,
+                      "rmsc": 0.2527548,
+                      "rmsc_glo": 0.717084,
+                      "stdv_pc": 0.803041,
+                      "stdv_pc_ratio_to_obs": 1.051405
+                    },
+                    "eof1": {
+                      "bias": 0.000836551,
+                      "bias_glo": -0.007350662,
+                      "cor": 0.02746122,
+                      "cor_glo": 0.002230965,
+                      "frac": 0.2782871,
+                      "mean": 6.214617e-15,
+                      "mean_glo": -0.1864355,
+                      "rms": 1.278282,
+                      "rms_glo": 0.5637758,
+                      "rmsc": 1.39466,
+                      "rmsc_glo": 1.412635,
+                      "stdv_pc": 1.058394,
+                      "stdv_pc_ratio_to_obs": 1.385733
+                    },
+                    "eof2": {
+                      "bias": -0.003064799,
+                      "bias_glo": 0.09106562,
+                      "cor": 0.8716694,
+                      "cor_glo": 0.7272199,
+                      "frac": 0.1791062,
+                      "mean": 2.88359e-15,
+                      "mean_glo": -0.0880192,
+                      "rms": 0.4145842,
+                      "rms_glo": 0.2592252,
+                      "rmsc": 0.5066174,
+                      "rmsc_glo": 0.7386205,
+                      "stdv_pc": 0.8490953,
+                      "stdv_pc_ratio_to_obs": 1.111702
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.003231994,
-                    "bias_glo": -0.4095763,
-                    "cor": 0.9247022,
-                    "cor_glo": 0.7810496,
-                    "frac": 0.1934667,
-                    "frac_cbf_regrid": 0.1495934,
-                    "mean": 3.601233e-15,
-                    "mean_glo": -0.1088049,
-                    "rms": 0.4796899,
-                    "rms_glo": 0.5523216,
-                    "rmsc": 0.3880666,
-                    "rmsc_glo": 0.6617407,
-                    "stdv_pc": 1.136463,
-                    "stdv_pc_ratio_to_obs": 0.914857
-                  },
-                  "eof1": {
-                    "bias": -0.007512416,
-                    "bias_glo": -1.416634,
-                    "cor": 0.1054597,
-                    "cor_glo": 0.1067177,
-                    "frac": 0.4459002,
-                    "mean": 3.842821e-14,
-                    "mean_glo": -1.115863,
-                    "rms": 2.113898,
-                    "rms_glo": 1.693602,
-                    "rmsc": 1.337565,
-                    "rmsc_glo": 1.336624,
-                    "stdv_pc": 1.879116,
-                    "stdv_pc_ratio_to_obs": 1.512695
-                  },
-                  "eof2": {
-                    "bias": 0.001927344,
-                    "bias_glo": -0.3526828,
-                    "cor": 0.8272324,
-                    "cor_glo": 0.6752448,
-                    "frac": 0.2027935,
-                    "mean": 1.320555e-15,
-                    "mean_glo": -0.05191146,
-                    "rms": 0.7346259,
-                    "rms_glo": 0.5618944,
-                    "rmsc": 0.5878223,
-                    "rmsc_glo": 0.805922,
-                    "stdv_pc": 1.267248,
-                    "stdv_pc_ratio_to_obs": 1.02014
+                    "target_model_eofs": 2
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.001965422,
-                    "bias_glo": 0.05806837,
-                    "cor": 0.9122083,
-                    "cor_glo": 0.7775047,
-                    "frac": 0.224873,
-                    "frac_cbf_regrid": 0.1821159,
-                    "mean": 2.75475e-15,
-                    "mean_glo": -0.08074314,
-                    "rms": 0.3137266,
-                    "rms_glo": 0.2196611,
-                    "rmsc": 0.4190266,
-                    "rmsc_glo": 0.6670762,
-                    "stdv_pc": 0.6222273,
-                    "stdv_pc_ratio_to_obs": 1.297093
-                  },
-                  "eof1": {
-                    "bias": 2.688043e-05,
-                    "bias_glo": 0.07285189,
-                    "cor": 0.6527494,
-                    "cor_glo": 0.5431576,
-                    "frac": 0.2736954,
-                    "mean": 2.184495e-15,
-                    "mean_glo": -0.06595961,
-                    "rms": 0.5690407,
-                    "rms_glo": 0.3083463,
-                    "rmsc": 0.8333674,
-                    "rmsc_glo": 0.9558686,
-                    "stdv_pc": 0.7589778,
-                    "stdv_pc_ratio_to_obs": 1.582163
-                  },
-                  "eof2": {
-                    "bias": -0.004090241,
-                    "bias_glo": 0.1720103,
-                    "cor": 0.6076769,
-                    "cor_glo": 0.4886326,
-                    "frac": 0.1587845,
-                    "mean": -9.457472e-16,
-                    "mean_glo": 0.03319881,
-                    "rms": 0.4758642,
-                    "rms_glo": 0.3203243,
-                    "rmsc": 0.8858026,
-                    "rmsc_glo": 1.011304,
-                    "stdv_pc": 0.5780952,
-                    "stdv_pc_ratio_to_obs": 1.205096
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.00220391,
-                    "bias_glo": 0.05499773,
-                    "cor": 0.9191628,
-                    "cor_glo": 0.7269497,
-                    "frac": 0.1825753,
-                    "frac_cbf_regrid": 0.1512343,
-                    "mean": 5.832621e-16,
-                    "mean_glo": -0.01736389,
-                    "rms": 0.3585589,
-                    "rms_glo": 0.2698424,
-                    "rmsc": 0.4020874,
-                    "rmsc_glo": 0.7389862,
-                    "stdv_pc": 0.8363425,
-                    "stdv_pc_ratio_to_obs": 0.9872479
-                  },
-                  "eof1": {
-                    "bias": 0.002017288,
-                    "bias_glo": -0.1209493,
-                    "cor": 0.2131215,
-                    "cor_glo": 0.1757718,
-                    "frac": 0.4079202,
-                    "mean": 6.476127e-15,
-                    "mean_glo": -0.193311,
-                    "rms": 1.434592,
-                    "rms_glo": 0.673587,
-                    "rmsc": 1.254495,
-                    "rmsc_glo": 1.283922,
-                    "stdv_pc": 1.369149,
-                    "stdv_pc_ratio_to_obs": 1.616192
-                  },
-                  "eof2": {
-                    "bias": 0.002455991,
-                    "bias_glo": 0.2023852,
-                    "cor": 0.913807,
-                    "cor_glo": 0.6952528,
-                    "frac": 0.1555162,
-                    "mean": -4.375151e-15,
-                    "mean_glo": 0.1300236,
-                    "rms": 0.3502364,
-                    "rms_glo": 0.3310062,
-                    "rmsc": 0.4151939,
-                    "rmsc_glo": 0.7807013,
-                    "stdv_pc": 0.8453782,
-                    "stdv_pc_ratio_to_obs": 0.997914
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.003380835,
-                    "bias_glo": 0.0598824,
-                    "cor": 0.9680575,
-                    "cor_glo": 0.7428952,
-                    "frac": 0.1729541,
-                    "frac_cbf_regrid": 0.1399775,
-                    "mean": 3.968767e-15,
-                    "mean_glo": -0.1192024,
-                    "rms": 0.2116899,
-                    "rms_glo": 0.2458417,
-                    "rmsc": 0.2527548,
-                    "rmsc_glo": 0.717084,
-                    "stdv_pc": 0.803041,
-                    "stdv_pc_ratio_to_obs": 1.051405
-                  },
-                  "eof1": {
-                    "bias": 0.000836551,
-                    "bias_glo": -0.007350662,
-                    "cor": 0.02746122,
-                    "cor_glo": 0.002230965,
-                    "frac": 0.2782871,
-                    "mean": 6.214617e-15,
-                    "mean_glo": -0.1864355,
-                    "rms": 1.278282,
-                    "rms_glo": 0.5637758,
-                    "rmsc": 1.39466,
-                    "rmsc_glo": 1.412635,
-                    "stdv_pc": 1.058394,
-                    "stdv_pc_ratio_to_obs": 1.385733
-                  },
-                  "eof2": {
-                    "bias": -0.003064799,
-                    "bias_glo": 0.09106562,
-                    "cor": 0.8716694,
-                    "cor_glo": 0.7272199,
-                    "frac": 0.1791062,
-                    "mean": 2.88359e-15,
-                    "mean_glo": -0.0880192,
-                    "rms": 0.4145842,
-                    "rms_glo": 0.2592252,
-                    "rmsc": 0.5066174,
-                    "rmsc_glo": 0.7386205,
-                    "stdv_pc": 0.8490953,
-                    "stdv_pc_ratio_to_obs": 1.111702
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 2
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip7/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "d8fe04e12ce8e9b2a628bc79d539f17e62478ab1",
   "committed": {
-    "diagnostic.json": "3174ad996b1c9da7d14fe6ee436c0a88327f4baa9c1cd17beff85d10906a9f3b",
+    "diagnostic.json": "8834bdb0dab5e9cbbc6beb9ec9ac46db4efd9e99b9cf86ab2067e74a65aeda49",
     "output.json": "de79a3ddc42c9739cc69e39a77348f8d119b871ac46a161e199663f8280a501e",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_NPO_DJF_20CR_1900-2005.png": {
       "sha256": "cd7d18a767f9e3563783b655ab9a248b6d61bc3ac25e7a075bb631fca29d75bf",
@@ -265,5 +265,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-npo/cmip7/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -61,230 +65,232 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "NPO": {
-                "DJF": {
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "NPO": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.003231994,
+                      "bias_glo": -0.4095763,
+                      "cor": 0.9247022,
+                      "cor_glo": 0.7810496,
+                      "frac": 0.1934667,
+                      "frac_cbf_regrid": 0.1495934,
+                      "mean": 3.601233e-15,
+                      "mean_glo": -0.1088049,
+                      "rms": 0.4796899,
+                      "rms_glo": 0.5523216,
+                      "rmsc": 0.3880666,
+                      "rmsc_glo": 0.6617407,
+                      "stdv_pc": 1.136463,
+                      "stdv_pc_ratio_to_obs": 0.914857
+                    },
+                    "eof1": {
+                      "bias": -0.007512416,
+                      "bias_glo": -1.416634,
+                      "cor": 0.1054597,
+                      "cor_glo": 0.1067177,
+                      "frac": 0.4459002,
+                      "mean": 3.842821e-14,
+                      "mean_glo": -1.115863,
+                      "rms": 2.113898,
+                      "rms_glo": 1.693602,
+                      "rmsc": 1.337565,
+                      "rmsc_glo": 1.336624,
+                      "stdv_pc": 1.879116,
+                      "stdv_pc_ratio_to_obs": 1.512695
+                    },
+                    "eof2": {
+                      "bias": 0.001927344,
+                      "bias_glo": -0.3526828,
+                      "cor": 0.8272324,
+                      "cor_glo": 0.6752448,
+                      "frac": 0.2027935,
+                      "mean": 1.320555e-15,
+                      "mean_glo": -0.05191146,
+                      "rms": 0.7346259,
+                      "rms_glo": 0.5618944,
+                      "rmsc": 0.5878223,
+                      "rmsc_glo": 0.805922,
+                      "stdv_pc": 1.267248,
+                      "stdv_pc_ratio_to_obs": 1.02014
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.001965422,
+                      "bias_glo": 0.05806837,
+                      "cor": 0.9122083,
+                      "cor_glo": 0.7775047,
+                      "frac": 0.224873,
+                      "frac_cbf_regrid": 0.1821159,
+                      "mean": 2.75475e-15,
+                      "mean_glo": -0.08074314,
+                      "rms": 0.3137266,
+                      "rms_glo": 0.2196611,
+                      "rmsc": 0.4190266,
+                      "rmsc_glo": 0.6670762,
+                      "stdv_pc": 0.6222273,
+                      "stdv_pc_ratio_to_obs": 1.297093
+                    },
+                    "eof1": {
+                      "bias": 2.688043e-05,
+                      "bias_glo": 0.07285189,
+                      "cor": 0.6527494,
+                      "cor_glo": 0.5431576,
+                      "frac": 0.2736954,
+                      "mean": 2.184495e-15,
+                      "mean_glo": -0.06595961,
+                      "rms": 0.5690407,
+                      "rms_glo": 0.3083463,
+                      "rmsc": 0.8333674,
+                      "rmsc_glo": 0.9558686,
+                      "stdv_pc": 0.7589778,
+                      "stdv_pc_ratio_to_obs": 1.582163
+                    },
+                    "eof2": {
+                      "bias": -0.004090241,
+                      "bias_glo": 0.1720103,
+                      "cor": 0.6076769,
+                      "cor_glo": 0.4886326,
+                      "frac": 0.1587845,
+                      "mean": -9.457472e-16,
+                      "mean_glo": 0.03319881,
+                      "rms": 0.4758642,
+                      "rms_glo": 0.3203243,
+                      "rmsc": 0.8858026,
+                      "rmsc_glo": 1.011304,
+                      "stdv_pc": 0.5780952,
+                      "stdv_pc_ratio_to_obs": 1.205096
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.00220391,
+                      "bias_glo": 0.05499773,
+                      "cor": 0.9191628,
+                      "cor_glo": 0.7269497,
+                      "frac": 0.1825753,
+                      "frac_cbf_regrid": 0.1512343,
+                      "mean": 5.832621e-16,
+                      "mean_glo": -0.01736389,
+                      "rms": 0.3585589,
+                      "rms_glo": 0.2698424,
+                      "rmsc": 0.4020874,
+                      "rmsc_glo": 0.7389862,
+                      "stdv_pc": 0.8363425,
+                      "stdv_pc_ratio_to_obs": 0.9872479
+                    },
+                    "eof1": {
+                      "bias": 0.002017288,
+                      "bias_glo": -0.1209493,
+                      "cor": 0.2131215,
+                      "cor_glo": 0.1757718,
+                      "frac": 0.4079202,
+                      "mean": 6.476127e-15,
+                      "mean_glo": -0.193311,
+                      "rms": 1.434592,
+                      "rms_glo": 0.673587,
+                      "rmsc": 1.254495,
+                      "rmsc_glo": 1.283922,
+                      "stdv_pc": 1.369149,
+                      "stdv_pc_ratio_to_obs": 1.616192
+                    },
+                    "eof2": {
+                      "bias": 0.002455991,
+                      "bias_glo": 0.2023852,
+                      "cor": 0.913807,
+                      "cor_glo": 0.6952528,
+                      "frac": 0.1555162,
+                      "mean": -4.375151e-15,
+                      "mean_glo": 0.1300236,
+                      "rms": 0.3502364,
+                      "rms_glo": 0.3310062,
+                      "rmsc": 0.4151939,
+                      "rmsc_glo": 0.7807013,
+                      "stdv_pc": 0.8453782,
+                      "stdv_pc_ratio_to_obs": 0.997914
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 2,
+                      "best_matching_model_eofs__rms": 2,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.003380835,
+                      "bias_glo": 0.0598824,
+                      "cor": 0.9680575,
+                      "cor_glo": 0.7428952,
+                      "frac": 0.1729541,
+                      "frac_cbf_regrid": 0.1399775,
+                      "mean": 3.968767e-15,
+                      "mean_glo": -0.1192024,
+                      "rms": 0.2116899,
+                      "rms_glo": 0.2458417,
+                      "rmsc": 0.2527548,
+                      "rmsc_glo": 0.717084,
+                      "stdv_pc": 0.803041,
+                      "stdv_pc_ratio_to_obs": 1.051405
+                    },
+                    "eof1": {
+                      "bias": 0.000836551,
+                      "bias_glo": -0.007350662,
+                      "cor": 0.02746122,
+                      "cor_glo": 0.002230965,
+                      "frac": 0.2782871,
+                      "mean": 6.214617e-15,
+                      "mean_glo": -0.1864355,
+                      "rms": 1.278282,
+                      "rms_glo": 0.5637758,
+                      "rmsc": 1.39466,
+                      "rmsc_glo": 1.412635,
+                      "stdv_pc": 1.058394,
+                      "stdv_pc_ratio_to_obs": 1.385733
+                    },
+                    "eof2": {
+                      "bias": -0.003064799,
+                      "bias_glo": 0.09106562,
+                      "cor": 0.8716694,
+                      "cor_glo": 0.7272199,
+                      "frac": 0.1791062,
+                      "mean": 2.88359e-15,
+                      "mean_glo": -0.0880192,
+                      "rms": 0.4145842,
+                      "rms_glo": 0.2592252,
+                      "rmsc": 0.5066174,
+                      "rmsc_glo": 0.7386205,
+                      "stdv_pc": 0.8490953,
+                      "stdv_pc_ratio_to_obs": 1.111702
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.003231994,
-                    "bias_glo": -0.4095763,
-                    "cor": 0.9247022,
-                    "cor_glo": 0.7810496,
-                    "frac": 0.1934667,
-                    "frac_cbf_regrid": 0.1495934,
-                    "mean": 3.601233e-15,
-                    "mean_glo": -0.1088049,
-                    "rms": 0.4796899,
-                    "rms_glo": 0.5523216,
-                    "rmsc": 0.3880666,
-                    "rmsc_glo": 0.6617407,
-                    "stdv_pc": 1.136463,
-                    "stdv_pc_ratio_to_obs": 0.914857
-                  },
-                  "eof1": {
-                    "bias": -0.007512416,
-                    "bias_glo": -1.416634,
-                    "cor": 0.1054597,
-                    "cor_glo": 0.1067177,
-                    "frac": 0.4459002,
-                    "mean": 3.842821e-14,
-                    "mean_glo": -1.115863,
-                    "rms": 2.113898,
-                    "rms_glo": 1.693602,
-                    "rmsc": 1.337565,
-                    "rmsc_glo": 1.336624,
-                    "stdv_pc": 1.879116,
-                    "stdv_pc_ratio_to_obs": 1.512695
-                  },
-                  "eof2": {
-                    "bias": 0.001927344,
-                    "bias_glo": -0.3526828,
-                    "cor": 0.8272324,
-                    "cor_glo": 0.6752448,
-                    "frac": 0.2027935,
-                    "mean": 1.320555e-15,
-                    "mean_glo": -0.05191146,
-                    "rms": 0.7346259,
-                    "rms_glo": 0.5618944,
-                    "rmsc": 0.5878223,
-                    "rmsc_glo": 0.805922,
-                    "stdv_pc": 1.267248,
-                    "stdv_pc_ratio_to_obs": 1.02014
+                    "target_model_eofs": 2
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.001965422,
-                    "bias_glo": 0.05806837,
-                    "cor": 0.9122083,
-                    "cor_glo": 0.7775047,
-                    "frac": 0.224873,
-                    "frac_cbf_regrid": 0.1821159,
-                    "mean": 2.75475e-15,
-                    "mean_glo": -0.08074314,
-                    "rms": 0.3137266,
-                    "rms_glo": 0.2196611,
-                    "rmsc": 0.4190266,
-                    "rmsc_glo": 0.6670762,
-                    "stdv_pc": 0.6222273,
-                    "stdv_pc_ratio_to_obs": 1.297093
-                  },
-                  "eof1": {
-                    "bias": 2.688043e-05,
-                    "bias_glo": 0.07285189,
-                    "cor": 0.6527494,
-                    "cor_glo": 0.5431576,
-                    "frac": 0.2736954,
-                    "mean": 2.184495e-15,
-                    "mean_glo": -0.06595961,
-                    "rms": 0.5690407,
-                    "rms_glo": 0.3083463,
-                    "rmsc": 0.8333674,
-                    "rmsc_glo": 0.9558686,
-                    "stdv_pc": 0.7589778,
-                    "stdv_pc_ratio_to_obs": 1.582163
-                  },
-                  "eof2": {
-                    "bias": -0.004090241,
-                    "bias_glo": 0.1720103,
-                    "cor": 0.6076769,
-                    "cor_glo": 0.4886326,
-                    "frac": 0.1587845,
-                    "mean": -9.457472e-16,
-                    "mean_glo": 0.03319881,
-                    "rms": 0.4758642,
-                    "rms_glo": 0.3203243,
-                    "rmsc": 0.8858026,
-                    "rmsc_glo": 1.011304,
-                    "stdv_pc": 0.5780952,
-                    "stdv_pc_ratio_to_obs": 1.205096
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.00220391,
-                    "bias_glo": 0.05499773,
-                    "cor": 0.9191628,
-                    "cor_glo": 0.7269497,
-                    "frac": 0.1825753,
-                    "frac_cbf_regrid": 0.1512343,
-                    "mean": 5.832621e-16,
-                    "mean_glo": -0.01736389,
-                    "rms": 0.3585589,
-                    "rms_glo": 0.2698424,
-                    "rmsc": 0.4020874,
-                    "rmsc_glo": 0.7389862,
-                    "stdv_pc": 0.8363425,
-                    "stdv_pc_ratio_to_obs": 0.9872479
-                  },
-                  "eof1": {
-                    "bias": 0.002017288,
-                    "bias_glo": -0.1209493,
-                    "cor": 0.2131215,
-                    "cor_glo": 0.1757718,
-                    "frac": 0.4079202,
-                    "mean": 6.476127e-15,
-                    "mean_glo": -0.193311,
-                    "rms": 1.434592,
-                    "rms_glo": 0.673587,
-                    "rmsc": 1.254495,
-                    "rmsc_glo": 1.283922,
-                    "stdv_pc": 1.369149,
-                    "stdv_pc_ratio_to_obs": 1.616192
-                  },
-                  "eof2": {
-                    "bias": 0.002455991,
-                    "bias_glo": 0.2023852,
-                    "cor": 0.913807,
-                    "cor_glo": 0.6952528,
-                    "frac": 0.1555162,
-                    "mean": -4.375151e-15,
-                    "mean_glo": 0.1300236,
-                    "rms": 0.3502364,
-                    "rms_glo": 0.3310062,
-                    "rmsc": 0.4151939,
-                    "rmsc_glo": 0.7807013,
-                    "stdv_pc": 0.8453782,
-                    "stdv_pc_ratio_to_obs": 0.997914
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 2,
-                    "best_matching_model_eofs__rms": 2,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 2,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.003380835,
-                    "bias_glo": 0.0598824,
-                    "cor": 0.9680575,
-                    "cor_glo": 0.7428952,
-                    "frac": 0.1729541,
-                    "frac_cbf_regrid": 0.1399775,
-                    "mean": 3.968767e-15,
-                    "mean_glo": -0.1192024,
-                    "rms": 0.2116899,
-                    "rms_glo": 0.2458417,
-                    "rmsc": 0.2527548,
-                    "rmsc_glo": 0.717084,
-                    "stdv_pc": 0.803041,
-                    "stdv_pc_ratio_to_obs": 1.051405
-                  },
-                  "eof1": {
-                    "bias": 0.000836551,
-                    "bias_glo": -0.007350662,
-                    "cor": 0.02746122,
-                    "cor_glo": 0.002230965,
-                    "frac": 0.2782871,
-                    "mean": 6.214617e-15,
-                    "mean_glo": -0.1864355,
-                    "rms": 1.278282,
-                    "rms_glo": 0.5637758,
-                    "rmsc": 1.39466,
-                    "rmsc_glo": 1.412635,
-                    "stdv_pc": 1.058394,
-                    "stdv_pc_ratio_to_obs": 1.385733
-                  },
-                  "eof2": {
-                    "bias": -0.003064799,
-                    "bias_glo": 0.09106562,
-                    "cor": 0.8716694,
-                    "cor_glo": 0.7272199,
-                    "frac": 0.1791062,
-                    "mean": 2.88359e-15,
-                    "mean_glo": -0.0880192,
-                    "rms": 0.4145842,
-                    "rms_glo": 0.2592252,
-                    "rmsc": 0.5066174,
-                    "rmsc_glo": 0.7386205,
-                    "stdv_pc": 0.8490953,
-                    "stdv_pc_ratio_to_obs": 1.111702
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 2
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip6/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "8f3a4713d6af9bf6fbac2c17dfc468151d122fb5",
   "committed": {
-    "diagnostic.json": "ab066bf5af715834148fab72604cc6835276054cce74fb64158c4652051965df",
+    "diagnostic.json": "e5cba91edcac578b6cdc59d22a22c003123bd94d9c6ff5eca736013c428fac65",
     "output.json": "a882dd976926ecf89e7fc7efbea9e0fd2ddd2280c45760a4cff284d6bbe73f62",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_PDO_monthly_HadISST-1-1_1900-2005.png": {
       "sha256": "b39032778d59e47a7c3269e66aed9aadab04c887de0c19de65317350df53fe19",
@@ -73,5 +73,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip6/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -57,52 +61,54 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "HadISST-1-1": {
-              "PDO": {
-                "attributes": {
-                  "target_model_eofs": 1
-                },
-                "monthly": {
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "HadISST-1-1": {
+                "PDO": {
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
+                    "target_model_eofs": 1
                   },
-                  "cbf": {
-                    "bias": -0.001180545,
-                    "bias_glo": -0.0490107,
-                    "cor": 0.898669,
-                    "cor_glo": 0.8131307,
-                    "frac": 0.1940063,
-                    "frac_cbf_regrid": 0.3454751,
-                    "mean": 1.306594e-16,
-                    "mean_glo": 0.03319002,
-                    "rms": 0.1720045,
-                    "rms_glo": 0.1126162,
-                    "rmsc": 0.453562,
-                    "rmsc_glo": 0.6673075,
-                    "stdv_pc": 0.255592,
-                    "stdv_pc_ratio_to_obs": 1.083201
-                  },
-                  "eof1": {
-                    "bias": -0.0006476972,
-                    "bias_glo": -0.04768813,
-                    "cor": 0.8341324,
-                    "cor_glo": 0.7640831,
-                    "frac": 0.2065719,
-                    "mean": 2.912426e-17,
-                    "mean_glo": 0.03476321,
-                    "rms": 0.2171376,
-                    "rms_glo": 0.1224397,
-                    "rmsc": 0.5787447,
-                    "rmsc_glo": 0.7385282,
-                    "stdv_pc": 0.3114757,
-                    "stdv_pc_ratio_to_obs": 1.320037
+                  "monthly": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.001180545,
+                      "bias_glo": -0.0490107,
+                      "cor": 0.898669,
+                      "cor_glo": 0.8131307,
+                      "frac": 0.1940063,
+                      "frac_cbf_regrid": 0.3454751,
+                      "mean": 1.306594e-16,
+                      "mean_glo": 0.03319002,
+                      "rms": 0.1720045,
+                      "rms_glo": 0.1126162,
+                      "rmsc": 0.453562,
+                      "rmsc_glo": 0.6673075,
+                      "stdv_pc": 0.255592,
+                      "stdv_pc_ratio_to_obs": 1.083201
+                    },
+                    "eof1": {
+                      "bias": -0.0006476972,
+                      "bias_glo": -0.04768813,
+                      "cor": 0.8341324,
+                      "cor_glo": 0.7640831,
+                      "frac": 0.2065719,
+                      "mean": 2.912426e-17,
+                      "mean_glo": 0.03476321,
+                      "rms": 0.2171376,
+                      "rms_glo": 0.1224397,
+                      "rmsc": 0.5787447,
+                      "rmsc_glo": 0.7385282,
+                      "stdv_pc": 0.3114757,
+                      "stdv_pc_ratio_to_obs": 1.320037
+                    }
                   }
                 }
               }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip7/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "f08a7aebd0f75f6aee658e536ee9de9f28317bba",
   "committed": {
-    "diagnostic.json": "2ad8da046facbf0021ab0ba90a8f869eaa7b2213eb4f8c61ab30b66b87b01e04",
+    "diagnostic.json": "3c0289163eed1b3c6f3d8f870c0f4aa19e07147fee6284bb5f6c32b1e849637d",
     "output.json": "37f0eed421f73813e27df652aeab97a28a142adda89d3f5e26862b345c92168c",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_PDO_monthly_HadISST-1-1_1900-2005.png": {
       "sha256": "b39032778d59e47a7c3269e66aed9aadab04c887de0c19de65317350df53fe19",
@@ -73,5 +73,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pdo/cmip7/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -57,52 +61,54 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "HadISST-1-1": {
-              "PDO": {
-                "attributes": {
-                  "target_model_eofs": 1
-                },
-                "monthly": {
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "HadISST-1-1": {
+                "PDO": {
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
+                    "target_model_eofs": 1
                   },
-                  "cbf": {
-                    "bias": -0.001180549,
-                    "bias_glo": -0.04901057,
-                    "cor": 0.8986691,
-                    "cor_glo": 0.8131307,
-                    "frac": 0.1940059,
-                    "frac_cbf_regrid": 0.3454753,
-                    "mean": 1.467634e-16,
-                    "mean_glo": 0.03319017,
-                    "rms": 0.1720042,
-                    "rms_glo": 0.1126161,
-                    "rmsc": 0.4535619,
-                    "rmsc_glo": 0.6673076,
-                    "stdv_pc": 0.2555918,
-                    "stdv_pc_ratio_to_obs": 1.0832
-                  },
-                  "eof1": {
-                    "bias": -0.0006477075,
-                    "bias_glo": -0.04768806,
-                    "cor": 0.8341323,
-                    "cor_glo": 0.7640828,
-                    "frac": 0.2065715,
-                    "mean": 5.133864e-17,
-                    "mean_glo": 0.0347633,
-                    "rms": 0.2171373,
-                    "rms_glo": 0.1224397,
-                    "rmsc": 0.5787448,
-                    "rmsc_glo": 0.7385287,
-                    "stdv_pc": 0.3114754,
-                    "stdv_pc_ratio_to_obs": 1.320036
+                  "monthly": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.001180549,
+                      "bias_glo": -0.04901057,
+                      "cor": 0.8986691,
+                      "cor_glo": 0.8131307,
+                      "frac": 0.1940059,
+                      "frac_cbf_regrid": 0.3454753,
+                      "mean": 1.467634e-16,
+                      "mean_glo": 0.03319017,
+                      "rms": 0.1720042,
+                      "rms_glo": 0.1126161,
+                      "rmsc": 0.4535619,
+                      "rmsc_glo": 0.6673076,
+                      "stdv_pc": 0.2555918,
+                      "stdv_pc_ratio_to_obs": 1.0832
+                    },
+                    "eof1": {
+                      "bias": -0.0006477075,
+                      "bias_glo": -0.04768806,
+                      "cor": 0.8341323,
+                      "cor_glo": 0.7640828,
+                      "frac": 0.2065715,
+                      "mean": 5.133864e-17,
+                      "mean_glo": 0.0347633,
+                      "rms": 0.2171373,
+                      "rms_glo": 0.1224397,
+                      "rmsc": 0.5787448,
+                      "rmsc_glo": 0.7385287,
+                      "stdv_pc": 0.3114754,
+                      "stdv_pc_ratio_to_obs": 1.320036
+                    }
                   }
                 }
               }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip6/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "97fbf6c3eafe72779d017d41744a0f69504f6128",
   "committed": {
-    "diagnostic.json": "d5eaddcd57663b2f957fe1e4367abbcabe39a76826022835ce1f53b10f539e81",
+    "diagnostic.json": "5b771925465c89f29804da47425b48e486d782261e3231f6f91cc83a27a3edf6",
     "output.json": "e20535bfc6e337eb4f36b90f75494a192878dc04b6a83cc334bc7595aafb05b4",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_PNA_DJF_20CR_1900-2005.png": {
       "sha256": "507f5faee65bd25a8d517604e236fae5c6fa0759c040dbfa96d1be6a1275a88b",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip6/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "PNA": {
-                "DJF": {
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "PNA": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.007562917,
+                      "bias_glo": 0.378952,
+                      "cor": 0.9834317,
+                      "cor_glo": 0.9195546,
+                      "frac": 0.442101,
+                      "frac_cbf_regrid": 0.4013135,
+                      "mean": -3.759713e-14,
+                      "mean_glo": 1.108599,
+                      "rms": 0.3981982,
+                      "rms_glo": 0.4932283,
+                      "rmsc": 0.1820346,
+                      "rmsc_glo": 0.401112,
+                      "stdv_pc": 1.828079,
+                      "stdv_pc_ratio_to_obs": 1.131194
+                    },
+                    "eof1": {
+                      "bias": 0.007633675,
+                      "bias_glo": 0.4191277,
+                      "cor": 0.9725514,
+                      "cor_glo": 0.9145459,
+                      "frac": 0.4459002,
+                      "mean": -3.846518e-14,
+                      "mean_glo": 1.148775,
+                      "rms": 0.4910956,
+                      "rms_glo": 0.5359746,
+                      "rmsc": 0.2343017,
+                      "rmsc_glo": 0.4134105,
+                      "stdv_pc": 1.879116,
+                      "stdv_pc_ratio_to_obs": 1.162774
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.002697485,
+                      "bias_glo": -0.00438577,
+                      "cor": 0.9097263,
+                      "cor_glo": 0.4985774,
+                      "frac": 0.2306745,
+                      "frac_cbf_regrid": 0.1966832,
+                      "mean": -1.462947e-15,
+                      "mean_glo": 0.04575654,
+                      "rms": 0.2873615,
+                      "rms_glo": 0.3604348,
+                      "rmsc": 0.4249086,
+                      "rmsc_glo": 1.001422,
+                      "stdv_pc": 0.6276113,
+                      "stdv_pc_ratio_to_obs": 0.9650817
+                    },
+                    "eof1": {
+                      "bias": -2.688043e-05,
+                      "bias_glo": 0.0158173,
+                      "cor": 0.6705735,
+                      "cor_glo": 0.3899653,
+                      "frac": 0.2736954,
+                      "mean": -2.151635e-15,
+                      "mean_glo": 0.06595961,
+                      "rms": 0.5761246,
+                      "rms_glo": 0.4117775,
+                      "rmsc": 0.8116976,
+                      "rmsc_glo": 1.104567,
+                      "stdv_pc": 0.7589778,
+                      "stdv_pc_ratio_to_obs": 1.167085
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.000881076,
+                      "bias_glo": -0.0303965,
+                      "cor": 0.9379068,
+                      "cor_glo": 0.8278275,
+                      "frac": 0.3922779,
+                      "frac_cbf_regrid": 0.3213323,
+                      "mean": -7.79052e-15,
+                      "mean_glo": 0.2335774,
+                      "rms": 0.4787085,
+                      "rms_glo": 0.3444954,
+                      "rmsc": 0.3524009,
+                      "rmsc_glo": 0.5868091,
+                      "stdv_pc": 1.244086,
+                      "stdv_pc_ratio_to_obs": 1.118752
+                    },
+                    "eof1": {
+                      "bias": -0.002017288,
+                      "bias_glo": -0.07066292,
+                      "cor": 0.894664,
+                      "cor_glo": 0.7959059,
+                      "frac": 0.4079202,
+                      "mean": -6.476127e-15,
+                      "mean_glo": 0.193311,
+                      "rms": 0.6119924,
+                      "rms_glo": 0.3900527,
+                      "rmsc": 0.4589902,
+                      "rmsc_glo": 0.638896,
+                      "stdv_pc": 1.369149,
+                      "stdv_pc_ratio_to_obs": 1.231216
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.0002653955,
+                      "bias_glo": -0.1367683,
+                      "cor": 0.9463496,
+                      "cor_glo": 0.5642451,
+                      "frac": 0.2641003,
+                      "frac_cbf_regrid": 0.2219144,
+                      "mean": -6.320042e-15,
+                      "mean_glo": 0.1902624,
+                      "rms": 0.3304454,
+                      "rms_glo": 0.4418701,
+                      "rmsc": 0.3275681,
+                      "rmsc_glo": 0.9335469,
+                      "stdv_pc": 0.9652394,
+                      "stdv_pc_ratio_to_obs": 1.02513
+                    },
+                    "eof1": {
+                      "bias": -0.000836551,
+                      "bias_glo": -0.1405952,
+                      "cor": 0.8803366,
+                      "cor_glo": 0.5074893,
+                      "frac": 0.2782871,
+                      "mean": -6.214617e-15,
+                      "mean_glo": 0.1864355,
+                      "rms": 0.4966898,
+                      "rms_glo": 0.4774734,
+                      "rmsc": 0.4892103,
+                      "rmsc_glo": 0.9924825,
+                      "stdv_pc": 1.058394,
+                      "stdv_pc_ratio_to_obs": 1.124065
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.007562917,
-                    "bias_glo": 0.378952,
-                    "cor": 0.9834317,
-                    "cor_glo": 0.9195546,
-                    "frac": 0.442101,
-                    "frac_cbf_regrid": 0.4013135,
-                    "mean": -3.759713e-14,
-                    "mean_glo": 1.108599,
-                    "rms": 0.3981982,
-                    "rms_glo": 0.4932283,
-                    "rmsc": 0.1820346,
-                    "rmsc_glo": 0.401112,
-                    "stdv_pc": 1.828079,
-                    "stdv_pc_ratio_to_obs": 1.131194
-                  },
-                  "eof1": {
-                    "bias": 0.007633675,
-                    "bias_glo": 0.4191277,
-                    "cor": 0.9725514,
-                    "cor_glo": 0.9145459,
-                    "frac": 0.4459002,
-                    "mean": -3.846518e-14,
-                    "mean_glo": 1.148775,
-                    "rms": 0.4910956,
-                    "rms_glo": 0.5359746,
-                    "rmsc": 0.2343017,
-                    "rmsc_glo": 0.4134105,
-                    "stdv_pc": 1.879116,
-                    "stdv_pc_ratio_to_obs": 1.162774
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.002697485,
-                    "bias_glo": -0.00438577,
-                    "cor": 0.9097263,
-                    "cor_glo": 0.4985774,
-                    "frac": 0.2306745,
-                    "frac_cbf_regrid": 0.1966832,
-                    "mean": -1.462947e-15,
-                    "mean_glo": 0.04575654,
-                    "rms": 0.2873615,
-                    "rms_glo": 0.3604348,
-                    "rmsc": 0.4249086,
-                    "rmsc_glo": 1.001422,
-                    "stdv_pc": 0.6276113,
-                    "stdv_pc_ratio_to_obs": 0.9650817
-                  },
-                  "eof1": {
-                    "bias": -2.688043e-05,
-                    "bias_glo": 0.0158173,
-                    "cor": 0.6705735,
-                    "cor_glo": 0.3899653,
-                    "frac": 0.2736954,
-                    "mean": -2.151635e-15,
-                    "mean_glo": 0.06595961,
-                    "rms": 0.5761246,
-                    "rms_glo": 0.4117775,
-                    "rmsc": 0.8116976,
-                    "rmsc_glo": 1.104567,
-                    "stdv_pc": 0.7589778,
-                    "stdv_pc_ratio_to_obs": 1.167085
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.000881076,
-                    "bias_glo": -0.0303965,
-                    "cor": 0.9379068,
-                    "cor_glo": 0.8278275,
-                    "frac": 0.3922779,
-                    "frac_cbf_regrid": 0.3213323,
-                    "mean": -7.79052e-15,
-                    "mean_glo": 0.2335774,
-                    "rms": 0.4787085,
-                    "rms_glo": 0.3444954,
-                    "rmsc": 0.3524009,
-                    "rmsc_glo": 0.5868091,
-                    "stdv_pc": 1.244086,
-                    "stdv_pc_ratio_to_obs": 1.118752
-                  },
-                  "eof1": {
-                    "bias": -0.002017288,
-                    "bias_glo": -0.07066292,
-                    "cor": 0.894664,
-                    "cor_glo": 0.7959059,
-                    "frac": 0.4079202,
-                    "mean": -6.476127e-15,
-                    "mean_glo": 0.193311,
-                    "rms": 0.6119924,
-                    "rms_glo": 0.3900527,
-                    "rmsc": 0.4589902,
-                    "rmsc_glo": 0.638896,
-                    "stdv_pc": 1.369149,
-                    "stdv_pc_ratio_to_obs": 1.231216
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.0002653955,
-                    "bias_glo": -0.1367683,
-                    "cor": 0.9463496,
-                    "cor_glo": 0.5642451,
-                    "frac": 0.2641003,
-                    "frac_cbf_regrid": 0.2219144,
-                    "mean": -6.320042e-15,
-                    "mean_glo": 0.1902624,
-                    "rms": 0.3304454,
-                    "rms_glo": 0.4418701,
-                    "rmsc": 0.3275681,
-                    "rmsc_glo": 0.9335469,
-                    "stdv_pc": 0.9652394,
-                    "stdv_pc_ratio_to_obs": 1.02513
-                  },
-                  "eof1": {
-                    "bias": -0.000836551,
-                    "bias_glo": -0.1405952,
-                    "cor": 0.8803366,
-                    "cor_glo": 0.5074893,
-                    "frac": 0.2782871,
-                    "mean": -6.214617e-15,
-                    "mean_glo": 0.1864355,
-                    "rms": 0.4966898,
-                    "rms_glo": 0.4774734,
-                    "rmsc": 0.4892103,
-                    "rmsc_glo": 0.9924825,
-                    "stdv_pc": 1.058394,
-                    "stdv_pc_ratio_to_obs": 1.124065
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip7/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "d8fe04e12ce8e9b2a628bc79d539f17e62478ab1",
   "committed": {
-    "diagnostic.json": "9de331f2cada90adea9f1a89767801b5654b875ee8d1f8adfc48b01edc7d4fce",
+    "diagnostic.json": "c0eeb8ffd6a4c328ac417ab9d55bc9998f64a40d16fd61dec0e1169944be29ed",
     "output.json": "341b4e6788ae59388c9bd54805e5340e72358b0491b825a7f0d93518f3725eb6",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_PNA_DJF_20CR_1900-2005.png": {
       "sha256": "507f5faee65bd25a8d517604e236fae5c6fa0759c040dbfa96d1be6a1275a88b",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-pna/cmip7/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "PNA": {
-                "DJF": {
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "PNA": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.007562917,
+                      "bias_glo": 0.378952,
+                      "cor": 0.9834317,
+                      "cor_glo": 0.9195546,
+                      "frac": 0.442101,
+                      "frac_cbf_regrid": 0.4013135,
+                      "mean": -3.759713e-14,
+                      "mean_glo": 1.108599,
+                      "rms": 0.3981982,
+                      "rms_glo": 0.4932283,
+                      "rmsc": 0.1820346,
+                      "rmsc_glo": 0.401112,
+                      "stdv_pc": 1.828079,
+                      "stdv_pc_ratio_to_obs": 1.131194
+                    },
+                    "eof1": {
+                      "bias": 0.007633675,
+                      "bias_glo": 0.4191277,
+                      "cor": 0.9725514,
+                      "cor_glo": 0.9145459,
+                      "frac": 0.4459002,
+                      "mean": -3.846518e-14,
+                      "mean_glo": 1.148775,
+                      "rms": 0.4910956,
+                      "rms_glo": 0.5359746,
+                      "rmsc": 0.2343017,
+                      "rmsc_glo": 0.4134105,
+                      "stdv_pc": 1.879116,
+                      "stdv_pc_ratio_to_obs": 1.162774
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.002697485,
+                      "bias_glo": -0.00438577,
+                      "cor": 0.9097263,
+                      "cor_glo": 0.4985774,
+                      "frac": 0.2306745,
+                      "frac_cbf_regrid": 0.1966832,
+                      "mean": -1.462947e-15,
+                      "mean_glo": 0.04575654,
+                      "rms": 0.2873615,
+                      "rms_glo": 0.3604348,
+                      "rmsc": 0.4249086,
+                      "rmsc_glo": 1.001422,
+                      "stdv_pc": 0.6276113,
+                      "stdv_pc_ratio_to_obs": 0.9650817
+                    },
+                    "eof1": {
+                      "bias": -2.688043e-05,
+                      "bias_glo": 0.0158173,
+                      "cor": 0.6705735,
+                      "cor_glo": 0.3899653,
+                      "frac": 0.2736954,
+                      "mean": -2.151635e-15,
+                      "mean_glo": 0.06595961,
+                      "rms": 0.5761246,
+                      "rms_glo": 0.4117775,
+                      "rmsc": 0.8116976,
+                      "rmsc_glo": 1.104567,
+                      "stdv_pc": 0.7589778,
+                      "stdv_pc_ratio_to_obs": 1.167085
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.000881076,
+                      "bias_glo": -0.0303965,
+                      "cor": 0.9379068,
+                      "cor_glo": 0.8278275,
+                      "frac": 0.3922779,
+                      "frac_cbf_regrid": 0.3213323,
+                      "mean": -7.79052e-15,
+                      "mean_glo": 0.2335774,
+                      "rms": 0.4787085,
+                      "rms_glo": 0.3444954,
+                      "rmsc": 0.3524009,
+                      "rmsc_glo": 0.5868091,
+                      "stdv_pc": 1.244086,
+                      "stdv_pc_ratio_to_obs": 1.118752
+                    },
+                    "eof1": {
+                      "bias": -0.002017288,
+                      "bias_glo": -0.07066292,
+                      "cor": 0.894664,
+                      "cor_glo": 0.7959059,
+                      "frac": 0.4079202,
+                      "mean": -6.476127e-15,
+                      "mean_glo": 0.193311,
+                      "rms": 0.6119924,
+                      "rms_glo": 0.3900527,
+                      "rmsc": 0.4589902,
+                      "rmsc_glo": 0.638896,
+                      "stdv_pc": 1.369149,
+                      "stdv_pc_ratio_to_obs": 1.231216
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.0002653955,
+                      "bias_glo": -0.1367683,
+                      "cor": 0.9463496,
+                      "cor_glo": 0.5642451,
+                      "frac": 0.2641003,
+                      "frac_cbf_regrid": 0.2219144,
+                      "mean": -6.320042e-15,
+                      "mean_glo": 0.1902624,
+                      "rms": 0.3304454,
+                      "rms_glo": 0.4418701,
+                      "rmsc": 0.3275681,
+                      "rmsc_glo": 0.9335469,
+                      "stdv_pc": 0.9652394,
+                      "stdv_pc_ratio_to_obs": 1.02513
+                    },
+                    "eof1": {
+                      "bias": -0.000836551,
+                      "bias_glo": -0.1405952,
+                      "cor": 0.8803366,
+                      "cor_glo": 0.5074893,
+                      "frac": 0.2782871,
+                      "mean": -6.214617e-15,
+                      "mean_glo": 0.1864355,
+                      "rms": 0.4966898,
+                      "rms_glo": 0.4774734,
+                      "rmsc": 0.4892103,
+                      "rmsc_glo": 0.9924825,
+                      "stdv_pc": 1.058394,
+                      "stdv_pc_ratio_to_obs": 1.124065
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.007562917,
-                    "bias_glo": 0.378952,
-                    "cor": 0.9834317,
-                    "cor_glo": 0.9195546,
-                    "frac": 0.442101,
-                    "frac_cbf_regrid": 0.4013135,
-                    "mean": -3.759713e-14,
-                    "mean_glo": 1.108599,
-                    "rms": 0.3981982,
-                    "rms_glo": 0.4932283,
-                    "rmsc": 0.1820346,
-                    "rmsc_glo": 0.401112,
-                    "stdv_pc": 1.828079,
-                    "stdv_pc_ratio_to_obs": 1.131194
-                  },
-                  "eof1": {
-                    "bias": 0.007633675,
-                    "bias_glo": 0.4191277,
-                    "cor": 0.9725514,
-                    "cor_glo": 0.9145459,
-                    "frac": 0.4459002,
-                    "mean": -3.846518e-14,
-                    "mean_glo": 1.148775,
-                    "rms": 0.4910956,
-                    "rms_glo": 0.5359746,
-                    "rmsc": 0.2343017,
-                    "rmsc_glo": 0.4134105,
-                    "stdv_pc": 1.879116,
-                    "stdv_pc_ratio_to_obs": 1.162774
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.002697485,
-                    "bias_glo": -0.00438577,
-                    "cor": 0.9097263,
-                    "cor_glo": 0.4985774,
-                    "frac": 0.2306745,
-                    "frac_cbf_regrid": 0.1966832,
-                    "mean": -1.462947e-15,
-                    "mean_glo": 0.04575654,
-                    "rms": 0.2873615,
-                    "rms_glo": 0.3604348,
-                    "rmsc": 0.4249086,
-                    "rmsc_glo": 1.001422,
-                    "stdv_pc": 0.6276113,
-                    "stdv_pc_ratio_to_obs": 0.9650817
-                  },
-                  "eof1": {
-                    "bias": -2.688043e-05,
-                    "bias_glo": 0.0158173,
-                    "cor": 0.6705735,
-                    "cor_glo": 0.3899653,
-                    "frac": 0.2736954,
-                    "mean": -2.151635e-15,
-                    "mean_glo": 0.06595961,
-                    "rms": 0.5761246,
-                    "rms_glo": 0.4117775,
-                    "rmsc": 0.8116976,
-                    "rmsc_glo": 1.104567,
-                    "stdv_pc": 0.7589778,
-                    "stdv_pc_ratio_to_obs": 1.167085
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.000881076,
-                    "bias_glo": -0.0303965,
-                    "cor": 0.9379068,
-                    "cor_glo": 0.8278275,
-                    "frac": 0.3922779,
-                    "frac_cbf_regrid": 0.3213323,
-                    "mean": -7.79052e-15,
-                    "mean_glo": 0.2335774,
-                    "rms": 0.4787085,
-                    "rms_glo": 0.3444954,
-                    "rmsc": 0.3524009,
-                    "rmsc_glo": 0.5868091,
-                    "stdv_pc": 1.244086,
-                    "stdv_pc_ratio_to_obs": 1.118752
-                  },
-                  "eof1": {
-                    "bias": -0.002017288,
-                    "bias_glo": -0.07066292,
-                    "cor": 0.894664,
-                    "cor_glo": 0.7959059,
-                    "frac": 0.4079202,
-                    "mean": -6.476127e-15,
-                    "mean_glo": 0.193311,
-                    "rms": 0.6119924,
-                    "rms_glo": 0.3900527,
-                    "rmsc": 0.4589902,
-                    "rmsc_glo": 0.638896,
-                    "stdv_pc": 1.369149,
-                    "stdv_pc_ratio_to_obs": 1.231216
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.0002653955,
-                    "bias_glo": -0.1367683,
-                    "cor": 0.9463496,
-                    "cor_glo": 0.5642451,
-                    "frac": 0.2641003,
-                    "frac_cbf_regrid": 0.2219144,
-                    "mean": -6.320042e-15,
-                    "mean_glo": 0.1902624,
-                    "rms": 0.3304454,
-                    "rms_glo": 0.4418701,
-                    "rmsc": 0.3275681,
-                    "rmsc_glo": 0.9335469,
-                    "stdv_pc": 0.9652394,
-                    "stdv_pc_ratio_to_obs": 1.02513
-                  },
-                  "eof1": {
-                    "bias": -0.000836551,
-                    "bias_glo": -0.1405952,
-                    "cor": 0.8803366,
-                    "cor_glo": 0.5074893,
-                    "frac": 0.2782871,
-                    "mean": -6.214617e-15,
-                    "mean_glo": 0.1864355,
-                    "rms": 0.4966898,
-                    "rms_glo": 0.4774734,
-                    "rmsc": 0.4892103,
-                    "rmsc_glo": 0.9924825,
-                    "stdv_pc": 1.058394,
-                    "stdv_pc_ratio_to_obs": 1.124065
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip6/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip6/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "97fbf6c3eafe72779d017d41744a0f69504f6128",
   "committed": {
-    "diagnostic.json": "8d5fb426a687b12e5713b8562dbd5a22187cb40fbba436a4a586ef35e54d4db3",
+    "diagnostic.json": "d0d33f6c6996961b7c9f86e22f0ef8bf818ada6e8f42f8b197b4cc8a7fa64bdf",
     "output.json": "e12259f127181727494f357ae5480074a7c3bff706bacc087fd6c53b02641587",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_SAM_DJF_20CR_1950-2005.png": {
       "sha256": "c7ef152390fa88c2cd263a03855103fe895e10e1be04497faf284e7ce93d4220",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip6/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip6/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip6": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "SAM": {
-                "DJF": {
+    "model": {
+      "cmip6": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "SAM": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.001762749,
+                      "bias_glo": -0.1075122,
+                      "cor": 0.95355,
+                      "cor_glo": 0.8750641,
+                      "frac": 0.5025455,
+                      "frac_cbf_regrid": 0.455665,
+                      "mean": 3.719662e-16,
+                      "mean_glo": -0.1980005,
+                      "rms": 0.4834196,
+                      "rms_glo": 0.4478494,
+                      "rmsc": 0.3047949,
+                      "rmsc_glo": 0.4998718,
+                      "stdv_pc": 1.441395,
+                      "stdv_pc_ratio_to_obs": 1.126895
+                    },
+                    "eof1": {
+                      "bias": -0.001667786,
+                      "bias_glo": -0.09820818,
+                      "cor": 0.9488642,
+                      "cor_glo": 0.8678051,
+                      "frac": 0.5048348,
+                      "mean": 3.719662e-16,
+                      "mean_glo": -0.1886964,
+                      "rms": 0.4970067,
+                      "rms_glo": 0.4541364,
+                      "rmsc": 0.3197994,
+                      "rmsc_glo": 0.5141886,
+                      "stdv_pc": 1.524994,
+                      "stdv_pc_ratio_to_obs": 1.192253
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.003367143,
+                      "bias_glo": 0.2083335,
+                      "cor": 0.9241482,
+                      "cor_glo": 0.9078857,
+                      "frac": 0.2951453,
+                      "frac_cbf_regrid": 0.2664703,
+                      "mean": 2.824359e-16,
+                      "mean_glo": -0.2056333,
+                      "rms": 0.5830726,
+                      "rms_glo": 0.4411841,
+                      "rmsc": 0.3894914,
+                      "rmsc_glo": 0.4292186,
+                      "stdv_pc": 1.389706,
+                      "stdv_pc_ratio_to_obs": 0.9331306
+                    },
+                    "eof1": {
+                      "bias": -0.003149839,
+                      "bias_glo": 0.2166533,
+                      "cor": 0.8912003,
+                      "cor_glo": 0.8757222,
+                      "frac": 0.3039656,
+                      "mean": 1.679847e-16,
+                      "mean_glo": -0.1973135,
+                      "rms": 0.7041843,
+                      "rms_glo": 0.5027321,
+                      "rmsc": 0.4664756,
+                      "rmsc_glo": 0.4985535,
+                      "stdv_pc": 1.534926,
+                      "stdv_pc_ratio_to_obs": 1.03064
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.00138727,
+                      "bias_glo": -0.01169619,
+                      "cor": 0.9264358,
+                      "cor_glo": 0.871208,
+                      "frac": 0.2725036,
+                      "frac_cbf_regrid": 0.244548,
+                      "mean": -2.067505e-16,
+                      "mean_glo": 0.1269256,
+                      "rms": 0.4435854,
+                      "rms_glo": 0.3492357,
+                      "rmsc": 0.3835732,
+                      "rmsc_glo": 0.5075274,
+                      "stdv_pc": 0.9998873,
+                      "stdv_pc_ratio_to_obs": 0.8488818
+                    },
+                    "eof1": {
+                      "bias": 0.001149139,
+                      "bias_glo": -0.02840441,
+                      "cor": 0.9006484,
+                      "cor_glo": 0.8410641,
+                      "frac": 0.2793511,
+                      "mean": -2.847434e-16,
+                      "mean_glo": 0.1102173,
+                      "rms": 0.512841,
+                      "rms_glo": 0.3888076,
+                      "rmsc": 0.4457613,
+                      "rmsc_glo": 0.5638013,
+                      "stdv_pc": 1.099716,
+                      "stdv_pc_ratio_to_obs": 0.9336339
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.002311634,
+                      "bias_glo": -0.02588984,
+                      "cor": 0.9449423,
+                      "cor_glo": 0.903724,
+                      "frac": 0.3829946,
+                      "frac_cbf_regrid": 0.3437269,
+                      "mean": -5.436429e-16,
+                      "mean_glo": 0.1588923,
+                      "rms": 0.5115627,
+                      "rms_glo": 0.3707613,
+                      "rmsc": 0.3318364,
+                      "rmsc_glo": 0.4388074,
+                      "stdv_pc": 1.36987,
+                      "stdv_pc_ratio_to_obs": 1.162428
+                    },
+                    "eof1": {
+                      "bias": 0.002349421,
+                      "bias_glo": -0.01438738,
+                      "cor": 0.9198651,
+                      "cor_glo": 0.8815445,
+                      "frac": 0.3919017,
+                      "mean": -5.002623e-16,
+                      "mean_glo": 0.1703948,
+                      "rms": 0.5998998,
+                      "rms_glo": 0.410809,
+                      "rmsc": 0.4003372,
+                      "rmsc_glo": 0.486735,
+                      "stdv_pc": 1.475538,
+                      "stdv_pc_ratio_to_obs": 1.252095
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.001762749,
-                    "bias_glo": -0.1075122,
-                    "cor": 0.95355,
-                    "cor_glo": 0.8750641,
-                    "frac": 0.5025455,
-                    "frac_cbf_regrid": 0.455665,
-                    "mean": 3.719662e-16,
-                    "mean_glo": -0.1980005,
-                    "rms": 0.4834196,
-                    "rms_glo": 0.4478494,
-                    "rmsc": 0.3047949,
-                    "rmsc_glo": 0.4998718,
-                    "stdv_pc": 1.441395,
-                    "stdv_pc_ratio_to_obs": 1.126895
-                  },
-                  "eof1": {
-                    "bias": -0.001667786,
-                    "bias_glo": -0.09820818,
-                    "cor": 0.9488642,
-                    "cor_glo": 0.8678051,
-                    "frac": 0.5048348,
-                    "mean": 3.719662e-16,
-                    "mean_glo": -0.1886964,
-                    "rms": 0.4970067,
-                    "rms_glo": 0.4541364,
-                    "rmsc": 0.3197994,
-                    "rmsc_glo": 0.5141886,
-                    "stdv_pc": 1.524994,
-                    "stdv_pc_ratio_to_obs": 1.192253
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.003367143,
-                    "bias_glo": 0.2083335,
-                    "cor": 0.9241482,
-                    "cor_glo": 0.9078857,
-                    "frac": 0.2951453,
-                    "frac_cbf_regrid": 0.2664703,
-                    "mean": 2.824359e-16,
-                    "mean_glo": -0.2056333,
-                    "rms": 0.5830726,
-                    "rms_glo": 0.4411841,
-                    "rmsc": 0.3894914,
-                    "rmsc_glo": 0.4292186,
-                    "stdv_pc": 1.389706,
-                    "stdv_pc_ratio_to_obs": 0.9331306
-                  },
-                  "eof1": {
-                    "bias": -0.003149839,
-                    "bias_glo": 0.2166533,
-                    "cor": 0.8912003,
-                    "cor_glo": 0.8757222,
-                    "frac": 0.3039656,
-                    "mean": 1.679847e-16,
-                    "mean_glo": -0.1973135,
-                    "rms": 0.7041843,
-                    "rms_glo": 0.5027321,
-                    "rmsc": 0.4664756,
-                    "rmsc_glo": 0.4985535,
-                    "stdv_pc": 1.534926,
-                    "stdv_pc_ratio_to_obs": 1.03064
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.00138727,
-                    "bias_glo": -0.01169619,
-                    "cor": 0.9264358,
-                    "cor_glo": 0.871208,
-                    "frac": 0.2725036,
-                    "frac_cbf_regrid": 0.244548,
-                    "mean": -2.067505e-16,
-                    "mean_glo": 0.1269256,
-                    "rms": 0.4435854,
-                    "rms_glo": 0.3492357,
-                    "rmsc": 0.3835732,
-                    "rmsc_glo": 0.5075274,
-                    "stdv_pc": 0.9998873,
-                    "stdv_pc_ratio_to_obs": 0.8488818
-                  },
-                  "eof1": {
-                    "bias": 0.001149139,
-                    "bias_glo": -0.02840441,
-                    "cor": 0.9006484,
-                    "cor_glo": 0.8410641,
-                    "frac": 0.2793511,
-                    "mean": -2.847434e-16,
-                    "mean_glo": 0.1102173,
-                    "rms": 0.512841,
-                    "rms_glo": 0.3888076,
-                    "rmsc": 0.4457613,
-                    "rmsc_glo": 0.5638013,
-                    "stdv_pc": 1.099716,
-                    "stdv_pc_ratio_to_obs": 0.9336339
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.002311634,
-                    "bias_glo": -0.02588984,
-                    "cor": 0.9449423,
-                    "cor_glo": 0.903724,
-                    "frac": 0.3829946,
-                    "frac_cbf_regrid": 0.3437269,
-                    "mean": -5.436429e-16,
-                    "mean_glo": 0.1588923,
-                    "rms": 0.5115627,
-                    "rms_glo": 0.3707613,
-                    "rmsc": 0.3318364,
-                    "rmsc_glo": 0.4388074,
-                    "stdv_pc": 1.36987,
-                    "stdv_pc_ratio_to_obs": 1.162428
-                  },
-                  "eof1": {
-                    "bias": 0.002349421,
-                    "bias_glo": -0.01438738,
-                    "cor": 0.9198651,
-                    "cor_glo": 0.8815445,
-                    "frac": 0.3919017,
-                    "mean": -5.002623e-16,
-                    "mean_glo": 0.1703948,
-                    "rms": 0.5998998,
-                    "rms_glo": 0.410809,
-                    "rmsc": 0.4003372,
-                    "rmsc_glo": 0.486735,
-                    "stdv_pc": 1.475538,
-                    "stdv_pc_ratio_to_obs": 1.252095
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip7/manifest.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip7/manifest.json
@@ -1,11 +1,11 @@
 {
   "catalog_hash": "d8fe04e12ce8e9b2a628bc79d539f17e62478ab1",
   "committed": {
-    "diagnostic.json": "da4ce9197cb05c76911c69c5db41a297a8fdd82c2c46a3b0ef471e74e6be3ba0",
+    "diagnostic.json": "e2c7cf3dd62073d34d7dd6aa2665f9ff688b6c35767be0c2ac37b6aed68aade7",
     "output.json": "9eeab48e41a1de571f02f399dc4bd66e4f8e6406b498c108e3baaa99041a6486",
     "series.json": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
   },
-  "diagnostic_version": 1,
+  "diagnostic_version": 2,
   "native": {
     "EG_Spec_North_test_SAM_DJF_20CR_1950-2005.png": {
       "sha256": "c7ef152390fa88c2cd263a03855103fe895e10e1be04497faf284e7ce93d4220",
@@ -217,5 +217,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip7/regression/diagnostic.json
+++ b/packages/climate-ref-pmp/tests/test-data/extratropical-modes-of-variability-sam/cmip7/regression/diagnostic.json
@@ -4,6 +4,7 @@
       "historical": {}
     },
     "json_structure": [
+      "kind",
       "mip_id",
       "source_id",
       "member_id",
@@ -14,6 +15,9 @@
       "method",
       "statistic"
     ],
+    "kind": {
+      "model": {}
+    },
     "member_id": {
       "r1i1p1f1": {}
     },
@@ -60,170 +64,172 @@
   "NOTES": null,
   "PROVENANCE": {},
   "RESULTS": {
-    "cmip7": {
-      "ACCESS-ESM1-5": {
-        "r1i1p1f1": {
-          "historical": {
-            "20CR": {
-              "SAM": {
-                "DJF": {
+    "model": {
+      "cmip7": {
+        "ACCESS-ESM1-5": {
+          "r1i1p1f1": {
+            "historical": {
+              "20CR": {
+                "SAM": {
+                  "DJF": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.001762749,
+                      "bias_glo": -0.1075122,
+                      "cor": 0.95355,
+                      "cor_glo": 0.8750641,
+                      "frac": 0.5025455,
+                      "frac_cbf_regrid": 0.455665,
+                      "mean": 3.719662e-16,
+                      "mean_glo": -0.1980005,
+                      "rms": 0.4834196,
+                      "rms_glo": 0.4478494,
+                      "rmsc": 0.3047949,
+                      "rmsc_glo": 0.4998718,
+                      "stdv_pc": 1.441395,
+                      "stdv_pc_ratio_to_obs": 1.126895
+                    },
+                    "eof1": {
+                      "bias": -0.001667786,
+                      "bias_glo": -0.09820818,
+                      "cor": 0.9488642,
+                      "cor_glo": 0.8678051,
+                      "frac": 0.5048348,
+                      "mean": 3.719662e-16,
+                      "mean_glo": -0.1886964,
+                      "rms": 0.4970067,
+                      "rms_glo": 0.4541364,
+                      "rmsc": 0.3197994,
+                      "rmsc_glo": 0.5141886,
+                      "stdv_pc": 1.524994,
+                      "stdv_pc_ratio_to_obs": 1.192253
+                    }
+                  },
+                  "JJA": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": -0.003367143,
+                      "bias_glo": 0.2083335,
+                      "cor": 0.9241482,
+                      "cor_glo": 0.9078857,
+                      "frac": 0.2951453,
+                      "frac_cbf_regrid": 0.2664703,
+                      "mean": 2.824359e-16,
+                      "mean_glo": -0.2056333,
+                      "rms": 0.5830726,
+                      "rms_glo": 0.4411841,
+                      "rmsc": 0.3894914,
+                      "rmsc_glo": 0.4292186,
+                      "stdv_pc": 1.389706,
+                      "stdv_pc_ratio_to_obs": 0.9331306
+                    },
+                    "eof1": {
+                      "bias": -0.003149839,
+                      "bias_glo": 0.2166533,
+                      "cor": 0.8912003,
+                      "cor_glo": 0.8757222,
+                      "frac": 0.3039656,
+                      "mean": 1.679847e-16,
+                      "mean_glo": -0.1973135,
+                      "rms": 0.7041843,
+                      "rms_glo": 0.5027321,
+                      "rmsc": 0.4664756,
+                      "rmsc_glo": 0.4985535,
+                      "stdv_pc": 1.534926,
+                      "stdv_pc_ratio_to_obs": 1.03064
+                    }
+                  },
+                  "MAM": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.00138727,
+                      "bias_glo": -0.01169619,
+                      "cor": 0.9264358,
+                      "cor_glo": 0.871208,
+                      "frac": 0.2725036,
+                      "frac_cbf_regrid": 0.244548,
+                      "mean": -2.067505e-16,
+                      "mean_glo": 0.1269256,
+                      "rms": 0.4435854,
+                      "rms_glo": 0.3492357,
+                      "rmsc": 0.3835732,
+                      "rmsc_glo": 0.5075274,
+                      "stdv_pc": 0.9998873,
+                      "stdv_pc_ratio_to_obs": 0.8488818
+                    },
+                    "eof1": {
+                      "bias": 0.001149139,
+                      "bias_glo": -0.02840441,
+                      "cor": 0.9006484,
+                      "cor_glo": 0.8410641,
+                      "frac": 0.2793511,
+                      "mean": -2.847434e-16,
+                      "mean_glo": 0.1102173,
+                      "rms": 0.512841,
+                      "rms_glo": 0.3888076,
+                      "rmsc": 0.4457613,
+                      "rmsc_glo": 0.5638013,
+                      "stdv_pc": 1.099716,
+                      "stdv_pc_ratio_to_obs": 0.9336339
+                    }
+                  },
+                  "SON": {
+                    "attributes": {
+                      "best_matching_model_eofs__cor": 1,
+                      "best_matching_model_eofs__rms": 1,
+                      "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
+                      "period": "1900-2005"
+                    },
+                    "cbf": {
+                      "bias": 0.002311634,
+                      "bias_glo": -0.02588984,
+                      "cor": 0.9449423,
+                      "cor_glo": 0.903724,
+                      "frac": 0.3829946,
+                      "frac_cbf_regrid": 0.3437269,
+                      "mean": -5.436429e-16,
+                      "mean_glo": 0.1588923,
+                      "rms": 0.5115627,
+                      "rms_glo": 0.3707613,
+                      "rmsc": 0.3318364,
+                      "rmsc_glo": 0.4388074,
+                      "stdv_pc": 1.36987,
+                      "stdv_pc_ratio_to_obs": 1.162428
+                    },
+                    "eof1": {
+                      "bias": 0.002349421,
+                      "bias_glo": -0.01438738,
+                      "cor": 0.9198651,
+                      "cor_glo": 0.8815445,
+                      "frac": 0.3919017,
+                      "mean": -5.002623e-16,
+                      "mean_glo": 0.1703948,
+                      "rms": 0.5998998,
+                      "rms_glo": 0.410809,
+                      "rmsc": 0.4003372,
+                      "rmsc_glo": 0.486735,
+                      "stdv_pc": 1.475538,
+                      "stdv_pc_ratio_to_obs": 1.252095
+                    }
+                  },
                   "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.001762749,
-                    "bias_glo": -0.1075122,
-                    "cor": 0.95355,
-                    "cor_glo": 0.8750641,
-                    "frac": 0.5025455,
-                    "frac_cbf_regrid": 0.455665,
-                    "mean": 3.719662e-16,
-                    "mean_glo": -0.1980005,
-                    "rms": 0.4834196,
-                    "rms_glo": 0.4478494,
-                    "rmsc": 0.3047949,
-                    "rmsc_glo": 0.4998718,
-                    "stdv_pc": 1.441395,
-                    "stdv_pc_ratio_to_obs": 1.126895
-                  },
-                  "eof1": {
-                    "bias": -0.001667786,
-                    "bias_glo": -0.09820818,
-                    "cor": 0.9488642,
-                    "cor_glo": 0.8678051,
-                    "frac": 0.5048348,
-                    "mean": 3.719662e-16,
-                    "mean_glo": -0.1886964,
-                    "rms": 0.4970067,
-                    "rms_glo": 0.4541364,
-                    "rmsc": 0.3197994,
-                    "rmsc_glo": 0.5141886,
-                    "stdv_pc": 1.524994,
-                    "stdv_pc_ratio_to_obs": 1.192253
+                    "target_model_eofs": 1
                   }
-                },
-                "JJA": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": -0.003367143,
-                    "bias_glo": 0.2083335,
-                    "cor": 0.9241482,
-                    "cor_glo": 0.9078857,
-                    "frac": 0.2951453,
-                    "frac_cbf_regrid": 0.2664703,
-                    "mean": 2.824359e-16,
-                    "mean_glo": -0.2056333,
-                    "rms": 0.5830726,
-                    "rms_glo": 0.4411841,
-                    "rmsc": 0.3894914,
-                    "rmsc_glo": 0.4292186,
-                    "stdv_pc": 1.389706,
-                    "stdv_pc_ratio_to_obs": 0.9331306
-                  },
-                  "eof1": {
-                    "bias": -0.003149839,
-                    "bias_glo": 0.2166533,
-                    "cor": 0.8912003,
-                    "cor_glo": 0.8757222,
-                    "frac": 0.3039656,
-                    "mean": 1.679847e-16,
-                    "mean_glo": -0.1973135,
-                    "rms": 0.7041843,
-                    "rms_glo": 0.5027321,
-                    "rmsc": 0.4664756,
-                    "rmsc_glo": 0.4985535,
-                    "stdv_pc": 1.534926,
-                    "stdv_pc_ratio_to_obs": 1.03064
-                  }
-                },
-                "MAM": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.00138727,
-                    "bias_glo": -0.01169619,
-                    "cor": 0.9264358,
-                    "cor_glo": 0.871208,
-                    "frac": 0.2725036,
-                    "frac_cbf_regrid": 0.244548,
-                    "mean": -2.067505e-16,
-                    "mean_glo": 0.1269256,
-                    "rms": 0.4435854,
-                    "rms_glo": 0.3492357,
-                    "rmsc": 0.3835732,
-                    "rmsc_glo": 0.5075274,
-                    "stdv_pc": 0.9998873,
-                    "stdv_pc_ratio_to_obs": 0.8488818
-                  },
-                  "eof1": {
-                    "bias": 0.001149139,
-                    "bias_glo": -0.02840441,
-                    "cor": 0.9006484,
-                    "cor_glo": 0.8410641,
-                    "frac": 0.2793511,
-                    "mean": -2.847434e-16,
-                    "mean_glo": 0.1102173,
-                    "rms": 0.512841,
-                    "rms_glo": 0.3888076,
-                    "rmsc": 0.4457613,
-                    "rmsc_glo": 0.5638013,
-                    "stdv_pc": 1.099716,
-                    "stdv_pc_ratio_to_obs": 0.9336339
-                  }
-                },
-                "SON": {
-                  "attributes": {
-                    "best_matching_model_eofs__cor": 1,
-                    "best_matching_model_eofs__rms": 1,
-                    "best_matching_model_eofs__tcor_cbf_vs_eof_pc": 1,
-                    "period": "1900-2005"
-                  },
-                  "cbf": {
-                    "bias": 0.002311634,
-                    "bias_glo": -0.02588984,
-                    "cor": 0.9449423,
-                    "cor_glo": 0.903724,
-                    "frac": 0.3829946,
-                    "frac_cbf_regrid": 0.3437269,
-                    "mean": -5.436429e-16,
-                    "mean_glo": 0.1588923,
-                    "rms": 0.5115627,
-                    "rms_glo": 0.3707613,
-                    "rmsc": 0.3318364,
-                    "rmsc_glo": 0.4388074,
-                    "stdv_pc": 1.36987,
-                    "stdv_pc_ratio_to_obs": 1.162428
-                  },
-                  "eof1": {
-                    "bias": 0.002349421,
-                    "bias_glo": -0.01438738,
-                    "cor": 0.9198651,
-                    "cor_glo": 0.8815445,
-                    "frac": 0.3919017,
-                    "mean": -5.002623e-16,
-                    "mean_glo": 0.1703948,
-                    "rms": 0.5998998,
-                    "rms_glo": 0.410809,
-                    "rmsc": 0.4003372,
-                    "rmsc_glo": 0.486735,
-                    "stdv_pc": 1.475538,
-                    "stdv_pc_ratio_to_obs": 1.252095
-                  }
-                },
-                "attributes": {
-                  "target_model_eofs": 1
                 }
               }
             }

--- a/packages/climate-ref-pmp/tests/unit/test_variability_modes.py
+++ b/packages/climate-ref-pmp/tests/unit/test_variability_modes.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 
 import pytest
@@ -83,6 +84,40 @@ def test_pdo_metric(data_catalog, config, mocker, pdo_example_dir, provider):
     assert result.successful
     assert metric_bundle_path.exists()
     assert metric_bundle_path.is_file()
+
+
+def test_pdo_bundle_carries_kind_and_reference_source_id(
+    data_catalog, config, mocker, pdo_example_dir, provider
+):
+    # The Layer A contract: every PMP scalar keys its reference identity on
+    # ``reference_source_id`` and declares its role via ``kind`` (always ``model`` for these
+    # model-performance scores). Both must appear in the emitted metric bundle.
+    diagnostic = ExtratropicalModesOfVariability("PDO")
+    diagnostic.provider = provider
+
+    execution = next(
+        solve_executions(
+            data_catalog=data_catalog,
+            diagnostic=diagnostic,
+            provider=diagnostic.provider,
+        )
+    )
+    definition = execution.build_execution_definition(output_root=config.paths.scratch)
+
+    def mock_run_fn(cmd, *args, **kwargs):
+        shutil.copytree(pdo_example_dir, definition.output_directory)
+
+    mocker.patch.object(provider, "run", autospec=True, spec_set=True, side_effect=mock_run_fn)
+    result = diagnostic.run(definition)
+    assert result.successful
+
+    bundle = json.loads((definition.output_directory / result.metric_bundle_filename).read_text())
+    json_structure = bundle["DIMENSIONS"]["json_structure"]
+
+    assert "kind" in json_structure
+    assert "reference_source_id" in json_structure
+    assert "reference_datasets" not in json_structure
+    assert list(bundle["DIMENSIONS"]["kind"]) == ["model"]
 
 
 def test_mode_id_valid():


### PR DESCRIPTION
## Description

Unifies PMP reference identity onto the shared metric-value contract. ENSO previously keyed reference identity on `reference_datasets` while variability-modes and annual-cycle already used `reference_source_id`; this makes every PMP diagnostic key reference identity the same way and declare its role with the first-class `kind` (`model` for all PMP scalars, which are model-vs-reference scores).

Core mechanism: `iter_results` now lifts a `kind` bundle dimension into `ScalarMetricValue.kind`, so a producer can declare a value's role inline while it stays a first-class field with its own column. Bundles that do not carry a `kind` dimension keep the field default, so existing baselines and providers that predate the contract are unaffected.

Combined references (the STOP-gated step in the plan): ENSO scores some metrics jointly against two observation datasets (for example `HadISST_GPCP-Monthly-3-2`). These are kept as a single combined `reference_source_id` value rather than split, because the score is one value that depends on both references and the source data does not expose a per-reference decomposition; splitting is left as a possible follow-up.

The resulting ENSO `json_structure` is `["kind", "mip_id", "source_id", "member_id", "grid_label", "experiment_id", "metric", "reference_source_id"]`.

All 21 PMP regression baselines were re-minted (17 via replay for the key/kind change; the 4 ENSO cases execute-minted) and `Diagnostic.version` bumped accordingly. The coupling gate routes all 21 cases to `replay` with zero failures.

### Portable regression provenance

While re-minting, the committed baselines were found to embed machine-specific values in the CMEC command-line provenance: the source-checkout path of in-repo driver/param scripts (e.g. `/home/jared/.../packages/climate-ref-pmp/.../enso_driver.py`) and the host `OS` (`Darwin`/`Linux`). These were pre-existing on `main` and would drift between a macOS mint and a Linux CI execute. Regression capture now redacts both to portable `<SOURCE_DIR>` and `<OS>` placeholders (the source-path redaction is checkout-agnostic, so a Linux-minted and a macOS-re-derived baseline reduce to identical bytes). Applied symmetrically through the capture path, so replay reproduces the committed bundle.

Surfaced while minting locally (not fixed here): #773 — on macOS the `Application Support` space in the default software path breaks the PMP conda console-script shebang; the PMP conda-lock is also not resolved for `osx-arm64`, so local mints use `MAMBA_PLATFORM=osx-64` with a space-free `REF_SOFTWARE_ROOT`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metric outputs now expose a first-class `kind` field and include consistent “model” role metadata.
  * Diagnostics standardise reference identity via `reference_source_id` (including consistent handling when scoring is computed jointly).
  * Updated diagnostic result nesting to align with the new `kind`/`model` structure.
* **Bug Fixes**
  * Improved portability of generated committed baselines by redacting machine-specific paths and host OS details to reusable placeholders.
* **Tests**
  * Added/updated unit coverage for the new metric shape and backwards compatibility.
  * Refreshed regression fixtures/manifests and checksums to match the updated schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->