### PR TITLE
Enable the CEDA Solr index for ESGF searches

### DIFF
--- a/changelog/812.fix.md
+++ b/changelog/812.fix.md
@@ -1,0 +1,4 @@
+Enables the CEDA Solr index as an additional ESGF search index when fetching data.
+The obs4MIPs ozone reference C3S-GTO-ECV-9-0 is currently missing from the default
+ESGF2-US-1.5-Catalog index but is still served by CEDA,
+so this lets `ref test-cases fetch` and `scripts/fetch-esgf.py` resolve it again.

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/__init__.py
@@ -5,7 +5,7 @@ This module provides classes for searching and fetching datasets from ESGF
 (Earth System Grid Federation) and other data registries.
 """
 
-from climate_ref_core.esgf.base import ESGFRequest, IntakeESGFMixin
+from climate_ref_core.esgf.base import ESGFRequest, IntakeESGFMixin, enable_ceda_solr_index
 from climate_ref_core.esgf.cmip6 import CMIP6Request
 from climate_ref_core.esgf.cmip7 import CMIP7Request
 from climate_ref_core.esgf.fetcher import ESGFFetcher
@@ -20,4 +20,5 @@ __all__ = [
     "IntakeESGFMixin",
     "Obs4MIPsRequest",
     "RegistryRequest",
+    "enable_ceda_solr_index",
 ]

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/base.py
@@ -7,8 +7,21 @@ using the intake-esgf package.
 
 from typing import Any, Protocol, runtime_checkable
 
+import intake_esgf
 import pandas as pd
 from intake_esgf import ESGFCatalog
+
+
+def enable_ceda_solr_index() -> None:
+    """
+    Enable the CEDA Solr index as an additional ESGF search index.
+
+    The obs4MIPs record for C3S-GTO-ECV-9-0 (the ozone reference) is missing
+    from the default ESGF2-US-1.5-Catalog index but is still served by the
+    CEDA Solr index, so search that index as well.
+    Remove once the record returns to the 1.5 catalog.
+    """
+    intake_esgf.conf["solr_indices"]["esgf.ceda.ac.uk"] = True
 
 
 @runtime_checkable
@@ -107,6 +120,8 @@ class IntakeESGFMixin:
         # intake-esgf assigns Python lists into individual DataFrame cells, which only works for object dtype.
         # Pandas >= 3.0 defaults strings to the pyarrow-backed dtype, where that assignment raises,
         # so pin the legacy object-string behaviour for the intake-esgf interaction.
+        enable_ceda_solr_index()
+
         with pd.option_context("future.infer_string", False):
             cat = ESGFCatalog()  # type: ignore[no-untyped-call]
             cat.search(**facets)

--- a/packages/climate-ref-core/tests/unit/esgf/test_base.py
+++ b/packages/climate-ref-core/tests/unit/esgf/test_base.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import intake_esgf
 import pandas as pd
 import pytest
 
@@ -224,6 +225,31 @@ class TestIntakeESGFMixin:
             request.fetch_datasets()
 
         mock_cat.remove_ensembles.assert_called_once()
+
+    def test_fetch_datasets_enables_ceda_solr_index(self):
+        """
+        The CEDA Solr index must be enabled as a fallback while the ozone reference
+        C3S-GTO-ECV-9-0 is missing from the default ESGF2-US-1.5-Catalog index.
+        """
+        request = CMIP6Request(
+            slug="test",
+            facets={"source_id": "ACCESS-ESM1-5"},
+        )
+
+        mock_cat = MagicMock()
+        mock_cat.df = pd.DataFrame(
+            {
+                "key": ["ds1"],
+                "source_id": ["ACCESS-ESM1-5"],
+            }
+        )
+        mock_cat.to_path_dict.return_value = {"ds1": ["/path/to/file.nc"]}
+
+        intake_esgf.conf["solr_indices"]["esgf.ceda.ac.uk"] = False
+        with patch("climate_ref_core.esgf.base.ESGFCatalog", return_value=mock_cat):
+            request.fetch_datasets()
+
+        assert intake_esgf.conf["solr_indices"]["esgf.ceda.ac.uk"] is True
 
     def test_fetch_datasets_empty_result(self):
         """Test fetch_datasets raises error when no datasets found."""

--- a/scripts/fetch-esgf.py
+++ b/scripts/fetch-esgf.py
@@ -24,6 +24,8 @@ from intake_esgf.exceptions import (
 )
 from loguru import logger
 
+from climate_ref_core.esgf import enable_ceda_solr_index
+
 PathDict = dict[str, list[Path]]
 
 TRANSIENT_ERRORS = (DatasetLoadError, StalledDownload, GlobusTransferError)
@@ -630,4 +632,5 @@ def main(
 # joblib.Parallel(n_jobs=2)(joblib.delayed(run_request)(request) for request in requests)
 
 if __name__ == "__main__":
+    enable_ceda_solr_index()
     typer.run(main)


### PR DESCRIPTION
## Description

Enables the CEDA Solr index as an additional ESGF search index when fetching data.

- The obs4MIPs ozone reference `C3S-GTO-ECV-9-0` (used by all four esmvaltool ozone diagnostics) is missing from the default ESGF2-US-1.5-Catalog index, so `ref test-cases fetch` can no longer refresh the ozone test-case catalogs. The CEDA Solr index still serves the exact instance the committed catalogs reference (`v20231115`), so refreshed catalogs are unchanged.
- The enablement lives in a single helper, `enable_ceda_solr_index`, called from `IntakeESGFMixin.fetch_datasets` and `scripts/fetch-esgf.py`. This gives one place to delete once the record returns to the 1.5 catalog.

This complements #811, which lets the fetch log and skip a de-indexed case instead of crashing.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`