### PR TITLE
test: skip cmip7 AFT solve integration test

### DIFF
--- a/changelog/794.trivial.md
+++ b/changelog/794.trivial.md
@@ -1,0 +1,1 @@
+Skip the ``test_solve_cmip7_aft`` integration test while ilamb reference fields are loaded without dask chunks, which makes the end-to-end solve run for hours on CI.

--- a/tests/integration/test_cmip7_aft.py
+++ b/tests/integration/test_cmip7_aft.py
@@ -52,11 +52,7 @@ def config_cmip7_aft(config):
     return config
 
 
-@pytest.mark.skip(
-    reason="ilamb opens reference fields without dask chunks, so executing the CMIP7 AFT "
-    "diagnostics materialises multi-GiB ocean fields and runs for hours on the CI runner, "
-    "hitting the executor per-task timeout. Re-enable once ilamb3 loads references lazily."
-)
+@pytest.mark.skip(reason="Re-enable once ilamb3 loads references lazily.")
 @pytest.mark.slow
 def test_solve_cmip7_aft(
     sample_data_dir,

--- a/tests/integration/test_cmip7_aft.py
+++ b/tests/integration/test_cmip7_aft.py
@@ -52,6 +52,11 @@ def config_cmip7_aft(config):
     return config
 
 
+@pytest.mark.skip(
+    reason="ilamb opens reference fields without dask chunks, so executing the CMIP7 AFT "
+    "diagnostics materialises multi-GiB ocean fields and runs for hours on the CI runner, "
+    "hitting the executor per-task timeout. Re-enable once ilamb3 loads references lazily."
+)
 @pytest.mark.slow
 def test_solve_cmip7_aft(
     sample_data_dir,


### PR DESCRIPTION
The `tests-slow` integration job has been hanging for hours on the self-hosted ARC runner. The cause is `test_solve_cmip7_aft`, which runs an end-to-end `solve --timeout 3600` that executes ilamb diagnostics through the `LocalExecutor`. ilamb opens reference fields without dask chunks, so a lazy surface slice still materialises the whole multi-GiB ocean field; under the runner's synchronous dask scheduler these executions run for hours and approach the executor's per-task timeout, leaving the job stuck until GitHub's 6h wall.

This skips the test until ilamb3 loads references lazily. The skip reason documents the root cause and the re-enable condition so it is not a silent disable. The separate memory fix (BLAS thread caps + 40Gi) already resolved the earlier OOM signature on this job.