### PR TITLE
ci: bound ESMValTool memory use in integration tests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,3 +24,10 @@ runs:
       shell: bash
       run: |
         uv sync --all-extras --dev --locked
+    # Bound ESMValTool/Dask memory use so the slow suite fits the runner's memory limit.
+    # Mirrors the production HelmRelease providers.esmvaltool.config; see the config file
+    # for details. Merged under the per-run config the REF writes via `--config-dir`.
+    - name: Configure ESMValTool memory limits
+      shell: bash
+      run: |
+        echo "ESMVALTOOL_CONFIG_DIR=${GITHUB_ACTION_PATH}/esmvaltool-config" >> "$GITHUB_ENV"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,8 +25,6 @@ runs:
       run: |
         uv sync --all-extras --dev --locked
     # Bound ESMValTool/Dask memory use so the slow suite fits the runner's memory limit.
-    # Mirrors the production HelmRelease providers.esmvaltool.config; see the config file
-    # for details. Merged under the per-run config the REF writes via `--config-dir`.
     - name: Configure ESMValTool memory limits
       shell: bash
       run: |

--- a/.github/actions/setup/esmvaltool-config/config.yml
+++ b/.github/actions/setup/esmvaltool-config/config.yml
@@ -3,14 +3,7 @@
 # The self-hosted `arc-climate-ref` runners have a 16 GiB memory limit.
 # ESMValCore's stock defaults (max_parallel_tasks=2 and a local_distributed Dask
 # cluster of 4 workers x 4 GiB = up to 16 GiB) exhaust that budget,
-# and the slow test suite fails with an in-process MemoryError.
-#
-# These values mirror the production deployment
-# (home-infra HelmRelease providers.esmvaltool.config)
-# so CI and production share the same memory envelope.
-# They are merged *under* the per-run configuration that the REF writes via
-# `--config-dir` (which only sets output_dir/search_data/projects),
-# so those keys are left untouched.
+# resulting in a MemoryError.
 #
 # Delivered to ESMValCore via ESMVALTOOL_CONFIG_DIR, exported by the setup action.
 max_parallel_tasks: 1

--- a/.github/actions/setup/esmvaltool-config/config.yml
+++ b/.github/actions/setup/esmvaltool-config/config.yml
@@ -1,0 +1,25 @@
+# ESMValCore runtime configuration for CI.
+#
+# The self-hosted `arc-climate-ref` runners have a 16 GiB memory limit.
+# ESMValCore's stock defaults (max_parallel_tasks=2 and a local_distributed Dask
+# cluster of 4 workers x 4 GiB = up to 16 GiB) exhaust that budget,
+# and the slow test suite fails with an in-process MemoryError.
+#
+# These values mirror the production deployment
+# (home-infra HelmRelease providers.esmvaltool.config)
+# so CI and production share the same memory envelope.
+# They are merged *under* the per-run configuration that the REF writes via
+# `--config-dir` (which only sets output_dir/search_data/projects),
+# so those keys are left untouched.
+#
+# Delivered to ESMValCore via ESMVALTOOL_CONFIG_DIR, exported by the setup action.
+max_parallel_tasks: 1
+dask:
+  use: local_distributed
+  profiles:
+    local_distributed:
+      cluster:
+        type: distributed.LocalCluster
+        n_workers: 2
+        threads_per_worker: 2
+        memory_limit: 4GiB

--- a/changelog/783.trivial.md
+++ b/changelog/783.trivial.md
@@ -1,0 +1,1 @@
+Bounded ESMValTool and Dask memory use in the integration test suite so it runs within the self-hosted runners' memory limit.


### PR DESCRIPTION
## Description

The scheduled `CI Integration Tests` workflow runs the slow suite on the self-hosted `arc-climate-ref` runners, which have a 16 GiB memory limit. ESMValCore's stock defaults (`max_parallel_tasks=2` and a `local_distributed` Dask cluster of 4 workers x 4 GiB) can request up to 16 GiB on their own, leaving no headroom for the main process, so the suite failed with an in-process `MemoryError` (not a Kubernetes OOM-kill — the runner never exceeded ~1.6 GiB resident before the failing allocation).

This wires the same memory envelope we already run in production into CI, rather than into the runner image or deployment. A committed ESMValCore config (`.github/actions/setup/esmvaltool-config/config.yml`) mirrors the production HelmRelease `providers.esmvaltool.config` — `max_parallel_tasks: 1` and a 2 x 4 GiB `local_distributed` Dask cluster — and the setup composite action exports `ESMVALTOOL_CONFIG_DIR` to point at it. ESMValCore merges these values *under* the per-run configuration the REF writes via `--config-dir`, so per-run output paths and projects are untouched. All three integration jobs (`populate-cache`, `tests-slow`, `test-cases`) inherit the setting through the shared setup action, so no per-job YAML and no runner-image changes are required.

Verified locally against the pinned ESMValTool conda environment: with `ESMVALTOOL_CONFIG_DIR` set and a simulated per-run `--config-dir`, `CFG` resolves to `max_parallel_tasks=1` and the 2 x 4 GiB cluster while the per-run `output_dir` still wins the merge.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Bounded ESMValTool and Dask memory usage in the integration test suite to better fit the self-hosted runner limits, improving CI stability.

* **Chores**
  * Updated the setup workflow so later steps can automatically locate the ESMValTool configuration directory.
  * Added a CI runtime configuration profile that reduces parallelism and limits Dask memory to prevent memory-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->