### PR TITLE
Upload only the wheels and sdists as release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,4 +45,5 @@ jobs:
           token: "${{ secrets.PAT }}"
           draft: true
           files: |
-            dist/*
+            dist/*.whl
+            dist/*.tar.gz

--- a/changelog/819.fix.md
+++ b/changelog/819.fix.md
@@ -1,0 +1,4 @@
+Fixed the GitHub release listing a stray `default.gitignore` alongside the wheels and sdists.
+`uv build` writes a `.gitignore` into the build output directory,
+and the release workflow's `dist/*` glob was uploading it as a release asset.
+The upload is now restricted to the built wheels and source distributions.


### PR DESCRIPTION
## Description

Restricts the release asset upload to `dist/*.whl` and `dist/*.tar.gz`. `uv build` drops a `dist/.gitignore` into the output directory, and the old `dist/*` glob swept it into the GitHub release as `default.gitignore`. This keeps that stray ignore file out of the release file list, so only the wheels and sdists ship.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
