### PR TITLE
Speed up database test setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,9 @@ jobs:
       - name: Test ref (unit)
         run: |
           echo "::group::test-ref-unit"
-          time make test-ref-unit
+          # Public GitHub hosted Linux runners have four vCPUs.
+          # Keep module scoped fixtures in one worker.
+          PYTEST_ADDOPTS="-n 4 --dist=loadscope" time make test-ref-unit
           echo "::endgroup::"
       - name: Test celery
         run: |
@@ -60,6 +62,7 @@ jobs:
         # the aggregate fail_under gate is enforced by codecov/project rather
         # than here -- both jobs upload to the same `core` flag.
         run: |
+          uv run coverage combine
           uv run coverage report --fail-under=0
           uv run coverage xml --fail-under=0
       - name: Upload coverage reports to Codecov with GitHub Action
@@ -97,6 +100,7 @@ jobs:
           echo "::endgroup::"
       - name: Coverage report
         run: |
+          uv run coverage combine
           uv run coverage report --fail-under=0
           uv run coverage xml --fail-under=0
       - name: Upload coverage reports to Codecov with GitHub Action
@@ -141,6 +145,7 @@ jobs:
         # fail_under gate is enforced by codecov/project (all jobs upload to the
         # same `providers` flag) rather than here.
         run: |
+          uv run coverage combine
           uv run coverage report --fail-under=0
           uv run coverage xml --fail-under=0
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ mypy:  ## run mypy on the codebase
 .PHONY: clean
 clean:  ## clean up temporary files
 	rm -rf site dist build
-	rm -rf .coverage
+	rm -rf .coverage .coverage.*
 
 .PHONY: clean-sample-data
 clean-sample-data:  ## clean up the sample data
@@ -64,7 +64,8 @@ ruff-fixes:  ## fix the code using ruff
 
 # Coverage is collected with `coverage run` (rather than pytest-cov) so that
 # module-level code in entry-point plugins is tracked from process start.
-# Each target appends to .coverage; the `test` target runs a final report.
+# Each target writes a parallel-compatible data file. The `test` target combines
+# the files before reporting.
 
 .PHONY: test-ref
 test-ref: test-ref-unit test-ref-integration  ## run all the climate-ref tests (unit + integration)
@@ -72,7 +73,7 @@ test-ref: test-ref-unit test-ref-integration  ## run all the climate-ref tests (
 .PHONY: test-ref-unit
 test-ref-unit:  ## run the climate-ref unit tests (+ src doctests)
 	uv run --package climate-ref \
-		coverage run --append --source=packages/climate-ref/src \
+		coverage run --source=packages/climate-ref/src \
 		-m pytest packages/climate-ref \
 		--ignore=packages/climate-ref/tests/integration \
 		-r a -v --doctest-modules --durations=0 --durations-min=1
@@ -80,35 +81,35 @@ test-ref-unit:  ## run the climate-ref unit tests (+ src doctests)
 .PHONY: test-ref-integration
 test-ref-integration:  ## run the climate-ref integration tests
 	uv run --package climate-ref \
-		coverage run --append --source=packages/climate-ref/src \
+		coverage run --source=packages/climate-ref/src \
 		-m pytest packages/climate-ref/tests/integration \
 		-r a -v --durations=20
 
 .PHONY: test-core
 test-core:  ## run the tests
 	uv run --package climate-ref-core \
-		coverage run --append --source=packages/climate-ref-core/src \
+		coverage run --source=packages/climate-ref-core/src \
 		-m pytest packages/climate-ref-core \
 		-r a -v --doctest-modules --durations=20
 
 .PHONY: test-celery
 test-celery:  ## run the tests
 	uv run --package climate-ref-celery \
-		coverage run --append --source=packages/climate-ref-celery/src \
+		coverage run --source=packages/climate-ref-celery/src \
 		-m pytest packages/climate-ref-celery \
 		-r a -v --doctest-modules --durations=20
 
 .PHONY: test-diagnostic-example
 test-diagnostic-example:  ## run the tests
 	uv run --package climate-ref-example \
-		coverage run --append --source=packages/climate-ref-example/src \
+		coverage run --source=packages/climate-ref-example/src \
 		-m pytest packages/climate-ref-example \
 		-r a -v --doctest-modules --durations=20
 
 .PHONY: test-diagnostic-esmvaltool
 test-diagnostic-esmvaltool:  ## run the tests
 	uv run --package climate-ref-esmvaltool \
-		coverage run --append --source=packages/climate-ref-esmvaltool/src \
+		coverage run --source=packages/climate-ref-esmvaltool/src \
 		-m pytest packages/climate-ref-esmvaltool \
 		-r a -v --doctest-modules --durations=20
 
@@ -116,14 +117,14 @@ test-diagnostic-esmvaltool:  ## run the tests
 test-diagnostic-ilamb:  ## run the tests
 	uv run ref datasets fetch-data --registry ilamb-test
 	uv run --package climate-ref-ilamb \
-		coverage run --append --source=packages/climate-ref-ilamb/src \
+		coverage run --source=packages/climate-ref-ilamb/src \
 		-m pytest packages/climate-ref-ilamb \
 		-r a -v --doctest-modules --durations=20
 
 .PHONY: test-diagnostic-pmp
 test-diagnostic-pmp:  ## run the tests
 	uv run --package climate-ref-pmp \
-		coverage run --append --source=packages/climate-ref-pmp/src \
+		coverage run --source=packages/climate-ref-pmp/src \
 		-m pytest packages/climate-ref-pmp \
 		-r a -v --doctest-modules --durations=20
 
@@ -151,6 +152,7 @@ regression-gate:  ## run the regression baseline coupling gate + replay (compare
 
 .PHONY: test
 test: clean test-core test-ref test-executors test-diagnostics test-integration ## run the tests
+	uv run coverage combine
 	uv run coverage report
 
 .PHONY: test-quick

--- a/changelog/825.improvement.md
+++ b/changelog/825.improvement.md
@@ -1,0 +1,1 @@
+Reduced the `climate-ref` unit test runtime by reusing migrated database templates while preserving isolated test databases and migration coverage.

--- a/changelog/825.improvement.md
+++ b/changelog/825.improvement.md
@@ -1,1 +1,1 @@
-Reduced the `climate-ref` unit test runtime by reusing migrated database templates and moving full archive solver regressions to the main slow test suite.
+Reduced the `climate-ref` unit test runtime by reusing migrated database templates, parallelising pull request checks, and moving full archive solver regressions to the main slow test suite.

--- a/changelog/825.improvement.md
+++ b/changelog/825.improvement.md
@@ -1,1 +1,1 @@
-Reduced the `climate-ref` unit test runtime by reusing migrated database templates while preserving isolated test databases and migration coverage.
+Reduced the `climate-ref` unit test runtime by reusing migrated database templates and moving full archive solver regressions to the main slow test suite.

--- a/docs/development.md
+++ b/docs/development.md
@@ -251,15 +251,16 @@ python scripts/generate_esgf_catalog.py \
 ### Solver regression tests
 
 Solver regression tests in `packages/climate-ref/tests/unit/test_solve_regression.py`
-run the solver against the ESGF parquet catalogs for each provider
+run the solver against the full ESGF parquet catalogs for each provider
 and compare the output against YAML baselines.
+They run in the slow test suite after merges to `main`.
 Any change to solver logic, constraints, or data requirements
 will produce a diff in these baseline files.
 
 To regenerate baselines after an intentional change:
 
 ```bash
-uv run pytest packages/climate-ref/tests/unit/test_solve_regression.py --force-regen
+uv run pytest packages/climate-ref/tests/unit/test_solve_regression.py --slow --force-regen
 ```
 
 ## Documentation

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -4,7 +4,6 @@ import shutil
 from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Any
-from urllib import parse as urlparse
 
 import cftime
 import pandas as pd
@@ -15,7 +14,7 @@ from pytest_regressions.data_regression import RegressionYamlDumper
 from yaml.representer import SafeRepresenter
 
 from climate_ref.config import Config
-from climate_ref.database import Database
+from climate_ref.database import Database, _get_sqlite_path
 from climate_ref.datasets.cmip6 import CMIP6DatasetAdapter
 from climate_ref.datasets.cmip6_parsers import parse_cmip6_complete, parse_cmip6_drs
 from climate_ref.datasets.cmip7 import CMIP7DatasetAdapter
@@ -51,18 +50,65 @@ for _cftime_cls in cftime._cftime.DATE_TYPES.values():
 
 
 def _clone_db(target_db_url: str, template_db_path: Path) -> None:
-    split_url = urlparse.urlsplit(target_db_url)
-    target_db_path = Path(split_url.path[1:])
-    target_db_path.parent.mkdir(parents=True)
+    target_db_path = _get_sqlite_path(target_db_url)
+    if target_db_path is None:
+        raise ValueError("Expected a file-based SQLite database URL")
 
+    target_db_path.parent.mkdir(parents=True)
     shutil.copy(template_db_path, target_db_path)
 
 
+@pytest.fixture(scope="session")
+def migrated_db_template(tmp_path_session: Path) -> Path:
+    """Build the current database schema once for reuse by isolated test databases."""
+    template_db_path = tmp_path_session / "climate_ref_template.db"
+    template_config = Config()
+    template_config.paths.dimensions_cv = Path(
+        str(importlib.resources.files("climate_ref_core.pycmec") / "cv_cmip7_aft.yaml")
+    )
+    template_config.db.database_url = f"sqlite:///{template_db_path}"
+
+    database = Database.from_config(template_config, run_migrations=True, skip_backup=True)
+    database.close()
+
+    return template_db_path
+
+
 @pytest.fixture
-def db(config) -> Generator[Database, None, None]:
-    database = Database.from_config(config, run_migrations=True)
+def db(config: Config, migrated_db_template: Path) -> Generator[Database, None, None]:
+    _clone_db(config.db.database_url, migrated_db_template)
+    database = Database.from_config(config, run_migrations=False)
     yield database
     database.close()
+
+
+@pytest.fixture
+def invoke_cli(
+    config: Config,
+    migrated_db_template: Path,
+    cli_runner: Callable[..., Any],
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[..., Any]:
+    """Invoke the CLI against an isolated database with the current schema."""
+    if not {"db", "db_seeded"}.intersection(request.fixturenames):
+        _clone_db(config.db.database_url, migrated_db_template)
+
+    def _invoke_cli(*args: Any, **kwargs: Any) -> Any:
+        def _skip_migrate(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        with monkeypatch.context() as migration_patch:
+            migration_patch.setattr(Database, "migrate", _skip_migrate)
+            return cli_runner(*args, **kwargs)
+
+    return _invoke_cli
+
+
+@pytest.fixture
+def invoke_cli_unmigrated(config: Config, cli_runner: Callable[..., Any]) -> Callable[..., Any]:
+    """Invoke the CLI without preparing its isolated database."""
+    return cli_runner
 
 
 @pytest.fixture(scope="session")
@@ -78,12 +124,17 @@ def prepare_db(cmip7_aft_cv):
 
 
 @pytest.fixture(scope="session")
-def db_seeded_template(tmp_path_session, cmip6_data_catalog, obs4mips_data_catalog, prepare_db) -> Path:
+def db_seeded_template(
+    tmp_path_session: Path,
+    migrated_db_template: Path,
+    cmip6_data_catalog,
+    obs4mips_data_catalog,
+    prepare_db,
+) -> Path:
     template_db_path = tmp_path_session / "climate_ref_template_seeded.db"
+    shutil.copy(migrated_db_template, template_db_path)
 
-    config = Config.default()  # This is just dummy config
     database = Database(f"sqlite:///{template_db_path}")
-    database.migrate(config)
 
     # Seed the CMIP6 sample datasets. ``register_dataset`` trusts callers to
     # have already validated the catalog, so do that here before iterating.
@@ -109,11 +160,10 @@ def db_seeded_template(tmp_path_session, cmip6_data_catalog, obs4mips_data_catal
 
 
 @pytest.fixture
-def db_seeded(db_seeded_template, config) -> Database:
-    # Copy the template database to the location in the config
+def db_seeded(db_seeded_template: Path, config: Config) -> Generator[Database, None, None]:
     _clone_db(config.db.database_url, db_seeded_template)
 
-    database = Database.from_config(config, run_migrations=True)
+    database = Database.from_config(config, run_migrations=False)
     yield database
     database.close()
 

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -54,7 +54,7 @@ def _clone_db(target_db_url: str, template_db_path: Path) -> None:
     if target_db_path is None:
         raise ValueError("Expected a file-based SQLite database URL")
 
-    target_db_path.parent.mkdir(parents=True)
+    target_db_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(template_db_path, target_db_path)
 
 

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -299,13 +299,8 @@ def config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.Fixt
 
 
 @pytest.fixture
-def invoke_cli(config: Config, monkeypatch: pytest.MonkeyPatch) -> Callable[..., Result]:
-    """Invoke the REF CLI and verify exit code.
-
-    Depends on the ``config`` fixture so every CLI invocation uses an
-    isolated configuration directory and database rather than the user's
-    real one.
-    """
+def cli_runner(monkeypatch: pytest.MonkeyPatch) -> Callable[..., Result]:
+    """Build a REF CLI runner with deterministic output and exit-code checks."""
     runner = CliRunner()
     # Older versions of typer mix stderr and stdout. This option has been removed in newer versions
     runner.mix_stderr = False  # type: ignore[attr-defined]
@@ -338,6 +333,12 @@ def invoke_cli(config: Config, monkeypatch: pytest.MonkeyPatch) -> Callable[...,
         return result
 
     return _invoke_cli
+
+
+@pytest.fixture
+def invoke_cli(config: Config, cli_runner: Callable[..., Result]) -> Callable[..., Result]:
+    """Invoke the REF CLI with an isolated configuration and database."""
+    return cli_runner
 
 
 class MockDiagnostic(Diagnostic):

--- a/packages/climate-ref/tests/unit/cli/test_db.py
+++ b/packages/climate-ref/tests/unit/cli/test_db.py
@@ -1,6 +1,12 @@
 import pytest
 
 
+@pytest.fixture
+def invoke_cli(invoke_cli_unmigrated):
+    """Keep migration commands on a database without a revision stamp."""
+    return invoke_cli_unmigrated
+
+
 def test_without_subcommand(invoke_cli):
     result = invoke_cli(["db"], expected_exit_code=2)
     assert "Missing command." in result.stderr

--- a/packages/climate-ref/tests/unit/cli/test_root.py
+++ b/packages/climate-ref/tests/unit/cli/test_root.py
@@ -228,3 +228,9 @@ def test_config_list_skips_database(invoke_cli, mocker):
 
     # Database should not have been created for config list
     mock_from_config.assert_not_called()
+
+
+def test_cli_database_access_migrates_fresh_database(invoke_cli_unmigrated):
+    result = invoke_cli_unmigrated(["datasets", "list"])
+
+    assert result.exit_code == 0

--- a/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
+++ b/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
@@ -12,8 +12,6 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pandas as pd
 
-from climate_ref.database import Database
-
 
 def _make_unfinalised_df(cfg, paths: list) -> pd.DataFrame:
     """Build a minimal unfinalised DataFrame matching adapter column expectations."""
@@ -81,141 +79,133 @@ class TestParserDispatch:
 class TestFinalisationEdgeCases:
     """Finalisation edge cases for FinaliseableDatasetAdapterMixin, parameterised over adapter types."""
 
-    def test_skips_rows_with_na_path(self, config, adapter_config):
+    def test_skips_rows_with_na_path(self, config, adapter_config, db):
         """Rows with NA path are skipped and remain unfinalised."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            df = _make_unfinalised_df(adapter_config, [pd.NA])
-            result = adapter.finalise_datasets(database, df)
-            assert not result["finalised"].any()
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, [pd.NA])
+        result = adapter.finalise_datasets(db, df)
+        assert not result["finalised"].any()
 
-    def test_skips_invalid_asset_response(self, config, adapter_config):
+    def test_skips_invalid_asset_response(self, config, adapter_config, db):
         """Rows returning INVALID_ASSET from the parser remain unfinalised."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            df = _make_unfinalised_df(adapter_config, ["/fake/path.nc"])
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/fake/path.nc"])
 
-            with patch(
-                adapter_config.complete_parser_patch_path,
-                return_value={"INVALID_ASSET": "/fake/path.nc", "TRACEBACK": "parse error"},
-            ):
-                result = adapter.finalise_datasets(database, df)
-            assert not result["finalised"].any()
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value={"INVALID_ASSET": "/fake/path.nc", "TRACEBACK": "parse error"},
+        ):
+            result = adapter.finalise_datasets(db, df)
+        assert not result["finalised"].any()
 
-    def test_noop_when_all_already_finalised(self, config, adapter_config):
+    def test_noop_when_all_already_finalised(self, config, adapter_config, db):
         """No parsing occurs when all rows are already finalised."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            df = _make_unfinalised_df(adapter_config, ["/some/path.nc"])
-            df["finalised"] = True
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/some/path.nc"])
+        df["finalised"] = True
 
-            with patch(adapter_config.complete_parser_patch_path) as mock_parse:
-                result = adapter.finalise_datasets(database, df)
-            mock_parse.assert_not_called()
-            assert result["finalised"].all()
+        with patch(adapter_config.complete_parser_patch_path) as mock_parse:
+            result = adapter.finalise_datasets(db, df)
+        mock_parse.assert_not_called()
+        assert result["finalised"].all()
 
-    def test_successful_parse_updates_metadata(self, config, adapter_config):
+    def test_successful_parse_updates_metadata(self, config, adapter_config, db):
         """Successful parsing updates metadata columns and marks finalised."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            df = _make_unfinalised_df(adapter_config, ["/fake/path.nc"])
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/fake/path.nc"])
 
-            with patch(
-                adapter_config.complete_parser_patch_path,
-                return_value=adapter_config.successful_parsed_result,
-            ):
-                result = adapter.finalise_datasets(database, df)
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value=adapter_config.successful_parsed_result,
+        ):
+            result = adapter.finalise_datasets(db, df)
 
-            assert result["finalised"].iloc[0]
-            for field, expected in adapter_config.metadata_checks.items():
-                assert result[field].iloc[0] == expected, (
-                    f"Expected {field}={expected!r}, got {result[field].iloc[0]!r}"
-                )
+        assert result["finalised"].iloc[0]
+        for field, expected in adapter_config.metadata_checks.items():
+            assert result[field].iloc[0] == expected, (
+                f"Expected {field}={expected!r}, got {result[field].iloc[0]!r}"
+            )
 
-    def test_partial_failure_finalises_only_successful_rows(self, config, adapter_config):
+    def test_partial_failure_finalises_only_successful_rows(self, config, adapter_config, db):
         """When one row fails and another succeeds, only the successful one is finalised."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            df = _make_unfinalised_df(adapter_config, ["/bad/path.nc", "/good/path.nc"])
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/bad/path.nc", "/good/path.nc"])
 
-            def side_effect(path, **_):
-                if "bad" in path:
-                    return {"INVALID_ASSET": path, "TRACEBACK": "corrupt file"}
-                return adapter_config.successful_parsed_result
+        def side_effect(path, **_):
+            if "bad" in path:
+                return {"INVALID_ASSET": path, "TRACEBACK": "corrupt file"}
+            return adapter_config.successful_parsed_result
 
-            with patch(
-                adapter_config.complete_parser_patch_path,
-                side_effect=side_effect,
-            ):
-                result = adapter.finalise_datasets(database, df)
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            side_effect=side_effect,
+        ):
+            result = adapter.finalise_datasets(db, df)
 
-            assert not result["finalised"].iloc[0]
-            assert result["finalised"].iloc[1]
-            field, expected = next(iter(adapter_config.metadata_checks.items()))
-            assert result[field].iloc[1] == expected
+        assert not result["finalised"].iloc[0]
+        assert result["finalised"].iloc[1]
+        field, expected = next(iter(adapter_config.metadata_checks.items()))
+        assert result[field].iloc[1] == expected
 
-    def test_parsed_none_values_are_not_written(self, config, adapter_config):
+    def test_parsed_none_values_are_not_written(self, config, adapter_config, db):
         """Parsed values that are None do not overwrite existing column values."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            df = _make_unfinalised_df(adapter_config, ["/fake/path.nc"])
-            df["source_id"] = "original-model"
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/fake/path.nc"])
+        df["source_id"] = "original-model"
 
-            check_field = next(iter(adapter_config.metadata_checks))
-            check_value = adapter_config.metadata_checks[check_field]
-            parsed = {
-                "source_id": None,
-                check_field: check_value,
-            }
-            with patch(
-                adapter_config.complete_parser_patch_path,
-                return_value=parsed,
-            ):
-                result = adapter.finalise_datasets(database, df)
+        check_field = next(iter(adapter_config.metadata_checks))
+        check_value = adapter_config.metadata_checks[check_field]
+        parsed = {
+            "source_id": None,
+            check_field: check_value,
+        }
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value=parsed,
+        ):
+            result = adapter.finalise_datasets(db, df)
 
-            # source_id should retain original value since parsed value was None
-            assert result["source_id"].iloc[0] == "original-model"
-            assert result[check_field].iloc[0] == check_value
+        # source_id should retain original value since parsed value was None
+        assert result["source_id"].iloc[0] == "original-model"
+        assert result[check_field].iloc[0] == check_value
 
 
 class TestPersistFinalisedMetadata:
     """_persist_finalised_metadata edge cases, parameterised over adapter types."""
 
-    def test_skips_when_no_matching_db_record(self, config, adapter_config):
+    def test_skips_when_no_matching_db_record(self, config, adapter_config, db):
         """Silently skips slugs that have no matching database record."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            data = {col: ["value"] for col in adapter.dataset_specific_metadata}
-            data.update({col: [pd.NA] for col in adapter.file_specific_metadata})
-            data["instance_id"] = [adapter_config.default_instance_id + ".nonexistent"]
-            data["finalised"] = [True]
-            data["path"] = ["/fake/path.nc"]
-            df = pd.DataFrame(data)
+        adapter = adapter_config.adapter_cls(config=config)
+        data = {col: ["value"] for col in adapter.dataset_specific_metadata}
+        data.update({col: [pd.NA] for col in adapter.file_specific_metadata})
+        data["instance_id"] = [adapter_config.default_instance_id + ".nonexistent"]
+        data["finalised"] = [True]
+        data["path"] = ["/fake/path.nc"]
+        df = pd.DataFrame(data)
 
-            # Should not raise
-            adapter._persist_finalised_metadata(database, df, df.index)
+        # Should not raise
+        adapter._persist_finalised_metadata(db, df, df.index)
 
-    def test_skips_duplicate_slugs(self, config, adapter_config):
+    def test_skips_duplicate_slugs(self, config, adapter_config, db):
         """Each slug is persisted only once even when multiple rows share it."""
-        with Database.from_config(config, run_migrations=True) as database:
-            adapter = adapter_config.adapter_cls(config=config)
-            slug = adapter_config.default_instance_id
-            data = {col: ["val", "val"] for col in adapter.dataset_specific_metadata}
-            data.update({col: [pd.NA, pd.NA] for col in adapter.file_specific_metadata})
-            data["instance_id"] = [slug, slug]
-            data["finalised"] = [True, True]
-            data["path"] = ["/fake/path1.nc", "/fake/path2.nc"]
-            df = pd.DataFrame(data)
+        adapter = adapter_config.adapter_cls(config=config)
+        slug = adapter_config.default_instance_id
+        data = {col: ["val", "val"] for col in adapter.dataset_specific_metadata}
+        data.update({col: [pd.NA, pd.NA] for col in adapter.file_specific_metadata})
+        data["instance_id"] = [slug, slug]
+        data["finalised"] = [True, True]
+        data["path"] = ["/fake/path1.nc", "/fake/path2.nc"]
+        df = pd.DataFrame(data)
 
-            # Make the query return None so we exercise the "no record" path
-            database.session.query = lambda *a, **kw: type(
-                "Q",
-                (),
-                {"filter": lambda *a, **kw: type("Q2", (), {"one_or_none": lambda: None})()},
-            )()
+        # Make the query return None so we exercise the "no record" path
+        db.session.query = lambda *a, **kw: type(
+            "Q",
+            (),
+            {"filter": lambda *a, **kw: type("Q2", (), {"one_or_none": lambda: None})()},
+        )()
 
-            # Should not raise and should only attempt once for the slug
-            adapter._persist_finalised_metadata(database, df, df.index)
+        # Should not raise and should only attempt once for the slug
+        adapter._persist_finalised_metadata(db, df, df.index)
 
     def test_na_values_do_not_overwrite_db_records(self, config, adapter_config):
         """pd.NA and np.nan values must not overwrite existing database fields.

--- a/packages/climate-ref/tests/unit/datasets/test_datasets.py
+++ b/packages/climate-ref/tests/unit/datasets/test_datasets.py
@@ -865,12 +865,12 @@ class TestIngestDatasets:
         with pytest.raises(ValueError, match=r"chunk_size must be >= 1"):
             ingest_datasets(adapter, data_dir, db, chunk_size=bad_size)
 
-    def test_chunk_size_rejected_when_adapter_lacks_iter(self, test_db, tmp_path):
+    def test_chunk_size_rejected_when_adapter_lacks_iter(self, monkeypatch, test_db, tmp_path):
         """``chunk_size`` requires the adapter to implement ``iter_local_datasets``."""
         adapter, db = test_db
         # The mock CMIP6 adapter inherits iter_local_datasets — drop it for this test.
         if hasattr(adapter, "iter_local_datasets"):
-            delattr(type(adapter), "iter_local_datasets")  # type: ignore[arg-type]
+            monkeypatch.delattr(type(adapter), "iter_local_datasets")
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         (data_dir / "test.nc").touch()

--- a/packages/climate-ref/tests/unit/datasets/test_datasets.py
+++ b/packages/climate-ref/tests/unit/datasets/test_datasets.py
@@ -4,8 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from climate_ref.config import Config
-from climate_ref.database import Database, ModelState
+from climate_ref.database import ModelState
 from climate_ref.datasets import IngestionStats, get_dataset_adapter, get_slug_column, ingest_datasets
 from climate_ref.datasets import base as base_module
 from climate_ref.datasets.base import DatasetAdapter, _is_na
@@ -122,8 +121,8 @@ def test_get_slug_column_resolves_for_every_source_type(source_type):
 
 
 @pytest.fixture
-def test_db(monkeypatch):
-    """Create an in-memory SQLite database for testing"""
+def test_db(monkeypatch, db):
+    """Create a CMIP6 adapter backed by the isolated test database."""
 
     # Keep validate_path from resolving to absolute paths
     monkeypatch.setattr(base_module, "validate_path", lambda p: p, raising=True)
@@ -145,11 +144,7 @@ def test_db(monkeypatch):
     # Bypass validation
     adapter.validate_data_catalog = lambda df, **kwargs: df
 
-    config = Config.default()
-    db = Database("sqlite:///:memory:")
-    db.migrate(config)
-    yield adapter, db
-    db.close()
+    return adapter, db
 
 
 def _mk_df(instance_id="CESM2.tas.gn", rows=None):
@@ -1072,7 +1067,7 @@ def _mk_df_with_na(instance_id="CESM2.tas.gn", rows=None, finalised=False, na_co
 
 
 @pytest.fixture
-def test_db_with_finalised(monkeypatch):
+def test_db_with_finalised(monkeypatch, db):
     """Like test_db but includes 'finalised' in the adapter metadata."""
     monkeypatch.setattr(base_module, "validate_path", lambda p: p, raising=True)
     adapter = CMIP6DatasetAdapter()
@@ -1098,11 +1093,7 @@ def test_db_with_finalised(monkeypatch):
     )
     adapter.validate_data_catalog = lambda df, **kwargs: df
 
-    config = Config.default()
-    db = Database("sqlite:///:memory:")
-    db.migrate(config)
-    yield adapter, db
-    db.close()
+    return adapter, db
 
 
 class TestReingestionWithNA:

--- a/packages/climate-ref/tests/unit/datasets/test_datasets.py
+++ b/packages/climate-ref/tests/unit/datasets/test_datasets.py
@@ -868,7 +868,8 @@ class TestIngestDatasets:
     def test_chunk_size_rejected_when_adapter_lacks_iter(self, monkeypatch, test_db, tmp_path):
         """``chunk_size`` requires the adapter to implement ``iter_local_datasets``."""
         adapter, db = test_db
-        # The mock CMIP6 adapter inherits iter_local_datasets — drop it for this test.
+        # CMIP6DatasetAdapter defines iter_local_datasets — drop it for this test.
+        # monkeypatch.delattr restores it afterwards so other tests keep the method.
         if hasattr(adapter, "iter_local_datasets"):
             monkeypatch.delattr(type(adapter), "iter_local_datasets")
         data_dir = tmp_path / "data"

--- a/packages/climate-ref/tests/unit/test_solve_helpers.py
+++ b/packages/climate-ref/tests/unit/test_solve_helpers.py
@@ -8,6 +8,7 @@ import json
 
 import pandas as pd
 import pytest
+from climate_ref_example import provider as example_provider
 
 from climate_ref.solve_helpers import (
     format_solve_results_json,
@@ -15,6 +16,7 @@ from climate_ref.solve_helpers import (
     generate_catalog,
     load_solve_catalog,
     solve_results_for_regression,
+    solve_to_results,
     write_catalog_parquet,
 )
 from climate_ref_core.datasets import SourceDatasetType
@@ -64,9 +66,9 @@ def obs4mips_generated_catalog(sample_data_dir):
 
 
 @pytest.fixture(scope="module")
-def example_solve_results(esgf_example_solve_results):
-    """Reuse the session-cached example-provider solve (see root conftest)."""
-    return esgf_example_solve_results
+def example_solve_results(esgf_data_catalog_trimmed):
+    """Solve a representative ESGF catalog for output contract tests."""
+    return solve_to_results(esgf_data_catalog_trimmed, providers=[example_provider])
 
 
 class TestGenerateCatalog:

--- a/packages/climate-ref/tests/unit/test_solve_regression.py
+++ b/packages/climate-ref/tests/unit/test_solve_regression.py
@@ -19,6 +19,8 @@ from climate_ref_example import provider as example_provider
 
 from climate_ref.solve_helpers import solve_results_for_regression
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.fixture(scope="module")
 def example_results(esgf_example_solve_results):

--- a/packages/climate-ref/tests/unit/test_testing.py
+++ b/packages/climate-ref/tests/unit/test_testing.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+from climate_ref.database import Database, MigrationState
 from climate_ref.testing import (
     TestCaseRunner,
     assert_test_case_no_drift,
@@ -24,6 +25,17 @@ from climate_ref_core.testing import (
     TestCasePaths,
     TestDataSpecification,
 )
+
+
+def test_invoke_cli_uses_migrated_database_template(config, invoke_cli):
+    original_migrate = Database.migrate
+
+    result = invoke_cli(["datasets", "list"])
+
+    assert result.exit_code == 0
+    assert Database.migrate is original_migrate
+    with Database.from_config(config, run_migrations=False) as database:
+        assert database.migration_status(config)["state"] is MigrationState.UP_TO_DATE
 
 
 class TestTestCasePathsFromDiagnostic:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ climate-ref-pmp = { workspace = true }
 [tool.coverage.run]
 source = ["packages"]
 branch = true
+parallel = true
+patch = ["subprocess"]
 
 [tool.coverage.report]
 fail_under = 70


### PR DESCRIPTION
## Description

Reuses a session scoped migrated SQLite template across isolated test databases. This avoids repeated Alembic migrations while keeping dedicated coverage for fresh database migrations.

Moves the full ESGF solver regression to the main slow suite. Pull request CI retains fast solver output-contract coverage against a representative catalog.

Runs `test-ref-unit` in four xdist workers on public GitHub hosted Linux runners. Coverage records each worker and subprocess, then combines their data before reporting.

Matched clean worktrees showed the template change reduced `test-ref-unit` from 293.53 to 164.27 seconds. The slow-regression split further reduced the current branch from 181.16 to 136.31 seconds locally. Four local workers completed the current no-slow unit suite in 59.06 seconds.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI database handling to ensure a migrated database template is used for database access.
  * Strengthened test database initialisation so migrations aren’t repeatedly re-run unnecessarily.
* **Performance**
  * Reduced unit test runtime by reusing migrated database templates and running checks in parallel.
  * Moved full solver regression coverage into the slower suite.
* **CI**
  * Improved parallel test execution and coverage reporting by combining coverage results before generating reports.
  * Expanded coverage cleanup to remove all related coverage artefacts.
* **Documentation**
  * Updated guidance for solver regression tests and baseline regeneration commands.
* **Tests**
  * Refined fixtures and added/updated tests covering migrated database behaviour and solver test runtime classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->