### PR TITLE
fix: unblock integration CI test failures and runaway ESGF fetch

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -8,6 +8,10 @@
 # REF_SOFTWARE_ROOT: /data/cache/software
 #
 # The ~/.esgf directory is also configured to point to a shared cache location downloaded ESGF datasets.
+#
+# Fetching is deliberately confined to the `populate-cache` job, which is the single
+# writer to the shared RWX cache. The `tests-slow` and `test-cases` jobs run after it
+# and are pure readers, so they can fan out in parallel without racing on downloads.
 name: CI Integration Tests
 on:
   # Allow manual triggering of this workflow
@@ -23,12 +27,21 @@ on:
 permissions:
   contents: read
 
+# Serialise integration runs so only one `populate-cache` ever writes to the shared
+# ESGF/dataset cache at a time. Queue rather than cancel: a half-finished fetch is
+# the thing we're trying to avoid.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   populate-cache:
     if: github.repository == 'Climate-REF/climate-ref'
     runs-on: "arc-climate-ref"
     env:
       TQDM_DISABLE: "1"
+      # Diagnostics whose full-resolution ESGF data is too large to fetch/run within CI limits
+      REF_TEST_CASES_SKIP: "ilamb/thetao-woa2023-surface"
     defaults:
       run:
         shell: bash
@@ -45,6 +58,24 @@ jobs:
           uv run ref datasets fetch-data --registry ilamb-test
           uv run ref datasets fetch-data --registry obs4ref
           uv run ref providers setup
+      # Warm the shared intake-esgf cache (~/.esgf) here, as the single writer, so the
+      # downstream test jobs only ever read from it. Deliberately not --only-missing:
+      # test-case catalogs are committed, so that flag would skip every fetch and leave
+      # the cache cold. A plain fetch is cheap on a warm cache (intake-esgf serves hits
+      # from ~/.esgf without touching the network).
+      - name: Prefetch test-case data from ESGF
+        timeout-minutes: 90
+        run: |
+          uv run ref test-cases fetch || echo "Some fetches failed"
+      # intake-esgf downloads to `<filename><8 random chars>` (tempfile.mkstemp with
+      # prefix=<filename>) and only renames into place after verifying the hash, so a
+      # killed transfer leaves an orphan rather than a corrupt cache entry. Sweep those
+      # up. Runs even when the fetch fails -- that is exactly when orphans exist. The
+      # workflow concurrency group guarantees no other job is writing to the cache here.
+      - name: Prune orphaned ESGF download temp files
+        if: always()
+        run: |
+          find "$HOME/.esgf" -type f -name '*.nc????????' -print -delete || true
 
   tests-slow:
     if: github.repository == 'Climate-REF/climate-ref'
@@ -86,6 +117,13 @@ jobs:
     runs-on: "arc-climate-ref"
     env:
       TQDM_DISABLE: "1"
+      # Diagnostics whose full-resolution ESGF data is too large to fetch/run within CI limits
+      REF_TEST_CASES_SKIP: "ilamb/thetao-woa2023-surface"
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [example, esmvaltool, ilamb, pmp]
+    name: test-cases (${{ matrix.provider }})
     defaults:
       run:
         shell: bash
@@ -95,15 +133,18 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           python-version: "3.13"
+      # No fetch here: populate-cache has already warmed ~/.esgf, so every dataset
+      # resolves as a local cache hit. Each provider is an independent reader, which is
+      # why this can safely fan out.
       - name: Run test cases
+        timeout-minutes: 60
         run: |
           uv sync
-          uv run ref test-cases fetch || echo "Some fetches failed"
-          uv run pytest packages -m test_cases --slow -v -r a
+          uv run pytest packages/climate-ref-${{ matrix.provider }} -m test_cases --slow -v -r a
       - name: Upload test case outputs
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-case-outputs
+          name: test-case-outputs-${{ matrix.provider }}
           path: ~/.climate-ref/results/
           retention-days: 7

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -9,9 +9,7 @@
 #
 # The ~/.esgf directory is also configured to point to a shared cache location downloaded ESGF datasets.
 #
-# Fetching is deliberately confined to the `populate-cache` job, which is the single
-# writer to the shared RWX cache. The `tests-slow` and `test-cases` jobs run after it
-# and are pure readers, so they can fan out in parallel without racing on downloads.
+# Fetching is deliberately confined to the `populate-cache` job which should pre-cache the required data.
 name: CI Integration Tests
 on:
   # Allow manual triggering of this workflow
@@ -27,9 +25,8 @@ on:
 permissions:
   contents: read
 
-# Serialise integration runs so only one `populate-cache` ever writes to the shared
-# ESGF/dataset cache at a time. Queue rather than cancel: a half-finished fetch is
-# the thing we're trying to avoid.
+# Serialise integration runs so only one `populate-cache` ever writes to the shared ESGF/dataset cache at a time.
+# Queue rather than cancel the in-flight run
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -59,19 +56,11 @@ jobs:
           uv run ref datasets fetch-data --registry obs4ref
           uv run ref providers setup
       # Warm the shared intake-esgf cache (~/.esgf) here, as the single writer, so the
-      # downstream test jobs only ever read from it. Deliberately not --only-missing:
-      # test-case catalogs are committed, so that flag would skip every fetch and leave
-      # the cache cold. A plain fetch is cheap on a warm cache (intake-esgf serves hits
-      # from ~/.esgf without touching the network).
+      # downstream test jobs only ever read from it.
       - name: Prefetch test-case data from ESGF
         timeout-minutes: 90
         run: |
           uv run ref test-cases fetch || echo "Some fetches failed"
-      # intake-esgf downloads to `<filename><8 random chars>` (tempfile.mkstemp with
-      # prefix=<filename>) and only renames into place after verifying the hash, so a
-      # killed transfer leaves an orphan rather than a corrupt cache entry. Sweep those
-      # up. Runs even when the fetch fails -- that is exactly when orphans exist. The
-      # workflow concurrency group guarantees no other job is writing to the cache here.
       - name: Prune orphaned ESGF download temp files
         if: always()
         run: |
@@ -133,9 +122,6 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           python-version: "3.13"
-      # No fetch here: populate-cache has already warmed ~/.esgf, so every dataset
-      # resolves as a local cache hit. Each provider is an independent reader, which is
-      # why this can safely fan out.
       - name: Run test cases
         timeout-minutes: 60
         run: |

--- a/changelog/797.feature.md
+++ b/changelog/797.feature.md
@@ -4,6 +4,4 @@ that are excluded from both `ref test-cases fetch` and the per-provider no-drift
 This keeps diagnostics whose full-resolution ESGF input cannot be fetched within CI limits
 (for example `ilamb/thetao-woa2023-surface`, a 3D ocean field)
 from being downloaded or executed.
-ESGF fetching is now confined to the `populate-cache` CI job,
-which is the single writer to the shared dataset cache,
-so the test-case job only reads from that cache and can fan out per provider.
+ESGF fetching is now confined to the `populate-cache` CI job.

--- a/changelog/797.feature.md
+++ b/changelog/797.feature.md
@@ -1,0 +1,9 @@
+Added `REF_TEST_CASES_SKIP`,
+a comma-separated list of `diagnostic` slugs or `provider/diagnostic` pairs
+that are excluded from both `ref test-cases fetch` and the per-provider no-drift test.
+This keeps diagnostics whose full-resolution ESGF input cannot be fetched within CI limits
+(for example `ilamb/thetao-woa2023-surface`, a 3D ocean field)
+from being downloaded or executed.
+ESGF fetching is now confined to the `populate-cache` CI job,
+which is the single writer to the shared dataset cache,
+so the test-case job only reads from that cache and can fan out per provider.

--- a/changelog/797.fix.md
+++ b/changelog/797.fix.md
@@ -1,0 +1,9 @@
+Fixed three integration-test failures caused by the self-hosted runner's shared cache
+and stable output directory leaking into tests that assumed a clean, default environment.
+The provider `get_data_path` tests no longer assert the default `pooch` cache location
+when `REF_DATASET_CACHE_DIR` is set,
+the lazy-ingest idempotency tests now depend on the fixture that fetches the sample data
+rather than only the one that names its path,
+and per-test output directories now include the test's class
+so two identically-named tests in different classes no longer collide
+on a shared `REF_TEST_OUTPUT`.

--- a/changelog/797.fix.md
+++ b/changelog/797.fix.md
@@ -1,9 +1,2 @@
 Fixed three integration-test failures caused by the self-hosted runner's shared cache
 and stable output directory leaking into tests that assumed a clean, default environment.
-The provider `get_data_path` tests no longer assert the default `pooch` cache location
-when `REF_DATASET_CACHE_DIR` is set,
-the lazy-ingest idempotency tests now depend on the fixture that fetches the sample data
-rather than only the one that names its path,
-and per-test output directories now include the test's class
-so two identically-named tests in different classes no longer collide
-on a shared `REF_TEST_OUTPUT`.

--- a/packages/climate-ref-core/src/climate_ref_core/testing.py
+++ b/packages/climate-ref-core/src/climate_ref_core/testing.py
@@ -10,6 +10,7 @@ This module provides:
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -25,7 +26,6 @@ from climate_ref_core.datasets import (
     Selector,
     SourceDatasetType,
 )
-from climate_ref_core.diagnostics import ExecutionResult
 from climate_ref_core.esgf.base import ESGFRequest
 from climate_ref_core.metric_values.typing import SeriesMetricValue
 from climate_ref_core.output_files import ordered_replacements
@@ -37,8 +37,25 @@ from climate_ref_core.regression.manifest import Manifest
 if TYPE_CHECKING:
     from _pytest.mark.structures import ParameterSet
 
-    from climate_ref_core.diagnostics import Diagnostic
+    from climate_ref_core.diagnostics import Diagnostic, ExecutionResult
     from climate_ref_core.providers import DiagnosticProvider
+
+
+def excluded_test_case_diagnostics() -> set[str]:
+    """
+    Diagnostic identifiers to skip when fetching or running test cases.
+
+    Reads the ``REF_TEST_CASES_SKIP`` environment variable
+    as a comma-separated list of ``diagnostic`` slugs or ``provider/diagnostic`` pairs.
+    """
+    raw = os.environ.get("REF_TEST_CASES_SKIP", "")
+    return {token.strip() for token in raw.split(",") if token.strip()}
+
+
+def is_test_case_excluded(provider_slug: str, diagnostic_slug: str) -> bool:
+    """Return True if the diagnostic is excluded via ``REF_TEST_CASES_SKIP``."""
+    excluded = excluded_test_case_diagnostics()
+    return diagnostic_slug in excluded or f"{provider_slug}/{diagnostic_slug}" in excluded
 
 
 @frozen

--- a/packages/climate-ref-esmvaltool/tests/unit/test_provider.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_provider.py
@@ -26,8 +26,10 @@ def test_provider():
 class TestESMValToolProviderHooks:
     """Tests for ESMValToolProvider lifecycle hooks."""
 
-    def test_get_data_path(self):
+    def test_get_data_path(self, monkeypatch):
         """Test that get_data_path returns the pooch cache path."""
+        monkeypatch.delenv("REF_DATASET_CACHE_DIR", raising=False)
+
         data_path = provider.get_data_path()
         assert data_path is not None
         assert isinstance(data_path, Path)

--- a/packages/climate-ref-ilamb/tests/unit/test_provider.py
+++ b/packages/climate-ref-ilamb/tests/unit/test_provider.py
@@ -20,8 +20,10 @@ def test_provider():
 class TestILAMBProviderHooks:
     """Tests for ILAMBProvider lifecycle hooks."""
 
-    def test_get_data_path(self):
+    def test_get_data_path(self, monkeypatch):
         """Test that get_data_path returns the pooch cache path."""
+        monkeypatch.delenv("REF_DATASET_CACHE_DIR", raising=False)
+
         data_path = provider.get_data_path()
         assert data_path is not None
         assert isinstance(data_path, Path)

--- a/packages/climate-ref-pmp/tests/unit/test_provider.py
+++ b/packages/climate-ref-pmp/tests/unit/test_provider.py
@@ -16,8 +16,10 @@ def test_provider():
 class TestPMPProviderHooks:
     """Tests for PMPDiagnosticProvider lifecycle hooks."""
 
-    def test_get_data_path(self):
+    def test_get_data_path(self, monkeypatch):
         """Test that get_data_path returns the pooch cache path."""
+        monkeypatch.delenv("REF_DATASET_CACHE_DIR", raising=False)
+
         data_path = provider.get_data_path()
         assert data_path is not None
         assert isinstance(data_path, Path)

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/discovery.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/discovery.py
@@ -16,6 +16,7 @@ from climate_ref.cli.test_cases._app import app
 from climate_ref.cli.test_cases._catalog import _fetch_and_build_catalog
 from climate_ref.cli.test_cases._common import _validate_provider_in_registry, _validate_requested_filters
 from climate_ref_core.exceptions import DatasetResolutionError
+from climate_ref_core.testing import TestCasePaths, is_test_case_excluded
 
 if TYPE_CHECKING:
     from climate_ref_core.diagnostics import Diagnostic
@@ -63,7 +64,6 @@ def fetch_test_data(  # noqa: PLR0912, PLR0913, PLR0915
         ref test-cases fetch --only-missing    # Skip test cases with existing catalogs
     """
     from climate_ref.provider_registry import ProviderRegistry
-    from climate_ref_core.testing import TestCasePaths
 
     config = ctx.obj.config
     db = ctx.obj.database
@@ -86,6 +86,12 @@ def fetch_test_data(  # noqa: PLR0912, PLR0913, PLR0915
             if diagnostic and diag.slug != diagnostic:
                 continue
             if diag.test_data_spec is None:
+                continue
+            if is_test_case_excluded(provider_instance.slug, diag.slug):
+                logger.info(
+                    f"Skipping excluded test-case diagnostic {provider_instance.slug}/{diag.slug} "
+                    "(REF_TEST_CASES_SKIP)"
+                )
                 continue
             diagnostics_to_process.append(diag)
 

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -121,7 +121,7 @@ def test_data_dir() -> Path:
 
 
 @pytest.fixture(scope="session")
-def sample_data_dir(test_data_dir: Path) -> Path:
+def sample_data_dir(sample_data: None, test_data_dir: Path) -> Path:
     """Path to the sample data directory."""
     return test_data_dir / "sample-data"
 
@@ -238,7 +238,10 @@ def config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.Fixt
     """Per-test Config with isolated directories."""
     root_output_dir = Path(os.environ.get("REF_TEST_OUTPUT", tmp_path / "climate_ref"))
     dir_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
-    ref_config_dir = root_output_dir / request.module.__name__ / dir_name
+    # Include the class name so two identically-named tests in different classes don't
+    # collide on a shared REF_TEST_OUTPUT dir (request.node.name omits the class).
+    class_segment = request.cls.__name__ if request.cls is not None else ""
+    ref_config_dir = root_output_dir / request.module.__name__ / class_segment / dir_name
 
     software_path = Config.default().paths.software
 

--- a/packages/climate-ref/src/climate_ref/testing.py
+++ b/packages/climate-ref/src/climate_ref/testing.py
@@ -26,7 +26,12 @@ from climate_ref_core.env import env
 from climate_ref_core.exceptions import DatasetResolutionError, NoTestDataSpecError, TestCaseNotFoundError
 from climate_ref_core.providers import DiagnosticProvider
 from climate_ref_core.regression import Manifest
-from climate_ref_core.testing import TestCasePaths, collect_test_case_params, load_datasets_from_yaml
+from climate_ref_core.testing import (
+    TestCasePaths,
+    collect_test_case_params,
+    is_test_case_excluded,
+    load_datasets_from_yaml,
+)
 
 
 def _determine_test_directory() -> Path | None:
@@ -216,6 +221,12 @@ def create_no_drift_test(provider: DiagnosticProvider) -> Callable[..., None]:
         tmp_path: Path,
     ) -> None:
         """Execute the test case end-to-end and assert the committed bundle has not drifted."""
+        if is_test_case_excluded(diagnostic.provider.slug, diagnostic.slug):
+            pytest.skip(
+                f"Test-case diagnostic {diagnostic.provider.slug}/{diagnostic.slug} "
+                "excluded via REF_TEST_CASES_SKIP"
+            )
+
         diagnostic.provider.configure(config)
 
         paths = TestCasePaths.from_diagnostic(diagnostic, test_case_name)


### PR DESCRIPTION
## Description

This adds `REF_TEST_CASES_SKIP` (a comma-separated list of `diagnostic` slugs or `provider/diagnostic` pairs), honoured by both `ref test-cases fetch` and the per-provider no-drift test, so an oversized case is neither fetched nor executed. `ilamb/thetao-woa2023-surface` is excluded in CI.

It also restructures the workflow so fetching is confined to `populate-cache`, the single writer to the shared cache. `test-cases` becomes a pure reader and fans out per provider (4 jobs). A workflow concurrency group prevents two runs from writing the cache concurrently, a prune step sweeps orphaned download temp files (matching intake-esgf's `<filename><8 random chars>` shape), and the fetch is bounded by a timeout so a runaway download can't take the runner down again.


## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`