### PR TITLE
fix(esmvaltool): make sea-ice-sensitivity pass over the full CMIP6 archive

### DIFF
--- a/changelog/827.fix.md
+++ b/changelog/827.fix.md
@@ -1,0 +1,8 @@
+Fixed `esmvaltool/sea-ice-sensitivity` failing over the full CMIP6 archive.
+The diagnostic script expects one ensemble member per model, but every ingested
+member was fed into its single execution, tripping
+`None or too many matching files found for siconc`.
+A new `SelectFirstMember` constraint now keeps one member per model
+(the lowest CMIP index, e.g. `r1i1p1f1`) for both the CMIP6 and CMIP7 requirements.
+The `CAS-ESM2-0` grey-list entry was also broadened from a single member to
+model-wide, since its curvilinear siconc grid fails the CMOR check for every member.

--- a/default_ignore_datasets.yaml
+++ b/default_ignore_datasets.yaml
@@ -22,12 +22,9 @@ esmvaltool:
   sea-ice-sensitivity:
       cmip6:
         - experiment_id: historical
-          grid_label: gn
-          member_id: r1i1p1f1
           source_id: CAS-ESM2-0
           table_id: SImon
           variable_id: siconc
-          version: v20201225
         - experiment_id: historical
           source_id: BCC-ESM1
           table_id: SImon

--- a/packages/climate-ref-core/src/climate_ref_core/constraints.py
+++ b/packages/climate-ref-core/src/climate_ref_core/constraints.py
@@ -2,6 +2,7 @@
 Dataset selection constraints
 """
 
+import re
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import total_ordering
@@ -632,3 +633,61 @@ class AddParentDataset:
             },
         }
         return cls(parent_facet_map=parent_facet_options[source_type])
+
+
+_MEMBER_RE = re.compile(r"r(\d+)i(\d+)p(\d+)f(\d+)")
+
+
+def _member_sort_key(member: str) -> tuple[int, tuple[int, ...] | str]:
+    """
+    Sort key that orders CMIP ensemble members numerically.
+
+    Members matching ``r<r>i<i>p<p>f<f>`` sort first, ordered by their numeric
+    (realization, initialization, physics, forcing) indices, so ``r1i1p1f1`` precedes
+    both ``r2i1p1f1`` and ``r10i1p1f1``. Members that do not match sort afterwards by
+    their raw string, keeping the ordering deterministic.
+    """
+    match = _MEMBER_RE.fullmatch(str(member))
+    if match:
+        return (0, tuple(int(value) for value in match.groups()))
+    return (1, str(member))
+
+
+@frozen
+class SelectFirstMember:
+    """
+    Keep a single ensemble member per group.
+
+    Within each group defined by ``group_by``, only the datasets belonging to a single
+    ensemble member are retained: the member with the lowest CMIP indices (``r1i1p1f1``
+    when present, see :func:`_member_sort_key`).
+
+    Some diagnostic scripts expect exactly one member per model and error when given
+    several (e.g. ``None or too many matching files``). The REF otherwise passes every
+    ingested member of a model into a single execution, so this constraint reduces each
+    model to one representative member.
+    """
+
+    member_facet: str = "member_id"
+    """The facet identifying the ensemble member (``member_id`` for CMIP6, ``variant_label`` for CMIP7)."""
+
+    group_by: tuple[str, ...] = field(converter=_to_tuple, default=("source_id",))
+    """The facets defining each model within which a single member is kept."""
+
+    def apply(self, group: pd.DataFrame, data_catalog: pd.DataFrame) -> pd.DataFrame:
+        """
+        Keep only the first ensemble member within each group.
+        """
+        if group.empty or self.member_facet not in group.columns:
+            return group
+
+        keep = pd.Series(False, index=group.index)
+        for _, subgroup in group.groupby(list(self.group_by)):
+            members = subgroup[self.member_facet].dropna().unique()
+            if len(members) == 0:
+                # No member information to select on; keep the subgroup unchanged.
+                keep.loc[subgroup.index] = True
+                continue
+            first = min(members, key=_member_sort_key)
+            keep.loc[subgroup.index[subgroup[self.member_facet] == first]] = True
+        return group[keep]

--- a/packages/climate-ref-core/tests/unit/test_constraints.py
+++ b/packages/climate-ref-core/tests/unit/test_constraints.py
@@ -1580,5 +1580,29 @@ class TestSelectFirstMember:
         data = pd.DataFrame(columns=["source_id", "member_id", "path"])
         assert SelectFirstMember().apply(data, data).empty
 
+    def test_non_cmip_members_sort_deterministically(self):
+        # Members that do not match r<r>i<i>p<p>f<f> fall back to raw-string ordering,
+        # so the alphabetically-first non-CMIP label is kept deterministically.
+        data = pd.DataFrame(
+            {
+                "source_id": ["MODEL", "MODEL"],
+                "member_id": ["obs-b", "obs-a"],
+                "path": ["a.nc", "b.nc"],
+            }
+        )
+        result = SelectFirstMember().apply(data, data)
+        assert list(result["member_id"]) == ["obs-a"]
+
+    def test_all_missing_members_keeps_subgroup(self):
+        # An all-NaN member column yields no members to select on; the subgroup is kept intact.
+        data = pd.DataFrame(
+            {
+                "source_id": ["A", "A"],
+                "member_id": [None, None],
+                "path": ["a.nc", "b.nc"],
+            }
+        )
+        assert_frame_equal(SelectFirstMember().apply(data, data), data)
+
     def test_is_group_constraint(self):
         assert isinstance(SelectFirstMember(), GroupConstraint)

--- a/packages/climate-ref-core/tests/unit/test_constraints.py
+++ b/packages/climate-ref-core/tests/unit/test_constraints.py
@@ -17,6 +17,7 @@ from climate_ref_core.constraints import (
     RequireFacets,
     RequireOverlappingTimerange,
     RequireTimerange,
+    SelectFirstMember,
     apply_constraint,
 )
 from climate_ref_core.datasets import SourceDatasetType
@@ -1521,3 +1522,63 @@ def test_apply_constraint_validate_invalid(data_catalog):
         )
         is None
     )
+
+
+class TestSelectFirstMember:
+    def test_reduces_to_one_member_per_model(self):
+        # Two models, several members each, both siconc and tas present per member.
+        rows = []
+        for source_id, members in (
+            ("ACCESS-CM2", ["r1i1p1f1", "r2i1p1f1", "r10i1p1f1"]),
+            ("CanESM5", ["r5i1p2f1", "r1i1p2f1"]),
+        ):
+            for member in members:
+                for var in ("siconc", "tas"):
+                    rows.append(
+                        {
+                            "source_id": source_id,
+                            "member_id": member,
+                            "grid_label": "gn",
+                            "variable_id": var,
+                            "path": f"{source_id}_{member}_{var}.nc",
+                        }
+                    )
+        data = pd.DataFrame(rows)
+
+        result = SelectFirstMember(member_facet="member_id", group_by=("source_id",)).apply(data, data)
+
+        # One member kept per model: the lowest CMIP index (r1i1p1f1; r1i1p2f1 for CanESM5),
+        # not the lexicographic first (r10.../r5...). Both variables of that member survive.
+        kept = {sid: sorted(sub["member_id"].unique()) for sid, sub in result.groupby("source_id")}
+        assert kept == {"ACCESS-CM2": ["r1i1p1f1"], "CanESM5": ["r1i1p2f1"]}
+        assert sorted(result[result["source_id"] == "ACCESS-CM2"]["variable_id"]) == ["siconc", "tas"]
+        assert len(result) == 4  # 2 models * 1 member * 2 variables
+
+    def test_variant_label_facet_for_cmip7(self):
+        data = pd.DataFrame(
+            {
+                "source_id": ["MODEL", "MODEL"],
+                "variant_label": ["r2i1p1f1", "r1i1p1f1"],
+                "path": ["a.nc", "b.nc"],
+            }
+        )
+        result = SelectFirstMember(member_facet="variant_label", group_by=("source_id",)).apply(data, data)
+        assert list(result["variant_label"]) == ["r1i1p1f1"]
+
+    def test_single_member_unchanged(self):
+        data = pd.DataFrame({"source_id": ["A"], "member_id": ["r1i1p1f1"], "path": ["a.nc"]})
+        assert_frame_equal(
+            SelectFirstMember().apply(data, data),
+            data,
+        )
+
+    def test_missing_member_facet_returns_group_unchanged(self):
+        data = pd.DataFrame({"source_id": ["A", "A"], "path": ["a.nc", "b.nc"]})
+        assert_frame_equal(SelectFirstMember().apply(data, data), data)
+
+    def test_empty_group(self):
+        data = pd.DataFrame(columns=["source_id", "member_id", "path"])
+        assert SelectFirstMember().apply(data, data).empty
+
+    def test_is_group_constraint(self):
+        assert isinstance(SelectFirstMember(), GroupConstraint)

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_sensitivity.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_sensitivity.py
@@ -8,6 +8,7 @@ from climate_ref_core.constraints import (
     PartialDateTime,
     RequireFacets,
     RequireTimerange,
+    SelectFirstMember,
 )
 from climate_ref_core.datasets import ExecutionDatasetCollection, FacetFilter, SourceDatasetType
 from climate_ref_core.diagnostics import DataRequirement
@@ -62,6 +63,9 @@ class SeaIceSensitivity(ESMValToolDiagnostic):
                         required_facets=("siconc", "tas"),
                         group_by=("source_id", "member_id", "grid_label"),
                     ),
+                    # The diagnostic script expects a single member per model; the REF
+                    # otherwise feeds every ingested member into this one execution.
+                    SelectFirstMember(member_facet="member_id", group_by=("source_id",)),
                     AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP6),
                     AddSupplementaryDataset.from_defaults("areacello", SourceDatasetType.CMIP6),
                     RequireFacets(
@@ -105,6 +109,9 @@ class SeaIceSensitivity(ESMValToolDiagnostic):
                         required_facets=("siconc", "tas"),
                         group_by=("source_id", "variant_label", "grid_label"),
                     ),
+                    # The diagnostic script expects a single member per model; the REF
+                    # otherwise feeds every ingested member into this one execution.
+                    SelectFirstMember(member_facet="variant_label", group_by=("source_id",)),
                     AddSupplementaryDataset.from_defaults("areacella", SourceDatasetType.CMIP7),
                     AddSupplementaryDataset.from_defaults("areacello", SourceDatasetType.CMIP7),
                     RequireFacets(

--- a/packages/climate-ref/src/climate_ref/default_ignore_datasets.yaml
+++ b/packages/climate-ref/src/climate_ref/default_ignore_datasets.yaml
@@ -22,12 +22,9 @@ esmvaltool:
   sea-ice-sensitivity:
       cmip6:
         - experiment_id: historical
-          grid_label: gn
-          member_id: r1i1p1f1
           source_id: CAS-ESM2-0
           table_id: SImon
           variable_id: siconc
-          version: v20201225
         - experiment_id: historical
           source_id: BCC-ESM1
           table_id: SImon


### PR DESCRIPTION
## Summary

`sea-ice-sensitivity` never produced a successful execution over the full CMIP6 archive. Two separate problems:

1. **CMOR failure (grey-list):** `CAS-ESM2-0` siconc has a malformed curvilinear grid (`lon`/`lat` beyond `valid_max`), failing ESMValTool's `cmor_check_metadata`. Only member `r1i1p1f1` was grey-listed, but the defect is model-wide (r1–r4 share the grid). Broadened the ignore entry to model-wide.

2. **Structural (multi-member):** after the CMOR fix, the diagnostic still failed with `None or too many matching files found for siconc`. The `seaice_sensitivity.py` script expects **exactly one ensemble member per model**, but the REF data requirement (`group_by=("experiment_id",)`) feeds **every** ingested member into a single execution. With the full archive (CanESM5-1 has 72 members, MIROC6 50, …) nearly every model tripped this.

## Changes

- New reusable constraint **`SelectFirstMember`** (`climate_ref_core.constraints`): within each group, keeps the datasets of one member — the lowest CMIP index (`r1i1p1f1` when present, via a numeric `r/i/p/f` sort so `r1` beats `r10`). Applied to both the CMIP6 (`member_id`) and CMIP7 (`variant_label`) requirements of `sea-ice-sensitivity`.
- Broadened the `CAS-ESM2-0` entry in `default_ignore_datasets.yaml` (both repo copies) from member-specific to model-wide.
- Unit tests for `SelectFirstMember` (numeric ordering, CMIP7 variant_label, single-member no-op, missing-facet passthrough, empty group, protocol conformance).

## Testing

- `test_constraints.py`: 103 passed (incl. 6 new).
- esmvaltool sea-ice suite: 11 passed / 4 skipped; the sea-ice-sensitivity solve-regression baseline is unchanged (its fixture removes ensembles, so the constraint is a no-op there).
- End-to-end: re-ran `sea-ice-sensitivity` over the full 2026-07-13 run → **success**, 240 metric values, all four plots + CSVs produced (24 models). Overall diagnostic coverage 46 → 47 of 48.

## Note

The one-member-per-model reduction is deliberate and matches the diagnostic's design (the test spec uses `remove_ensembles=True`). A rare edge case is untested: a model whose first member provides siconc at two `grid_label`s would still yield >1 siconc; none occur in the current archive.