### PR TITLE
Retry retryable execution failures and guard the output copy

### DIFF
--- a/changelog/822.fix.md
+++ b/changelog/822.fix.md
@@ -1,0 +1,10 @@
+Re-dirties the execution group when a run fails retryably, so the failure is actually retried on the next solve.
+A group that reran because its input hash changed starts from `dirty=False`,
+so a retryable failure (timeout, OOM, worker death, missing log file) left the group clean
+and the next solve never picked it back up.
+The stale-execution reaper had the same gap and now marks the group dirty too.
+
+Guards the success-path output copy so a diagnostic that reports success but under-declares
+a referenced output file fails only its own execution.
+`copy_execution_outputs` raising `FileNotFoundError` used to abort the whole result-collection loop
+inside the local executor and strand every not-yet-processed execution in the batch at `successful=None`.

--- a/packages/climate-ref/src/climate_ref/executor/result_handling.py
+++ b/packages/climate-ref/src/climate_ref/executor/result_handling.py
@@ -425,15 +425,20 @@ def handle_execution_result(
             f"This is likely a system error (will be retried on next solve)."
         )
         execution.mark_failed()
-        # Missing log file suggests the process was killed before writing output,
-        # so leave dirty=True for retry
+        if update_dirty:
+            # Missing log file suggests the process was killed before writing output,
+            # so set dirty=True for retry rather than assuming it was already set.
+            execution.execution_group.dirty = True
         return
 
     if not result.successful or result.metric_bundle_filename is None:
         execution.mark_failed()
         if result.retryable:
             logger.error(f"{execution} failed due to a system error (will be retried on next solve)")
-            # Leave dirty=True so the execution is retried on next solve
+            if update_dirty:
+                # A hash-change rerun starts from dirty=False, so set it explicitly
+                # rather than assuming it was already True.
+                execution.execution_group.dirty = True
         else:
             logger.error(f"{execution} failed due to a diagnostic error")
             if update_dirty:

--- a/packages/climate-ref/src/climate_ref/executor/result_handling.py
+++ b/packages/climate-ref/src/climate_ref/executor/result_handling.py
@@ -451,12 +451,20 @@ def handle_execution_result(
     # (metric bundle, output bundle and the files it references, series)
     # from scratch to results.
     # Only the files in results are served by the API.
-    copy_execution_outputs(
-        config.paths.scratch,
-        config.paths.results,
-        execution.output_fragment,
-        result,
-    )
+    try:
+        copy_execution_outputs(
+            config.paths.scratch,
+            config.paths.results,
+            execution.output_fragment,
+            result,
+        )
+    except (FileNotFoundError, OSError):
+        # The diagnostic reported success but a file its bundle references is
+        # missing or unreadable. Fail this execution rather than aborting the
+        # whole result-collection loop.
+        logger.exception(f"Could not copy outputs for {execution}")
+        execution.mark_failed()
+        return
 
     # Ingest outputs and metrics into the database via the shared ingestion path
     cv = CV.load_from_file(config.paths.dimensions_cv)

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -569,8 +569,8 @@ def fail_stale_in_progress_executions(
     a worker is killed (OOM, walltime, segfault) before its result-handling
     callback ran, or when the join loop crashed mid-flight.
 
-    The execution group's ``dirty`` flag is left untouched so the existing
-    retry logic (``ExecutionGroup.should_run``) picks the work back up.
+    The execution group's ``dirty`` flag is set so the existing retry logic
+    (``ExecutionGroup.should_run``) picks the work back up on the next solve.
 
     Parameters
     ----------
@@ -600,6 +600,9 @@ def fail_stale_in_progress_executions(
                 f"{execution.execution_group_id}) as failed; created at {execution.created_at}"
             )
             execution.mark_failed()
+            # This reaper only runs from a real solve (never from reingest), so no
+            # update_dirty guard is needed here.
+            execution.execution_group.dirty = True
 
     if stale:
         logger.info(f"Marked {len(stale)} stale in-progress executions as failed")

--- a/packages/climate-ref/tests/integration/test_executor_failure_modes.py
+++ b/packages/climate-ref/tests/integration/test_executor_failure_modes.py
@@ -52,6 +52,7 @@ def _seed_execution(
     *,
     key: str,
     dataset_hash: str = "hash",
+    dirty: bool = True,
 ) -> tuple[int, int, Path]:
     """Persist a pending Execution and stage its scratch directory + log file.
 
@@ -78,7 +79,7 @@ def _seed_execution(
         execution_group = ExecutionGroup(
             key=key,
             diagnostic_id=diagnostic_row.id,
-            dirty=True,
+            dirty=dirty,
             selectors={},
         )
         db.session.add(execution_group)
@@ -166,6 +167,55 @@ class TestLocalExecutorFailureModes:
         assert execution.successful is False
         # System-level failure: leave dirty=True so the next solve picks it up.
         assert execution_group.dirty is True
+
+    def test_system_failure_on_clean_group_sets_dirty(
+        self, db_with_provider, config, provider, definition_factory, mock_diagnostic, thread_pool
+    ):
+        """A retryable failure on a previously-clean group (hash-change rerun) must re-dirty it.
+
+        Without this, a group that reruns because its input dataset hash changed
+        and then hits a retryable system failure would be stranded: the failed
+        execution's hash matches the group, and the group is clean, so
+        ``ExecutionGroup.should_run`` never picks it back up.
+        """
+        executor = _build_executor(db_with_provider, config, thread_pool)
+        definition = definition_factory(diagnostic=mock_diagnostic)
+        execution_id, eg_id, _ = _seed_execution(
+            db_with_provider, provider, "mock", config, key="system-failure-clean-group", dirty=False
+        )
+        future: Future = Future()
+        future.set_result(ExecutionResult.build_from_failure(definition, retryable=True))
+        _attach_future(executor, definition, execution_id, future)
+
+        executor.join(timeout=10)
+
+        with db_with_provider.session.begin():
+            execution = db_with_provider.session.get(Execution, execution_id)
+            execution_group = db_with_provider.session.get(ExecutionGroup, eg_id)
+        assert execution.successful is False
+        # A hash-change rerun starts from dirty=False; the retryable failure must set it.
+        assert execution_group.dirty is True
+
+    def test_diagnostic_logic_failure_on_clean_group_stays_clean(
+        self, db_with_provider, config, provider, definition_factory, mock_diagnostic, thread_pool
+    ):
+        """A non-retryable failure on a previously-clean group must not re-dirty it."""
+        executor = _build_executor(db_with_provider, config, thread_pool)
+        definition = definition_factory(diagnostic=mock_diagnostic)
+        execution_id, eg_id, _ = _seed_execution(
+            db_with_provider, provider, "mock", config, key="logic-failure-clean-group", dirty=False
+        )
+        future: Future = Future()
+        future.set_result(ExecutionResult.build_from_failure(definition, retryable=False))
+        _attach_future(executor, definition, execution_id, future)
+
+        executor.join(timeout=10)
+
+        with db_with_provider.session.begin():
+            execution = db_with_provider.session.get(Execution, execution_id)
+            execution_group = db_with_provider.session.get(ExecutionGroup, eg_id)
+        assert execution.successful is False
+        assert execution_group.dirty is False
 
     def test_per_task_timeout_marks_failed_retryable(
         self, db_with_provider, config, provider, definition_factory, mock_diagnostic, thread_pool

--- a/packages/climate-ref/tests/unit/executor/test_result_handling.py
+++ b/packages/climate-ref/tests/unit/executor/test_result_handling.py
@@ -278,6 +278,21 @@ def test_handle_execution_result_ingestion_failure_leaves_dirty(
     assert mock_execution_result.execution_group.dirty
 
 
+def test_handle_execution_result_system_failure_respects_update_dirty_false(
+    config, db, mock_execution_result, mock_definition
+):
+    """Reingest (update_dirty=False) must not touch the dirty flag on a retryable failure."""
+    mock_execution_result.execution_group.dirty = False
+    result = ExecutionResult(
+        definition=mock_definition, successful=False, metric_bundle_filename=None, retryable=True
+    )
+
+    handle_execution_result(config, db, mock_execution_result, result, update_dirty=False)
+
+    mock_execution_result.mark_failed.assert_called_once()
+    assert mock_execution_result.execution_group.dirty is False
+
+
 def test_handle_execution_result_missing_log_file_leaves_dirty(
     config, db, mock_execution_result, mocker, definition_factory
 ):

--- a/packages/climate-ref/tests/unit/executor/test_result_handling.py
+++ b/packages/climate-ref/tests/unit/executor/test_result_handling.py
@@ -312,15 +312,25 @@ def test_handle_execution_result_missing_log_file_leaves_dirty(
     assert mock_execution_result.execution_group.dirty
 
 
-def test_handle_execution_result_missing_file(config, db, mock_execution_result, mock_definition):
+def test_handle_execution_result_missing_output_marks_failed(
+    config, db, mock_execution_result, mock_definition
+):
+    """A successful result whose outputs cannot be copied must fail, not raise.
+
+    Raising here aborts the whole result-collection loop and strands every
+    sibling execution in the batch at successful=None, so the missing output is
+    treated as a per-execution failure instead.
+    """
     result = ExecutionResult(
         definition=mock_definition, successful=True, metric_bundle_filename=pathlib.Path("diagnostic.json")
     )
 
-    with pytest.raises(
-        FileNotFoundError, match=r"Could not find diagnostic.json in .*/scratch/output_fragment"
-    ):
-        handle_execution_result(config, db, mock_execution_result, result)
+    # The metric bundle is absent from scratch, so copy_execution_outputs really
+    # raises FileNotFoundError (not mocked).
+    handle_execution_result(config, db, mock_execution_result, result)
+
+    mock_execution_result.mark_failed.assert_called_once()
+    mock_execution_result.mark_successful.assert_not_called()
 
 
 @pytest.mark.parametrize("is_relative", [True, False])


### PR DESCRIPTION
## Description

- Re-dirty the execution group when a run fails retryably, so the failure is actually retried on the next solve. A group that reran because its input hash changed starts from `dirty=False`, so a retryable failure (timeout, OOM, worker death, missing log file) left it clean and the next solve never picked it back up. The stale-execution reaper had the same gap, so it now marks the group dirty too.
- Guard the success-path output copy so a diagnostic that reports success but under-declares a referenced output file fails only its own execution. `copy_execution_outputs` raising `FileNotFoundError` used to abort the whole result-collection loop inside `LocalExecutor.join` and strand every not-yet-processed execution in the batch at `successful=None`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
