### PR TITLE
Re-enable the cmip7_aft solve test with an exclude list

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -87,6 +87,8 @@ jobs:
       REF_TEST_OUTPUT: "test-outputs"
       PYTEST_ADDOPTS: "--slow"
       TQDM_DISABLE: "1"
+      # Diagnostics that are too heavy for CI, also excluded from the cmip7_aft solve
+      REF_TEST_CASES_SKIP: "ilamb/thetao-woa2023-surface"
     strategy:
       fail-fast: false
       matrix:

--- a/changelog/820.feature.md
+++ b/changelog/820.feature.md
@@ -1,0 +1,3 @@
+Added a `--exclude-diagnostic` option to `ref solve`.
+Diagnostics can be excluded by slug or by `provider/diagnostic` pair, matched exactly and case-insensitively.
+This uses the same token format as the `REF_TEST_CASES_SKIP` environment variable.

--- a/packages/climate-ref/src/climate_ref/cli/solve.py
+++ b/packages/climate-ref/src/climate_ref/cli/solve.py
@@ -92,6 +92,15 @@ def solve(  # noqa: PLR0913
             "Multiple values can be provided"
         ),
     ] = None,
+    exclude_diagnostic: Annotated[
+        list[str] | None,
+        typer.Option(
+            help="Excludes diagnostics by slug or provider/diagnostic pair. "
+            "Matching is exact and case-insensitive, unlike --diagnostic. "
+            "For example, --exclude-diagnostic ilamb/thetao-woa2023-surface. "
+            "Multiple values can be provided"
+        ),
+    ] = None,
     dataset_filter: Annotated[
         list[str] | None,
         typer.Option(
@@ -140,6 +149,7 @@ def solve(  # noqa: PLR0913
         diagnostic=diagnostic,
         provider=provider,
         dataset=parsed_dataset_filters,
+        exclude_diagnostic=exclude_diagnostic,
     )
 
     solve_required_executions(

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -372,6 +372,14 @@ class SolveFilterOptions:
     lists of allowed values.  Different facets are ANDed together; multiple
     values for the same facet are ORed.
     """
+    exclude_diagnostic: list[str] | None = None
+    """
+    Exclude diagnostics by slug or ``provider/diagnostic`` pair.
+
+    Matching is exact and case-insensitive, unlike the fuzzy include filters.
+    This uses the same token format as the ``REF_TEST_CASES_SKIP``
+    environment variable.
+    """
 
 
 def apply_dataset_filters(
@@ -454,6 +462,11 @@ def matches_filter(diagnostic: Diagnostic, filters: SolveFilterOptions | None) -
 
     if filters.diagnostic and not any([f.lower() in diagnostic_slug for f in filters.diagnostic]):
         return False
+
+    if filters.exclude_diagnostic:
+        excluded = {f.lower() for f in filters.exclude_diagnostic}
+        if {diagnostic_slug.lower(), f"{provider_slug}/{diagnostic_slug}".lower()} & excluded:
+            return False
 
     return True
 

--- a/packages/climate-ref/tests/unit/cli/test_solve.py
+++ b/packages/climate-ref/tests/unit/cli/test_solve.py
@@ -69,6 +69,21 @@ class TestSolve:
         assert kwargs["filters"].diagnostic == ["global-mean-timeseries"]
         assert kwargs["filters"].provider == ["esmvaltool", "ilamb"]
 
+    def test_solve_with_exclude_diagnostic(self, sample_data_dir, db, invoke_cli, mocker):
+        mock_solve = mocker.patch("climate_ref.solver.solve_required_executions")
+        invoke_cli(
+            [
+                "solve",
+                "--exclude-diagnostic",
+                "ilamb/thetao-woa2023-surface",
+                "--exclude-diagnostic",
+                "annual-cycle",
+            ]
+        )
+
+        _args, kwargs = mock_solve.call_args
+        assert kwargs["filters"].exclude_diagnostic == ["ilamb/thetao-woa2023-surface", "annual-cycle"]
+
     def test_solve_with_mixed_case_provider_filter(self, sample_data_dir, db, invoke_cli, mocker, config):
         from climate_ref.config import DiagnosticProviderConfig
 

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -1423,6 +1423,33 @@ class TestMatchesFilter:
             is False
         )
 
+    def test_exclude_by_slug(self, mock_diagnostic):
+        assert matches_filter(mock_diagnostic, SolveFilterOptions(exclude_diagnostic=["mock"])) is False
+
+    def test_exclude_by_provider_pair(self, mock_diagnostic):
+        assert (
+            matches_filter(mock_diagnostic, SolveFilterOptions(exclude_diagnostic=["mock_provider/mock"]))
+            is False
+        )
+
+    def test_exclude_is_case_insensitive(self, mock_diagnostic):
+        assert matches_filter(mock_diagnostic, SolveFilterOptions(exclude_diagnostic=["MOCK"])) is False
+
+    def test_exclude_is_exact_not_substring(self, mock_diagnostic):
+        # Unlike the include filters, a partial match must not exclude
+        assert matches_filter(mock_diagnostic, SolveFilterOptions(exclude_diagnostic=["ock"])) is True
+
+    def test_exclude_wrong_provider_pair(self, mock_diagnostic):
+        assert matches_filter(mock_diagnostic, SolveFilterOptions(exclude_diagnostic=["other/mock"])) is True
+
+    def test_exclude_wins_over_include(self, mock_diagnostic):
+        assert (
+            matches_filter(
+                mock_diagnostic, SolveFilterOptions(diagnostic=["mock"], exclude_diagnostic=["mock"])
+            )
+            is False
+        )
+
 
 def test_solve_metric_executions_empty_dataframe(mock_diagnostic, provider):
     """Test solve_executions when data catalog has an empty DataFrame for the source type."""

--- a/tests/integration/test_cmip7_aft.py
+++ b/tests/integration/test_cmip7_aft.py
@@ -7,6 +7,7 @@ import pytest
 from climate_ref.config import DiagnosticProviderConfig
 from climate_ref.database import Database
 from climate_ref.models import ExecutionGroup
+from climate_ref_core.testing import excluded_test_case_diagnostics
 
 
 def create_execution_dataframe(execution_groups: Iterable[ExecutionGroup]) -> pd.DataFrame:
@@ -52,7 +53,6 @@ def config_cmip7_aft(config):
     return config
 
 
-@pytest.mark.skip(reason="Re-enable once ilamb3 loads references lazily.")
 @pytest.mark.slow
 def test_solve_cmip7_aft(
     sample_data_dir,
@@ -89,10 +89,17 @@ def test_solve_cmip7_aft(
         ["datasets", "ingest", "--source-type", "pmp-climatology", str(sample_data_dir / "pmp-climatology")]
     )
 
+    # Diagnostics that are too heavy for CI are excluded via REF_TEST_CASES_SKIP
+    excluded = sorted(excluded_test_case_diagnostics())
+    exclude_args = [arg for token in excluded for arg in ("--exclude-diagnostic", token)]
+
     # Solve
     # This will also create conda environments for the diagnostic providers
     # We always log the std out and stderr from the command as it is useful for debugging
-    invoke_cli(["--verbose", "solve", "--one-per-diagnostic", "--timeout", f"{60 * 60}"], always_log=True)
+    invoke_cli(
+        ["--verbose", "solve", "--one-per-diagnostic", "--timeout", f"{60 * 60}", *exclude_args],
+        always_log=True,
+    )
 
     execution_groups = db.session.query(ExecutionGroup).all()
     df = create_execution_dataframe(execution_groups)
@@ -101,6 +108,16 @@ def test_solve_cmip7_aft(
 
     # Check that all 3 diagnostic providers have been used
     assert set(df["provider"].unique()) == {"esmvaltool", "ilamb", "pmp"}
+
+    # Check that the excluded diagnostics were not solved
+    # Exclusion tokens are either a diagnostic slug or a provider/diagnostic pair
+    excluded_set = set(excluded)
+    solved_excluded = {
+        f"{provider}/{diagnostic}"
+        for provider, diagnostic in zip(df["provider"], df["diagnostic"], strict=True)
+        if diagnostic in excluded_set or f"{provider}/{diagnostic}" in excluded_set
+    }
+    assert not solved_excluded, f"excluded diagnostics were solved: {solved_excluded}"
 
     # Check that some of the diagnostics have been marked successful
     assert df["successful"].any()


### PR DESCRIPTION
## Description

Re-enables `test_solve_cmip7_aft`, which was skipped waiting on lazy ilamb3 reference loading.
Instead of waiting, the heavy diagnostics are now excluded from the solve.

- Adds `--exclude-diagnostic` to `ref solve` and `exclude_diagnostic` to `SolveFilterOptions`.
- Exclusion tokens are a diagnostic slug or a `provider/diagnostic` pair, matched exactly and case-insensitively.
  The include filters stay fuzzy, but a fuzzy exclude would be a footgun ("enso" would silently drop `enso_tel` and `enso_proc`).
- The token format matches `REF_TEST_CASES_SKIP`, so the same list drives test cases and solves.
- The test passes every `REF_TEST_CASES_SKIP` entry to the solve and asserts none of them were solved.
- The `tests-slow` CI job now sets `REF_TEST_CASES_SKIP: "ilamb/thetao-woa2023-surface"`, matching the test-cases jobs.

The original skip reason was eager reference loading in general.
If another diagnostic turns out to drag heavy references in CI, the fix is another entry in the exclude list.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`