### PR TITLE
Fix the ILAMB lai-avh15c1 test case running the CI runner out of memory

### DIFF
--- a/changelog/818.fix.md
+++ b/changelog/818.fix.md
@@ -1,6 +1,6 @@
 Fixes the ILAMB `lai-avh15c1` test case running the CI runner out of memory and getting killed with no logs.
 
-- Coarsens the very fine AVHRR LAI reference one time block at a time instead of loading the whole ~0.05 degree cube into memory at once. Peak memory drops from roughly 390 GB to a few GB.
+- Coarsens the very fine AVHRR LAI reference one time block at a time instead of loading the whole ~0.05 degree cube into memory at once. The coarsening no longer dominates, so the case now peaks around 30 GB (ILAMB scoring the coarsened field) instead of roughly 390 GB.
 - Caches the coarsened reference to disk, keyed on the source data and target resolution, because every model comparison in a solve reuses the same coarsened field. The first execution computes it, later ones read the cached file. Set `REF_ILAMB_COARSEN_NO_CACHE` to disable.
 - Logs wall clock, CPU time, and peak memory after each test case in `ref test-cases run` and the per-provider drift tests, which is how the runaway case was identified.
 - Re-mints the `lai-avh15c1` baselines against the chunked coarsening, and the `gpp-fluxnet2015` baselines to adopt the CF `long_name` a newer ILAMB now sets on the region traces.

--- a/changelog/818.fix.md
+++ b/changelog/818.fix.md
@@ -1,6 +1,6 @@
 Fixes the ILAMB `lai-avh15c1` test case running the CI runner out of memory and getting killed with no logs.
 
-- Coarsens the very fine AVHRR LAI reference one time block at a time instead of loading the whole ~0.05 degree cube into memory at once. The coarsening no longer dominates, so the case now peaks around 30 GB (ILAMB scoring the coarsened field) instead of roughly 390 GB.
+- Coarsens the very fine AVHRR LAI reference one time block at a time instead of loading the whole ~0.05 degree cube into memory at once
 - Caches the coarsened reference to disk, keyed on the source data and target resolution, because every model comparison in a solve reuses the same coarsened field. The first execution computes it, later ones read the cached file. Set `REF_ILAMB_COARSEN_NO_CACHE` to disable.
-- Logs wall clock, CPU time, and peak memory after each test case in `ref test-cases run` and the per-provider drift tests, which is how the runaway case was identified.
+- Logs wall clock, CPU time, and peak memory after each test case in `ref test-cases run` and the per-provider drift tests.
 - Re-mints the `lai-avh15c1` baselines against the chunked coarsening, and the `gpp-fluxnet2015` baselines to adopt the CF `long_name` a newer ILAMB now sets on the region traces.

--- a/changelog/818.fix.md
+++ b/changelog/818.fix.md
@@ -1,0 +1,6 @@
+Fixes the ILAMB `lai-avh15c1` test case running the CI runner out of memory and getting killed with no logs.
+
+- Coarsens the very fine AVHRR LAI reference one time block at a time instead of loading the whole ~0.05 degree cube into memory at once. Peak memory drops from roughly 390 GB to a few GB.
+- Caches the coarsened reference to disk, keyed on the source data and target resolution, because every model comparison in a solve reuses the same coarsened field. The first execution computes it, later ones read the cached file. Set `REF_ILAMB_COARSEN_NO_CACHE` to disable.
+- Logs wall clock, CPU time, and peak memory after each test case in `ref test-cases run` and the per-provider drift tests, which is how the runaway case was identified.
+- Re-mints the `lai-avh15c1` baselines against the chunked coarsening, and the `gpp-fluxnet2015` baselines to adopt the CF `long_name` a newer ILAMB now sets on the region traces.

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/configure/ilamb.yaml
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/configure/ilamb.yaml
@@ -57,10 +57,8 @@ cSoil-HWSD2:
   variable_cmap: viridis
 
 lai-AVH15C1:
-  # This case needs a lot of memory. ILAMB scores the coarsened 0.5 degree reference over its
-  # full monthly record, which peaks around 30 GB per execution regardless of the coarsen cache.
-  # A cold cache adds a few GB more (about 34 GB) while it also coarsens the ~0.05 degree source.
-  # A runner or solve worker with less than roughly 40 GB will be killed on this diagnostic.
+  # This case needs a lot of memory.
+  # ILAMB scores the coarsened 0.5 degree reference over its full monthly record, which peaks around 30 GB per execution.
   version: 4
   sources:
     lai:

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/configure/ilamb.yaml
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/configure/ilamb.yaml
@@ -57,6 +57,10 @@ cSoil-HWSD2:
   variable_cmap: viridis
 
 lai-AVH15C1:
+  # This case needs a lot of memory. ILAMB scores the coarsened 0.5 degree reference over its
+  # full monthly record, which peaks around 30 GB per execution regardless of the coarsen cache.
+  # A cold cache adds a few GB more (about 34 GB) while it also coarsens the ~0.05 degree source.
+  # A runner or solve worker with less than roughly 40 GB will be killed on this diagnostic.
   version: 4
   sources:
     lai:

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/configure/ilamb.yaml
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/configure/ilamb.yaml
@@ -16,7 +16,7 @@ gpp-WECANN:
   variable_cmap: Greens
 
 gpp-FLUXNET2015:
-  version: 3
+  version: 4
   sources:
     # Referenced by exact registry key rather than ingested facets
     # this file's source_id is spelled three different ways (https://github.com/Climate-REF/climate-ref/issues/784)
@@ -57,7 +57,7 @@ cSoil-HWSD2:
   variable_cmap: viridis
 
 lai-AVH15C1:
-  version: 3
+  version: 4
   sources:
     lai:
       obs_source: obs4mips

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
@@ -1,3 +1,5 @@
+import hashlib
+import os
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -18,7 +20,7 @@ from loguru import logger
 
 from climate_ref_core.cmip6_to_cmip7 import get_dreq_entry
 from climate_ref_core.constraints import AddSupplementaryDataset, RequireFacets
-from climate_ref_core.dataset_registry import dataset_registry_manager
+from climate_ref_core.dataset_registry import dataset_registry_manager, resolve_cache_dir
 from climate_ref_core.datasets import ExecutionDatasetCollection, FacetFilter, SourceDatasetType
 from climate_ref_core.diagnostics import (
     DataRequirement,
@@ -92,7 +94,15 @@ class _CoarsenSpatial(ILAMBTransform):
     than any CMIP model, which makes ilamb3's regrid/scoring step intractable.
     This coarsens the field to a common target resolution, which ESM outputs are compared to.
     Fields already at or coarser than the target (the models) are left untouched.
+
+    The coarsened reference is the same for every model comparison in a solve, so the result
+    is cached to disk keyed on the source data and resolution. The first execution computes it,
+    later ones read the cached file. Set ``REF_ILAMB_COARSEN_NO_CACHE`` to disable the cache.
     """
+
+    # Bump when the coarsening algorithm changes so stale cache entries are ignored.
+    _CACHE_VERSION = 1
+    _CACHE_NAME = "ilamb-coarsened"
 
     def __init__(self, variable_id: str, resolution: float = 0.5):
         self.variable_id = variable_id
@@ -112,9 +122,110 @@ class _CoarsenSpatial(ILAMBTransform):
         if current >= self.resolution:
             # Already at or coarser than the target (e.g. model data); leave it lazy.
             return ds
-        # ``coarsen_dataset`` uses ``.where(..., drop=True)``, whose boolean indexer must be in memory
-        # The reference is dask-backed ( open_mfdataset), so materialise it first.
-        return coarsen_dataset(ds.compute(), self.variable_id, res=self.resolution)
+
+        cache_path = self._cache_path(ds)
+        if cache_path is not None and cache_path.exists():
+            logger.debug(f"Reusing cached coarsened reference {cache_path}")
+            return xr.open_dataset(cache_path).load()
+
+        coarse = self._coarsen(ds)
+        if cache_path is not None:
+            self._write_cache(coarse, cache_path)
+        return coarse
+
+    # Time steps coarsened per pass. One pass of the ~0.05 degree AVHRR LAI reference is
+    # about 12 * 3600 * 7200 * 8 bytes ~= 2.5 GB, well within a CI runner.
+    _TIME_CHUNK = 12
+
+    def _coarsen(self, ds: xr.Dataset) -> xr.Dataset:
+        """
+        Coarsen the fine reference without materialising the whole cube.
+
+        The reference is opened dask-backed and chunked over time (``open_mfdataset`` in ilamb3).
+        Coarsening the whole field at once needs the entire cube in memory
+        (the AVHRR LAI reference is ~0.05 degrees, roughly 100 GB as float64, and the
+        conservative weighting makes several copies of it).
+        ``coarsen_dataset`` also cannot run on a lazy field, because its nan-masking indexes with
+        a boolean array that must be concrete. So the field is coarsened one time block at a time,
+        materialising only that block, and the small coarse blocks are concatenated.
+        """
+        if "time" not in ds.dims:
+            # A single 2D slice is small enough to coarsen in one pass.
+            return coarsen_dataset(ds.compute(), self.variable_id, res=self.resolution)
+
+        ntime = ds.sizes["time"]
+        blocks = [
+            coarsen_dataset(
+                ds.isel(time=slice(start, start + self._TIME_CHUNK)).compute(),
+                self.variable_id,
+                res=self.resolution,
+            )
+            for start in range(0, ntime, self._TIME_CHUNK)
+        ]
+        if len(blocks) == 1:
+            return blocks[0]
+        # ``data_vars="minimal"`` concatenates only the time-varying field, so the time-invariant
+        # ``cell_measures`` is kept once rather than broadcast across every block.
+        return xr.concat(blocks, dim="time", data_vars="minimal", coords="minimal", compat="override")
+
+    def _cache_path(self, ds: xr.Dataset) -> Path | None:
+        if os.environ.get("REF_ILAMB_COARSEN_NO_CACHE"):
+            return None
+        fingerprint = self._source_fingerprint(ds)
+        if fingerprint is None:
+            return None
+        digest = hashlib.sha256(fingerprint.encode()).hexdigest()[:32]
+        return resolve_cache_dir(self._CACHE_NAME) / f"{self.variable_id}_{digest}.nc"
+
+    def _source_fingerprint(self, ds: xr.Dataset) -> str | None:
+        """
+        Build a stable identity for the source data behind a cached coarsening.
+
+        Prefers the on-disk source files (path, size, mtime) recorded in the dataset encoding.
+        Falls back to the grid and identifying attributes when no source path is available.
+        Returns ``None`` only when nothing stable can be derived, which skips the cache.
+        """
+        parts = [f"v{self._CACHE_VERSION}", self.variable_id, f"{self.resolution:g}"]
+
+        sources = set()
+        for candidate in (ds, ds.get(self.variable_id)):
+            source = getattr(candidate, "encoding", {}).get("source")
+            if isinstance(source, str):
+                sources.add(source)
+        if sources:
+            for source in sorted(sources):
+                try:
+                    stat = os.stat(source)
+                    parts.append(f"{source}:{stat.st_size}:{stat.st_mtime_ns}")
+                except OSError:
+                    parts.append(source)
+            return "|".join(parts)
+
+        # No source path (merged or in-memory dataset): fall back to grid + identity attrs.
+        try:
+            for dim in ("time", "lat", "lon"):
+                name = get_dim_name(ds, dim) if dim in ("lat", "lon") else dim
+                if name in ds.coords:
+                    values = np.asarray(ds[name].values)
+                    parts.append(f"{name}:{values.shape}:{values.dtype}")
+                    parts.append(hashlib.sha256(np.ascontiguousarray(values).tobytes()).hexdigest())
+        except Exception:  # pragma: no cover - defensive; skip caching if the grid is unreadable
+            return None
+        for attr in ("tracking_id", "source_id", "activity_id", "version", "variable_id"):
+            if attr in ds.attrs:
+                parts.append(f"{attr}={ds.attrs[attr]}")
+        return "|".join(parts)
+
+    def _write_cache(self, coarse: xr.Dataset, cache_path: Path) -> None:
+        """Write the coarsened reference atomically so concurrent executions never read a partial file."""
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = cache_path.with_name(f"{cache_path.stem}.{os.getpid()}.tmp{cache_path.suffix}")
+            coarse.to_netcdf(tmp_path)
+            os.replace(tmp_path, cache_path)
+            logger.debug(f"Cached coarsened reference {cache_path}")
+        except Exception as exc:  # pragma: no cover - a cache write failure must not fail the run
+            logger.warning(f"Could not cache coarsened reference {cache_path}: {exc}")
 
 
 ilamb3.transform.ALL_TRANSFORMS.setdefault("climate_ref_coarsen_spatial", _CoarsenSpatial)

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
@@ -133,8 +133,8 @@ class _CoarsenSpatial(ILAMBTransform):
             self._write_cache(coarse, cache_path)
         return coarse
 
-    # Time steps coarsened per pass. One pass of the ~0.05 degree AVHRR LAI reference is
-    # about 12 * 3600 * 7200 * 8 bytes ~= 2.5 GB, well within a CI runner.
+    # Time steps coarsened per pass.
+    # One pass of the ~0.05 degree AVHRR LAI reference is about 12 * 3600 * 7200 * 8 bytes ~= 2.5 GB.
     _TIME_CHUNK = 12
 
     def _coarsen(self, ds: xr.Dataset) -> xr.Dataset:
@@ -142,11 +142,10 @@ class _CoarsenSpatial(ILAMBTransform):
         Coarsen the fine reference without materialising the whole cube.
 
         The reference is opened dask-backed and chunked over time (``open_mfdataset`` in ilamb3).
-        Coarsening the whole field at once needs the entire cube in memory
-        (the AVHRR LAI reference is ~0.05 degrees, roughly 100 GB as float64, and the
-        conservative weighting makes several copies of it).
+
         ``coarsen_dataset`` also cannot run on a lazy field, because its nan-masking indexes with
-        a boolean array that must be concrete. So the field is coarsened one time block at a time,
+        a boolean array that must be concrete.
+        So the field is coarsened one time block at a time,
         materialising only that block, and the small coarse blocks are concatenated.
         """
         if "time" not in ds.dims:

--- a/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip6/manifest.json
+++ b/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip6/manifest.json
@@ -3,9 +3,9 @@
   "committed": {
     "diagnostic.json": "44c0de2ba1a41f05298ed3aeac8d52d895da8056f292f9f07cf2e80e7ebaf363",
     "output.json": "20a28ce451d250fce7e27df05118f2ae2aebf2284252e59e07fc4dc59b4b7f69",
-    "series.json": "bff8ba1f76563a179dec1f4065c81b66cb394ade736780d6d45f4eac606ef654"
+    "series.json": "3dd543990fcbeb15d9fcbd78102df3aa758812e206b774e1d591f326a9d4f64a"
   },
-  "diagnostic_version": 3,
+  "diagnostic_version": 4,
   "native": {
     "CanESM5.csv": {
       "sha256": "7c9c53ab8b43ef37864d05161d968510c7089f13cac8dca7383bf80597eace95",
@@ -72,8 +72,8 @@
       "size": 101108
     },
     "Reference.nc": {
-      "sha256": "8348afb5da6fb5a4e11de9d5939ed33fd5d0714b3ac76f5fc20a6bec33927545",
-      "size": 42254
+      "sha256": "fe5f757418a8b88c8cc76d0844673094ee5f2b17a2baaf91793d71a71bcf2bdd",
+      "size": 44884
     },
     "Reference_global_mean.png": {
       "sha256": "bc49127734e68b89016015186f5bf70df1ac037c5f00c5d79b2a3c50081a331e",
@@ -96,10 +96,10 @@
       "size": 8457
     },
     "series.json": {
-      "sha256": "c153e93511ca4e3f1813a4ec0c6202a3825d799e02478cbec06b7d7120cb3c78",
-      "size": 62572
+      "sha256": "0488eff61a31a69249bc8ea0d00a3084efeb316db47a175fbadf16448528c739",
+      "size": 62816
     }
   },
   "schema": 2,
-  "test_case_version": 4
+  "test_case_version": 5
 }

--- a/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip6/regression/series.json
+++ b/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip6/regression/series.json
@@ -1204,7 +1204,7 @@
   {
     "attributes": {
       "calendar": "standard",
-      "long_name": "trace_global",
+      "long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
       "standard_name": "gross_primary_productivity",
       "units": "g d-1 m-2"
     },
@@ -1506,7 +1506,7 @@
     ],
     "index_name": "time",
     "kind": "reference",
-    "value_long_name": "trace_global",
+    "value_long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
     "value_units": "g d-1 m-2",
     "values": [
       0.463951,
@@ -1802,7 +1802,7 @@
   {
     "attributes": {
       "calendar": "standard",
-      "long_name": "trace_tropical",
+      "long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
       "standard_name": "gross_primary_productivity",
       "units": "g d-1 m-2"
     },
@@ -2104,7 +2104,7 @@
     ],
     "index_name": "time",
     "kind": "reference",
-    "value_long_name": "trace_tropical",
+    "value_long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
     "value_units": "g d-1 m-2",
     "values": [
       null,

--- a/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip7/manifest.json
+++ b/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip7/manifest.json
@@ -3,9 +3,9 @@
   "committed": {
     "diagnostic.json": "44c0de2ba1a41f05298ed3aeac8d52d895da8056f292f9f07cf2e80e7ebaf363",
     "output.json": "20a28ce451d250fce7e27df05118f2ae2aebf2284252e59e07fc4dc59b4b7f69",
-    "series.json": "bff8ba1f76563a179dec1f4065c81b66cb394ade736780d6d45f4eac606ef654"
+    "series.json": "3dd543990fcbeb15d9fcbd78102df3aa758812e206b774e1d591f326a9d4f64a"
   },
-  "diagnostic_version": 3,
+  "diagnostic_version": 4,
   "native": {
     "CanESM5.csv": {
       "sha256": "7c9c53ab8b43ef37864d05161d968510c7089f13cac8dca7383bf80597eace95",
@@ -72,8 +72,8 @@
       "size": 101108
     },
     "Reference.nc": {
-      "sha256": "8348afb5da6fb5a4e11de9d5939ed33fd5d0714b3ac76f5fc20a6bec33927545",
-      "size": 42254
+      "sha256": "fe5f757418a8b88c8cc76d0844673094ee5f2b17a2baaf91793d71a71bcf2bdd",
+      "size": 44884
     },
     "Reference_global_mean.png": {
       "sha256": "bc49127734e68b89016015186f5bf70df1ac037c5f00c5d79b2a3c50081a331e",
@@ -96,10 +96,10 @@
       "size": 8457
     },
     "series.json": {
-      "sha256": "c153e93511ca4e3f1813a4ec0c6202a3825d799e02478cbec06b7d7120cb3c78",
-      "size": 62572
+      "sha256": "0488eff61a31a69249bc8ea0d00a3084efeb316db47a175fbadf16448528c739",
+      "size": 62816
     }
   },
   "schema": 2,
-  "test_case_version": 1
+  "test_case_version": 2
 }

--- a/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip7/regression/series.json
+++ b/packages/climate-ref-ilamb/tests/test-data/gpp-fluxnet2015/cmip7/regression/series.json
@@ -1204,7 +1204,7 @@
   {
     "attributes": {
       "calendar": "standard",
-      "long_name": "trace_global",
+      "long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
       "standard_name": "gross_primary_productivity",
       "units": "g d-1 m-2"
     },
@@ -1506,7 +1506,7 @@
     ],
     "index_name": "time",
     "kind": "reference",
-    "value_long_name": "trace_global",
+    "value_long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
     "value_units": "g d-1 m-2",
     "values": [
       0.463951,
@@ -1802,7 +1802,7 @@
   {
     "attributes": {
       "calendar": "standard",
-      "long_name": "trace_tropical",
+      "long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
       "standard_name": "gross_primary_productivity",
       "units": "g d-1 m-2"
     },
@@ -2104,7 +2104,7 @@
     ],
     "index_name": "time",
     "kind": "reference",
-    "value_long_name": "trace_tropical",
+    "value_long_name": "Carbon Mass Flux out of Atmosphere Due to Gross Primary Production on Land",
     "value_units": "g d-1 m-2",
     "values": [
       null,

--- a/packages/climate-ref-ilamb/tests/test-data/lai-avh15c1/cmip6/manifest.json
+++ b/packages/climate-ref-ilamb/tests/test-data/lai-avh15c1/cmip6/manifest.json
@@ -5,7 +5,7 @@
     "output.json": "5e41386ac359e7e512d7ebbea293df36510b8ad85b2791742ad4401758a7662d",
     "series.json": "5c0df2070dab819b2d2d426e32d923276894629ed6fef481823576e2ea5a35cf"
   },
-  "diagnostic_version": 3,
+  "diagnostic_version": 4,
   "native": {
     "CanESM5.csv": {
       "sha256": "9942fa193f6d5dbb5109ae4207e05736c73ae4f92d04a70ff0ec3ec0ade61eb0",
@@ -101,5 +101,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 5
+  "test_case_version": 6
 }

--- a/packages/climate-ref-ilamb/tests/test-data/lai-avh15c1/cmip7/manifest.json
+++ b/packages/climate-ref-ilamb/tests/test-data/lai-avh15c1/cmip7/manifest.json
@@ -5,7 +5,7 @@
     "output.json": "5e41386ac359e7e512d7ebbea293df36510b8ad85b2791742ad4401758a7662d",
     "series.json": "3c17019cb37bca34021378f0bab187bc211381ae4b91a948e3f1e11f41c699de"
   },
-  "diagnostic_version": 3,
+  "diagnostic_version": 4,
   "native": {
     "CanESM5.csv": {
       "sha256": "3001b6bb233b7230eaea33b9b7dfacd65f311c88fb514b9de02043f3aa7de6bc",
@@ -101,5 +101,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 3
+  "test_case_version": 4
 }

--- a/packages/climate-ref-ilamb/tests/unit/test_standard_helpers.py
+++ b/packages/climate-ref-ilamb/tests/unit/test_standard_helpers.py
@@ -14,6 +14,7 @@ from climate_ref_ilamb.standard import (
     _CoarsenSpatial,
     _RelationshipTimeTransform,
 )
+from ilamb3.dataset import coarsen_dataset
 
 
 class TestRelationshipTimeTransform:
@@ -101,6 +102,62 @@ class TestCoarsenSpatial:
         original_spacing = float(np.diff(ds["lat"].values).mean())
         coarsened_spacing = float(np.diff(result["lat"].values).mean())
         assert coarsened_spacing > original_spacing
+
+    def _timed_dataset(self, spacing: float = 0.1, extent: float = 2.0, ntime: int = 4) -> xr.Dataset:
+        lat = np.arange(0, extent, spacing)
+        lon = np.arange(0, extent, spacing)
+        time = pd.date_range("2000-01-01", periods=ntime, freq="MS")
+        rng = np.random.default_rng(0)
+        data = rng.random((ntime, len(lat), len(lon)))
+        return xr.Dataset(
+            {"tas": (("time", "lat", "lon"), data)},
+            coords={"time": time, "lat": lat, "lon": lon},
+        )
+
+    def test_streaming_matches_eager_coarsen(self):
+        # The chunked (streaming) coarsen must produce the same numbers as coarsening the
+        # whole materialised cube in one pass.
+        ds = self._timed_dataset()
+        expected = coarsen_dataset(ds.compute(), "tas", res=0.5)
+
+        transform = _CoarsenSpatial("tas", resolution=0.5)
+        result = transform._coarsen(ds)
+
+        xr.testing.assert_allclose(result["tas"], expected["tas"])
+
+    def test_result_is_cached_and_reused(self, tmp_path, monkeypatch):
+        # First call computes and writes the cache; a second call reads it back rather
+        # than recomputing. Proven by overwriting the cached file with a sentinel value.
+        monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))
+        monkeypatch.delenv("REF_ILAMB_COARSEN_NO_CACHE", raising=False)
+        ds = self._timed_dataset()
+        transform = _CoarsenSpatial("tas", resolution=0.5)
+
+        first = transform(ds)
+        cache_path = transform._cache_path(ds)
+        assert cache_path is not None
+        assert cache_path.exists()
+
+        with xr.open_dataset(cache_path) as cached:
+            sentinel = cached.load()
+        sentinel["tas"] = sentinel["tas"] * 0.0 + 42.0
+        sentinel.to_netcdf(cache_path)
+
+        second = transform(ds)
+        assert float(second["tas"].mean()) == 42.0
+        # The uncached compute is unchanged and still available.
+        assert not np.allclose(first["tas"].values, 42.0)
+
+    def test_cache_disabled_by_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))
+        monkeypatch.setenv("REF_ILAMB_COARSEN_NO_CACHE", "1")
+        ds = self._timed_dataset()
+        transform = _CoarsenSpatial("tas", resolution=0.5)
+
+        transform(ds)
+
+        assert transform._cache_path(ds) is None
+        assert not list(tmp_path.rglob("*.nc"))
 
 
 class TestCleanUnits:

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/run.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/run.py
@@ -36,6 +36,7 @@ from climate_ref.cli.test_cases._stages import (
     write_source_stamp,
 )
 from climate_ref.config import Config
+from climate_ref.testing import ResourceSnapshot, log_resource_usage
 from climate_ref_core.exceptions import (
     DatasetResolutionError,
     InvalidDiagnosticException,
@@ -423,6 +424,8 @@ def run_test_case(  # noqa: PLR0912, PLR0913, PLR0915
         )
 
     for diag, tc in test_cases_to_run:
+        case_id = f"{provider}/{diag.slug}/{tc.name}"
+        resources_before = ResourceSnapshot.capture()
         success = _run_single_test_case(
             config=config,
             console=console,
@@ -435,11 +438,12 @@ def run_test_case(  # noqa: PLR0912, PLR0913, PLR0915
             clean=clean,
             label=label,
         )
+        log_resource_usage(case_id, resources_before)
         if success:
             successes += 1
         else:
             failures += 1
-            failed_cases.append(f"{provider}/{diag.slug}/{tc.name}")
+            failed_cases.append(case_id)
 
     # Print summary
     console.print()

--- a/packages/climate-ref/src/climate_ref/testing.py
+++ b/packages/climate-ref/src/climate_ref/testing.py
@@ -10,9 +10,14 @@ This module provides:
   used by every provider's integration test module)
 """
 
+import os
+import resource
 import shutil
+import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import NamedTuple
 
 from attrs import define
 from loguru import logger
@@ -45,6 +50,66 @@ def _determine_test_directory() -> Path | None:
 TEST_DATA_DIR = _determine_test_directory()
 """Path to the centralised test data directory (for sample data)."""
 # SAMPLE_DATA_VERSION is imported from climate_ref to avoid circular imports
+
+
+def _maxrss_bytes(who: int) -> int:
+    """
+    Peak RSS high-water mark for ``who`` in bytes.
+
+    ``ru_maxrss`` is reported in kilobytes on Linux and in bytes on macOS.
+    """
+    peak = resource.getrusage(who).ru_maxrss
+    return peak if sys.platform == "darwin" else peak * 1024
+
+
+class ResourceSnapshot(NamedTuple):
+    """Point-in-time resource counters used to report per test case usage."""
+
+    wall: float
+    cpu: os.times_result
+    self_peak_rss: int
+    children_peak_rss: int
+
+    @classmethod
+    def capture(cls) -> "ResourceSnapshot":
+        """Capture the current wall clock, CPU, and peak RSS counters."""
+        return cls(
+            wall=time.monotonic(),
+            cpu=os.times(),
+            self_peak_rss=_maxrss_bytes(resource.RUSAGE_SELF),
+            children_peak_rss=_maxrss_bytes(resource.RUSAGE_CHILDREN),
+        )
+
+
+def log_resource_usage(case_id: str, start: ResourceSnapshot) -> None:
+    """
+    Log wall clock, CPU time, and peak memory for a completed test case.
+
+    The peak RSS values are process-lifetime high-water marks,
+    so they never decrease over a multi-case run.
+    A case that pushes a mark higher is flagged,
+    which identifies the memory-hungry case in a sequential run.
+    """
+    from climate_ref.cli._utils import format_size  # noqa: PLC0415
+
+    end = ResourceSnapshot.capture()
+    wall = end.wall - start.wall
+    self_cpu = (end.cpu.user - start.cpu.user) + (end.cpu.system - start.cpu.system)
+    children_cpu = (end.cpu.children_user - start.cpu.children_user) + (
+        end.cpu.children_system - start.cpu.children_system
+    )
+
+    def _mark(before: int, after: int) -> str:
+        note = " (raised by this case)" if after > before else ""
+        return f"{format_size(after)}{note}"
+
+    logger.info(
+        f"Resources for {case_id}: "
+        f"wall {wall:.1f}s, cpu {self_cpu + children_cpu:.1f}s "
+        f"(self {self_cpu:.1f}s, subprocesses {children_cpu:.1f}s), "
+        f"peak RSS self {_mark(start.self_peak_rss, end.self_peak_rss)}, "
+        f"subprocesses {_mark(start.children_peak_rss, end.children_peak_rss)}"
+    )
 
 
 def fetch_sample_data(force_cleanup: bool = False, symlink: bool = False) -> None:
@@ -240,7 +305,14 @@ def create_no_drift_test(provider: DiagnosticProvider) -> Callable[..., None]:
         if not paths.manifest.exists() or not paths.regression.exists():
             pytest.skip(f"No committed baseline for {diagnostic.slug}/{test_case_name}")
 
-        assert_test_case_no_drift(config, diagnostic, test_case_name, paths, tmp_path)
+        resources_before = ResourceSnapshot.capture()
+        try:
+            assert_test_case_no_drift(config, diagnostic, test_case_name, paths, tmp_path)
+        finally:
+            log_resource_usage(
+                f"{diagnostic.provider.slug}/{diagnostic.slug}/{test_case_name}",
+                resources_before,
+            )
 
     return test_run_test_cases
 

--- a/packages/climate-ref/tests/unit/cli/test_test_cases.py
+++ b/packages/climate-ref/tests/unit/cli/test_test_cases.py
@@ -788,6 +788,19 @@ class TestRunTestCaseCommand:
         # The slot holds the rebuilt committed bundle even when the baseline is untouched.
         assert (paths.output_slot("latest") / "regression" / "diagnostic.json").exists()
 
+    def test_run_reports_resource_usage(self, invoke_cli, mocker, tmp_path):
+        """Each executed test case logs wall clock, CPU time, and peak RSS."""
+        _setup_real_run(mocker, tmp_path, regression_files={})
+
+        result = invoke_cli(
+            ["test-cases", "run", "--provider", "example", "--diagnostic", "test-diag"],
+        )
+
+        assert result.exit_code == 0
+        assert "Resources for example/test-diag/default: wall " in result.stderr
+        assert "peak RSS self " in result.stderr
+        assert "subprocesses " in result.stderr
+
     def test_run_output_directory_logs_scratch_and_slot_semantics(self, invoke_cli, mocker, tmp_path):
         """--output-directory is explained as scratch output, not the only written location."""
         paths, _scratch, _regression, _runner = _setup_real_run(mocker, tmp_path, regression_files={})


### PR DESCRIPTION
## Description

The ILAMB test-cases job was killed on every run with no logs. Per-case resource logging on Gus traced it to `lai-avh15c1`, which peaked at about 390 GB of memory while the runner is capped at 40Gi. The AVHRR LAI reference is a ~0.05 degree global grid, and `_CoarsenSpatial` was loading the whole cube into memory before coarsening it, then making several full-cube copies.

- Coarsens the fine reference one time block at a time instead of materialising the whole field. `coarsen_dataset` cannot run lazily because its nan-masking indexes with a boolean array that must be concrete, so each block is computed in turn and the small coarse blocks are concatenated. The result is numerically identical to the old single-pass coarsening, so the committed bundle is unchanged and only the manifest version moves.
- Caches the coarsened reference to disk, keyed on the source data and target resolution. Every model comparison in a solve reuses the same coarsened field, so the first execution computes it and later ones read the file. Set `REF_ILAMB_COARSEN_NO_CACHE` to disable.
- Logs wall clock, CPU time, and peak memory after each test case in `ref test-cases run` and the per-provider drift tests. This is how the runaway case was found, and it will name any future one directly.
- Re-mints the `lai-avh15c1` baselines against the chunked coarsening, and the `gpp-fluxnet2015` baselines to adopt the CF `long_name` a newer ILAMB now sets on the region traces.

Verified on Gus with the exact CI command: `lai-avh15c1` now peaks at 29.7 GB (cmip6) and 30.4 GB (cmip7), the full ILAMB replay is 20 passed and 0 failed, and the coupling gate routes the four re-minted cases to `replay`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

### Diagnostics

- [x] I have reviewed the diff of any regression baselines and explained the changes in the description.
- [ ] Any test case routed to `execute` by `ref test-cases ci-gate` has been minted.
- [x] I have read the `ci-gate --json` output and confirmed no case is gated `fail`.
- [x] Any `Diagnostic.version` bump re-mints every baseline of the diagnostics sharing that class.
- [x] Reference datasets used by the changed diagnostics are present in the solve snapshot.