### PR TITLE
Translate an empty ESGF search into DatasetResolutionError

### DIFF
--- a/changelog/811.fix.md
+++ b/changelog/811.fix.md
@@ -1,0 +1,3 @@
+Handles an ESGF search that returns no results by raising `DatasetResolutionError`.
+This lets `ref test-cases fetch` log and skip a test case whose dataset has been de-indexed,
+instead of crashing the whole prefetch.

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
@@ -9,6 +9,9 @@ from typing import Any, Protocol, runtime_checkable
 
 import pandas as pd
 from intake_esgf import ESGFCatalog
+from intake_esgf.exceptions import NoSearchResults
+
+from climate_ref_core.exceptions import DatasetResolutionError
 
 
 @runtime_checkable
@@ -109,7 +112,14 @@ class IntakeESGFMixin:
         # so pin the legacy object-string behaviour for the intake-esgf interaction.
         with pd.option_context("future.infer_string", False):
             cat = ESGFCatalog()  # type: ignore[no-untyped-call]
-            cat.search(**facets)
+            # A dataset disappearing from the index must not crash the whole prefetch,
+            # so translate intake-esgf's NoSearchResults into the per-test-case error
+            # that callers already log and skip.
+            try:
+                cat.search(**facets)
+            except NoSearchResults:
+                msg = f"ESGF search returned no results for facets: {facets}"
+                raise DatasetResolutionError(msg) from None
 
             if self.remove_ensembles:
                 cat.remove_ensembles()

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
@@ -112,9 +112,6 @@ class IntakeESGFMixin:
         # so pin the legacy object-string behaviour for the intake-esgf interaction.
         with pd.option_context("future.infer_string", False):
             cat = ESGFCatalog()  # type: ignore[no-untyped-call]
-            # A dataset disappearing from the index must not crash the whole prefetch,
-            # so translate intake-esgf's NoSearchResults into the per-test-case error
-            # that callers already log and skip.
             try:
                 cat.search(**facets)
             except NoSearchResults:

--- a/packages/climate-ref-core/tests/unit/esgf/test_base.py
+++ b/packages/climate-ref-core/tests/unit/esgf/test_base.py
@@ -4,9 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from intake_esgf.exceptions import NoSearchResults
 
 from climate_ref_core.esgf import CMIP6Request, ESGFRequest
 from climate_ref_core.esgf.base import _deduplicate_datasets
+from climate_ref_core.exceptions import DatasetResolutionError
 
 
 class TestESGFRequestProtocol:
@@ -253,6 +255,24 @@ class TestIntakeESGFMixin:
 
         with patch("climate_ref_core.esgf.base.ESGFCatalog", return_value=mock_cat):
             with pytest.raises(ValueError, match="No datasets found"):
+                request.fetch_datasets()
+
+    def test_fetch_datasets_no_search_results(self):
+        """
+        Regression: a dataset that has been de-indexed from ESGF makes the search
+        raise NoSearchResults, which must surface as the per-test-case
+        DatasetResolutionError instead of crashing the whole prefetch.
+        """
+        request = CMIP6Request(
+            slug="test",
+            facets={"source_id": "C3S-GTO-ECV-9-0"},
+        )
+
+        mock_cat = MagicMock()
+        mock_cat.search.side_effect = NoSearchResults()
+
+        with patch("climate_ref_core.esgf.base.ESGFCatalog", return_value=mock_cat):
+            with pytest.raises(DatasetResolutionError, match="no results"):
                 request.fetch_datasets()
 
     def test_fetch_datasets_converts_tuples_to_lists(self):


### PR DESCRIPTION
## Description

Translates intake-esgf's `NoSearchResults` into `DatasetResolutionError` in `IntakeESGFMixin.fetch_datasets`. `ref test-cases fetch` already logs and skips a test case that raises `DatasetResolutionError`, so a single de-indexed dataset no longer crashes the whole prefetch.

This is the failure behind the red CI Integration Tests run on the #810 merge commit. The obs4MIPs `C3S-GTO-ECV-9-0` record (the toz reference for the ozone diagnostics) is currently missing from the `ESGF2-US-1.5-Catalog` index that CI queries, but it still exists on the CEDA index and in the sample-data registry. While the record is missing, the ozone test-case catalogs stop refreshing and the committed catalogs keep the downstream jobs working.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ESGF searches with no matching datasets now return a clear dataset resolution error.
  - Test-case prefetching can log and skip unavailable or de-indexed datasets instead of stopping the entire process.
  - Error messages now include the requested search criteria to make failed dataset lookups easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->