### PR TITLE
feat: select ESMValTool reference data at solve time

### DIFF
--- a/changelog/835.feature.md
+++ b/changelog/835.feature.md
@@ -1,8 +1,3 @@
-Added solve-time selection of ESMValTool reference data.
+Added opt-in solve-time selection of ESMValTool reference data.
 Diagnostics can now request ESMValTool observational and reanalysis datasets
-the same way they request other reference data,
-so each request resolves against the tracked catalog.
-When a diagnostic requests its reference data this way,
-only the selected files are laid out for the run
-instead of the whole downloaded reference collection.
-Diagnostics that do not request it are unchanged.
+the same way they request other reference data so each request resolves against the tracked catalog.

--- a/changelog/835.feature.md
+++ b/changelog/835.feature.md
@@ -1,0 +1,8 @@
+Added solve-time selection of ESMValTool reference data.
+Diagnostics can now request ESMValTool observational and reanalysis datasets
+the same way they request other reference data,
+so each request resolves against the tracked catalog.
+When a diagnostic requests its reference data this way,
+only the selected files are laid out for the run
+instead of the whole downloaded reference collection.
+Diagnostics that do not request it are unchanged.

--- a/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
@@ -1,0 +1,52 @@
+"""
+Path conventions for ESMValTool reference (observational/reanalysis) data.
+
+ESMValTool reference data is located by ESMValCore from its own DRS directory templates
+rather than by ``instance_id``, so both the ingest adapter and the diagnostic runner need
+to know where the DRS-relative part of a path begins. That knowledge lives here so the two
+cannot drift apart.
+"""
+
+from pathlib import Path
+
+PROJECT_ANCHORS = ("OBS", "native6", "obs4MIPs")
+"""
+Top-level project directories, relative to the ``ESMValTool`` data root, that begin a DRS path.
+
+``OBS6`` data lives under the ``OBS`` directory, so the anchor for both is ``OBS``.
+The project itself is recovered from the filename.
+"""
+
+
+def relative_parts(path: str | Path) -> tuple[str, ...]:
+    """
+    Split a reference file path into its DRS-relative components.
+
+    Parameters
+    ----------
+    path
+        Path to a reference file, absolute or relative.
+
+    Returns
+    -------
+    :
+        The path components from the project anchor onward,
+        so ``.../ESMValTool/OBS/Tier2/CERES-EBAF/x.nc`` becomes
+        ``("OBS", "Tier2", "CERES-EBAF", "x.nc")``.
+
+    Raises
+    ------
+    ValueError
+        If no component of ``path`` is one of :data:`PROJECT_ANCHORS`.
+    """
+    parts = Path(path).parts
+
+    # Search from the right, so a data root that happens to contain a directory
+    # named after a project does not truncate the path at the wrong place.
+    for offset, part in enumerate(reversed(parts)):
+        if part in PROJECT_ANCHORS:
+            return parts[len(parts) - 1 - offset :]
+
+    raise ValueError(
+        f"{path} is not under a known ESMValTool reference project ({', '.join(PROJECT_ANCHORS)})"
+    )

--- a/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
@@ -1,8 +1,8 @@
 """
 Path conventions for ESMValTool reference (observational/reanalysis) data.
 
-ESMValCore locates this data from its own DRS directory templates rather than by
-``instance_id``, so a reference file is identified by where its DRS path begins.
+ESMValCore locates this data from its own DRS directory templates rather than by ``instance_id``,
+so a reference file is identified by where its DRS path begins.
 """
 
 from pathlib import Path

--- a/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
@@ -7,6 +7,7 @@ to know where the DRS-relative part of a path begins. That knowledge lives here 
 cannot drift apart.
 """
 
+import re
 from pathlib import Path
 
 PROJECT_ANCHORS = ("OBS", "native6", "obs4MIPs")
@@ -17,10 +18,32 @@ Top-level project directories, relative to the ``ESMValTool`` data root, that be
 The project itself is recovered from the filename.
 """
 
+_TIER_RE = re.compile(r"^Tier\d+$")
 
-def relative_parts(path: str | Path) -> tuple[str, ...]:
+# Shortest DRS path each project can produce, counted from the anchor.
+_OBS_MIN_PARTS = 3
+_OBS4MIPS_MIN_PARTS = 4
+_NATIVE6_MIN_PARTS = 7
+
+
+def _is_plausible_drs(rel: tuple[str, ...]) -> bool:
+    """Report whether ``rel`` looks like a DRS path for the project it starts with."""
+    if rel[0] == "obs4MIPs":
+        return len(rel) >= _OBS4MIPS_MIN_PARTS
+
+    minimum = _NATIVE6_MIN_PARTS if rel[0] == "native6" else _OBS_MIN_PARTS
+    return len(rel) >= minimum and bool(_TIER_RE.match(rel[1]))
+
+
+def drs_relative_parts(path: str | Path) -> tuple[str, ...]:
     """
     Split a reference file path into its DRS-relative components.
+
+    A data root may itself contain a directory named after a project, and a directory
+    inside the tree may in turn be named after another project, so neither the first nor
+    the last matching component is reliable on its own. The rightmost candidate whose
+    remaining structure fits its project is used, falling back to the leftmost candidate
+    when none fits.
 
     Parameters
     ----------
@@ -40,13 +63,15 @@ def relative_parts(path: str | Path) -> tuple[str, ...]:
         If no component of ``path`` is one of :data:`PROJECT_ANCHORS`.
     """
     parts = Path(path).parts
+    candidates = [index for index, part in enumerate(parts) if part in PROJECT_ANCHORS]
 
-    # Search from the right, so a data root that happens to contain a directory
-    # named after a project does not truncate the path at the wrong place.
-    for offset, part in enumerate(reversed(parts)):
-        if part in PROJECT_ANCHORS:
-            return parts[len(parts) - 1 - offset :]
+    if not candidates:
+        raise ValueError(
+            f"{path} is not under a known ESMValTool reference project ({', '.join(PROJECT_ANCHORS)})"
+        )
 
-    raise ValueError(
-        f"{path} is not under a known ESMValTool reference project ({', '.join(PROJECT_ANCHORS)})"
-    )
+    for index in reversed(candidates):
+        if _is_plausible_drs(parts[index:]):
+            return parts[index:]
+
+    return parts[candidates[0] :]

--- a/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
@@ -5,7 +5,6 @@ ESMValCore locates this data from its own DRS directory templates rather than by
 ``instance_id``, so a reference file is identified by where its DRS path begins.
 """
 
-import re
 from pathlib import Path
 from typing import NamedTuple
 
@@ -13,17 +12,18 @@ from typing import NamedTuple
 class _Layout(NamedTuple):
     """DRS shape of one project, counted from its anchor."""
 
-    min_parts: int
-    max_parts: int | None
-    """``None`` where the project allows extra directories above the file."""
+    parts: int
+    """The number of path components the project's template produces."""
+    allow_extra: bool
+    """Whether extra directories may sit between the dataset and the file."""
     tiered: bool
     """Whether a ``TierN`` directory sits directly under the anchor."""
 
 
 _PROJECT_LAYOUTS = {
-    "OBS": _Layout(min_parts=3, max_parts=None, tiered=True),
-    "native6": _Layout(min_parts=7, max_parts=7, tiered=True),
-    "obs4MIPs": _Layout(min_parts=4, max_parts=4, tiered=False),
+    "OBS": _Layout(parts=3, allow_extra=True, tiered=True),
+    "native6": _Layout(parts=7, allow_extra=False, tiered=True),
+    "obs4MIPs": _Layout(parts=4, allow_extra=False, tiered=False),
 }
 
 PROJECT_ANCHORS = tuple(_PROJECT_LAYOUTS)
@@ -34,33 +34,37 @@ Top-level project directories, relative to the ``ESMValTool`` data root, that be
 The project itself is recovered from the filename.
 """
 
-_TIER_RE = re.compile(r"^Tier\d+$")
 
-
-def matches_project_layout(rel: tuple[str, ...]) -> bool:
+def tier_from_segment(segment: str) -> int | None:
     """
-    Report whether DRS-relative components fit the layout of the project they start with.
+    Parse a ``TierN`` directory name into its tier number.
 
     Parameters
     ----------
-    rel
-        Path components from the project anchor onward, as returned by
-        :func:`drs_relative_parts`.
+    segment
+        A single path component.
 
     Returns
     -------
     :
-        Whether ``rel`` has a usable depth and tier directory for its project.
+        The tier number, or ``None`` if ``segment`` does not name a tier.
     """
+    if segment.startswith("Tier") and segment[4:].isdigit():
+        return int(segment[4:])
+    return None
+
+
+def _fits_layout(rel: tuple[str, ...]) -> bool:
+    """Report whether DRS-relative components fit the layout of the project they start with."""
     layout = _PROJECT_LAYOUTS[rel[0]]
 
     # Every layout is at least three components deep, so this also guards ``rel[1]`` below.
-    if len(rel) < layout.min_parts:
+    if len(rel) < layout.parts:
         return False
-    if layout.max_parts is not None and len(rel) > layout.max_parts:
+    if not layout.allow_extra and len(rel) > layout.parts:
         return False
 
-    return layout.tiered == bool(_TIER_RE.match(rel[1]))
+    return layout.tiered == (tier_from_segment(rel[1]) is not None)
 
 
 def drs_relative_parts(path: str | Path) -> tuple[str, ...]:
@@ -70,8 +74,7 @@ def drs_relative_parts(path: str | Path) -> tuple[str, ...]:
     A data root may itself contain a directory named after a project, and a directory
     inside the tree may in turn be named after another project, so neither the first nor
     the last matching component is reliable on its own. The rightmost candidate whose
-    remaining structure fits its project is used, falling back to the leftmost candidate
-    when none fits.
+    remaining components fit its project's layout wins.
 
     Parameters
     ----------
@@ -88,7 +91,8 @@ def drs_relative_parts(path: str | Path) -> tuple[str, ...]:
     Raises
     ------
     ValueError
-        If no component of ``path`` is one of :data:`PROJECT_ANCHORS`.
+        If no component of ``path`` names a project,
+        or if none of them begins a path that fits that project's layout.
     """
     parts = Path(path).parts
     candidates = [index for index, part in enumerate(parts) if part in PROJECT_ANCHORS]
@@ -99,7 +103,7 @@ def drs_relative_parts(path: str | Path) -> tuple[str, ...]:
         )
 
     for index in reversed(candidates):
-        if matches_project_layout(parts[index:]):
+        if _fits_layout(parts[index:]):
             return parts[index:]
 
-    return parts[candidates[0] :]
+    raise ValueError(f"unexpected {parts[candidates[0]]} path structure: {path}")

--- a/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
@@ -21,7 +21,7 @@ class _Layout(NamedTuple):
 
 
 _PROJECT_LAYOUTS = {
-    "OBS": _Layout(parts=3, allow_extra=True, tiered=True),
+    "OBS": _Layout(parts=4, allow_extra=True, tiered=True),
     "native6": _Layout(parts=7, allow_extra=False, tiered=True),
     "obs4MIPs": _Layout(parts=4, allow_extra=False, tiered=False),
 }
@@ -58,7 +58,7 @@ def _fits_layout(rel: tuple[str, ...]) -> bool:
     """Report whether DRS-relative components fit the layout of the project they start with."""
     layout = _PROJECT_LAYOUTS[rel[0]]
 
-    # Every layout is at least three components deep, so this also guards ``rel[1]`` below.
+    # Every layout is at least four components deep, so this also guards ``rel[1]`` below.
     if len(rel) < layout.parts:
         return False
     if not layout.allow_extra and len(rel) > layout.parts:

--- a/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
@@ -1,16 +1,24 @@
 """
 Path conventions for ESMValTool reference (observational/reanalysis) data.
 
-ESMValTool reference data is located by ESMValCore from its own DRS directory templates
-rather than by ``instance_id``, so both the ingest adapter and the diagnostic runner need
-to know where the DRS-relative part of a path begins. That knowledge lives here so the two
-cannot drift apart.
+ESMValCore locates this data from its own DRS directory templates rather than by
+``instance_id``, so a reference file is identified by where its DRS path begins.
 """
 
 import re
 from pathlib import Path
 
-PROJECT_ANCHORS = ("OBS", "native6", "obs4MIPs")
+# DRS shape of each project, counted from the anchor: the fewest and most path
+# components it produces, and whether a ``TierN`` directory sits directly under the
+# anchor. ``native6`` and ``obs4MIPs`` are fixed depth. ``OBS`` allows extra
+# directories between the dataset and the file, so it has no upper bound.
+_PROJECT_LAYOUTS = {
+    "OBS": (3, None, True),
+    "native6": (7, 7, True),
+    "obs4MIPs": (4, 4, False),
+}
+
+PROJECT_ANCHORS = tuple(_PROJECT_LAYOUTS)
 """
 Top-level project directories, relative to the ``ESMValTool`` data root, that begin a DRS path.
 
@@ -20,19 +28,15 @@ The project itself is recovered from the filename.
 
 _TIER_RE = re.compile(r"^Tier\d+$")
 
-# Shortest DRS path each project can produce, counted from the anchor.
-_OBS_MIN_PARTS = 3
-_OBS4MIPS_MIN_PARTS = 4
-_NATIVE6_MIN_PARTS = 7
-
 
 def _is_plausible_drs(rel: tuple[str, ...]) -> bool:
     """Report whether ``rel`` looks like a DRS path for the project it starts with."""
-    if rel[0] == "obs4MIPs":
-        return len(rel) >= _OBS4MIPS_MIN_PARTS
-
-    minimum = _NATIVE6_MIN_PARTS if rel[0] == "native6" else _OBS_MIN_PARTS
-    return len(rel) >= minimum and bool(_TIER_RE.match(rel[1]))
+    min_parts, max_parts, tiered = _PROJECT_LAYOUTS[rel[0]]
+    if len(rel) < min_parts or (max_parts is not None and len(rel) > max_parts):
+        return False
+    # Only the tiered projects put a ``TierN`` directory directly under the anchor,
+    # so its presence tells the two layouts apart.
+    return tiered == bool(_TIER_RE.match(rel[1]))
 
 
 def drs_relative_parts(path: str | Path) -> tuple[str, ...]:

--- a/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esmvaltool_reference.py
@@ -7,15 +7,23 @@ ESMValCore locates this data from its own DRS directory templates rather than by
 
 import re
 from pathlib import Path
+from typing import NamedTuple
 
-# DRS shape of each project, counted from the anchor: the fewest and most path
-# components it produces, and whether a ``TierN`` directory sits directly under the
-# anchor. ``native6`` and ``obs4MIPs`` are fixed depth. ``OBS`` allows extra
-# directories between the dataset and the file, so it has no upper bound.
+
+class _Layout(NamedTuple):
+    """DRS shape of one project, counted from its anchor."""
+
+    min_parts: int
+    max_parts: int | None
+    """``None`` where the project allows extra directories above the file."""
+    tiered: bool
+    """Whether a ``TierN`` directory sits directly under the anchor."""
+
+
 _PROJECT_LAYOUTS = {
-    "OBS": (3, None, True),
-    "native6": (7, 7, True),
-    "obs4MIPs": (4, 4, False),
+    "OBS": _Layout(min_parts=3, max_parts=None, tiered=True),
+    "native6": _Layout(min_parts=7, max_parts=7, tiered=True),
+    "obs4MIPs": _Layout(min_parts=4, max_parts=4, tiered=False),
 }
 
 PROJECT_ANCHORS = tuple(_PROJECT_LAYOUTS)
@@ -29,14 +37,30 @@ The project itself is recovered from the filename.
 _TIER_RE = re.compile(r"^Tier\d+$")
 
 
-def _is_plausible_drs(rel: tuple[str, ...]) -> bool:
-    """Report whether ``rel`` looks like a DRS path for the project it starts with."""
-    min_parts, max_parts, tiered = _PROJECT_LAYOUTS[rel[0]]
-    if len(rel) < min_parts or (max_parts is not None and len(rel) > max_parts):
+def matches_project_layout(rel: tuple[str, ...]) -> bool:
+    """
+    Report whether DRS-relative components fit the layout of the project they start with.
+
+    Parameters
+    ----------
+    rel
+        Path components from the project anchor onward, as returned by
+        :func:`drs_relative_parts`.
+
+    Returns
+    -------
+    :
+        Whether ``rel`` has a usable depth and tier directory for its project.
+    """
+    layout = _PROJECT_LAYOUTS[rel[0]]
+
+    # Every layout is at least three components deep, so this also guards ``rel[1]`` below.
+    if len(rel) < layout.min_parts:
         return False
-    # Only the tiered projects put a ``TierN`` directory directly under the anchor,
-    # so its presence tells the two layouts apart.
-    return tiered == bool(_TIER_RE.match(rel[1]))
+    if layout.max_parts is not None and len(rel) > layout.max_parts:
+        return False
+
+    return layout.tiered == bool(_TIER_RE.match(rel[1]))
 
 
 def drs_relative_parts(path: str | Path) -> tuple[str, ...]:
@@ -75,7 +99,7 @@ def drs_relative_parts(path: str | Path) -> tuple[str, ...]:
         )
 
     for index in reversed(candidates):
-        if _is_plausible_drs(parts[index:]):
+        if matches_project_layout(parts[index:]):
             return parts[index:]
 
     return parts[candidates[0] :]

--- a/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
+++ b/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
@@ -1,0 +1,51 @@
+import pytest
+
+from climate_ref_core.esmvaltool_reference import PROJECT_ANCHORS, relative_parts
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        (
+            "/data/ESMValTool/OBS/Tier2/CERES-EBAF/OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc",
+            ("OBS", "Tier2", "CERES-EBAF", "OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc"),
+        ),
+        # OBS6 data lives under the OBS directory, so its anchor is OBS too.
+        (
+            "/data/ESMValTool/OBS/Tier2/TROPFLUX/OBS6_TROPFLUX_reanaly_v1_Omon_tos_197901-201812.nc",
+            ("OBS", "Tier2", "TROPFLUX", "OBS6_TROPFLUX_reanaly_v1_Omon_tos_197901-201812.nc"),
+        ),
+        (
+            "/data/ESMValTool/native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc",
+            ("native6", "Tier3", "ERA5", "v1", "mon", "tas", "era5_tas_1980_monthly.nc"),
+        ),
+        (
+            "/data/ESMValTool/obs4MIPs/GPCP-V2-3/v20250101/pr_mon_GPCP-V2-3_gn_200001-200012.nc",
+            ("obs4MIPs", "GPCP-V2-3", "v20250101", "pr_mon_GPCP-V2-3_gn_200001-200012.nc"),
+        ),
+        # A relative path is handled the same way.
+        (
+            "OBS/Tier2/CERES-EBAF/OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc",
+            ("OBS", "Tier2", "CERES-EBAF", "OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc"),
+        ),
+    ],
+)
+def test_relative_parts(path, expected):
+    assert relative_parts(path) == expected
+
+
+def test_relative_parts_anchors_on_the_last_project_directory():
+    # A data root containing a directory named after a project must not truncate the
+    # path at the root instead of at the real anchor.
+    path = "/data/OBS/store/native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc"
+
+    assert relative_parts(path)[0] == "native6"
+
+
+def test_relative_parts_rejects_a_path_with_no_anchor():
+    with pytest.raises(ValueError, match="not under a known ESMValTool reference project"):
+        relative_parts("/data/somewhere/mystery.nc")
+
+
+def test_project_anchors_are_the_documented_set():
+    assert PROJECT_ANCHORS == ("OBS", "native6", "obs4MIPs")

--- a/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
+++ b/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
@@ -50,6 +50,14 @@ def test_drs_relative_parts_ignores_an_anchor_inside_the_tree():
     assert drs_relative_parts(path)[0] == "OBS"
 
 
+def test_drs_relative_parts_ignores_an_untiered_anchor_inside_a_tiered_tree():
+    # obs4MIPs has no TierN directory, so a dataset directory of that name inside a
+    # native6 tree is long enough to look plausible on length alone.
+    path = "/data/ESMValTool/native6/Tier3/obs4MIPs/v1/mon/tas/era5_tas_1980_monthly.nc"
+
+    assert drs_relative_parts(path)[0] == "native6"
+
+
 def test_drs_relative_parts_falls_back_to_the_leftmost_anchor():
     # Nothing structurally fits, so the leftmost candidate is used and the caller's
     # own parser reports what is wrong with it.

--- a/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
+++ b/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
@@ -1,24 +1,44 @@
 import pytest
 
-from climate_ref_core.esmvaltool_reference import drs_relative_parts, matches_project_layout
+from climate_ref_core.esmvaltool_reference import drs_relative_parts, tier_from_segment
 
 
 @pytest.mark.parametrize(
-    "rel, expected",
+    "segment, expected",
+    [("Tier2", 2), ("Tier10", 10), ("CERES-EBAF", None), ("Tier", None), ("TierX", None)],
+)
+def test_tier_from_segment(segment, expected):
+    assert tier_from_segment(segment) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
     [
-        (("OBS", "Tier2", "CERES-EBAF", "x.nc"), True),
         # OBS tolerates extra directories between the dataset and the file.
-        (("OBS", "Tier2", "CERES-EBAF", "sub", "x.nc"), True),
-        (("OBS", "CERES-EBAF", "x.nc"), False),
-        (("native6", "Tier3", "ERA5", "v1", "mon", "tas", "x.nc"), True),
-        (("native6", "Tier3", "ERA5", "v1", "mon", "tas", "sub", "x.nc"), False),
-        (("obs4MIPs", "GPCP-V2.3", "v20180519", "x.nc"), True),
-        (("obs4MIPs", "Tier2", "GPCP-V2.3", "x.nc"), False),
-        (("obs4MIPs", "GPCP-V2.3", "x.nc"), False),
+        "/data/OBS/Tier2/CERES-EBAF/sub/x.nc",
+        "/data/native6/Tier3/ERA5/v1/mon/tas/x.nc",
+        "/data/obs4MIPs/GPCP-V2.3/v20180519/x.nc",
     ],
 )
-def test_matches_project_layout(rel, expected):
-    assert matches_project_layout(rel) is expected
+def test_drs_relative_parts_accepts_each_project_layout(path):
+    assert drs_relative_parts(path)[0] in ("OBS", "native6", "obs4MIPs")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # No tier directory under a tiered project.
+        "/data/OBS/CERES-EBAF/x.nc",
+        # native6 and obs4MIPs are fixed depth, so neither may carry extra directories.
+        "/data/native6/Tier3/ERA5/v1/mon/tas/sub/x.nc",
+        "/data/obs4MIPs/GPCP-V2.3/x.nc",
+        # A tier directory under an untiered project.
+        "/data/obs4MIPs/Tier2/GPCP-V2.3/x.nc",
+    ],
+)
+def test_drs_relative_parts_rejects_a_path_that_fits_no_layout(path):
+    with pytest.raises(ValueError, match=r"unexpected \w+ path structure"):
+        drs_relative_parts(path)
 
 
 @pytest.mark.parametrize(
@@ -76,10 +96,10 @@ def test_drs_relative_parts_ignores_an_untiered_anchor_inside_a_tiered_tree():
     assert drs_relative_parts(path)[0] == "native6"
 
 
-def test_drs_relative_parts_falls_back_to_the_leftmost_anchor():
-    # Nothing structurally fits, so the leftmost candidate is used and the caller's
-    # own parser reports what is wrong with it.
-    assert drs_relative_parts("/data/OBS/odd.nc") == ("OBS", "odd.nc")
+def test_drs_relative_parts_names_the_project_it_could_not_fit():
+    # The message points at the leftmost candidate, which is the project the caller meant.
+    with pytest.raises(ValueError, match="unexpected OBS path structure"):
+        drs_relative_parts("/data/OBS/odd.nc")
 
 
 def test_drs_relative_parts_rejects_a_path_with_no_anchor():

--- a/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
+++ b/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
@@ -1,6 +1,6 @@
 import pytest
 
-from climate_ref_core.esmvaltool_reference import PROJECT_ANCHORS, relative_parts
+from climate_ref_core.esmvaltool_reference import drs_relative_parts
 
 
 @pytest.mark.parametrize(
@@ -20,8 +20,8 @@ from climate_ref_core.esmvaltool_reference import PROJECT_ANCHORS, relative_part
             ("native6", "Tier3", "ERA5", "v1", "mon", "tas", "era5_tas_1980_monthly.nc"),
         ),
         (
-            "/data/ESMValTool/obs4MIPs/GPCP-V2-3/v20250101/pr_mon_GPCP-V2-3_gn_200001-200012.nc",
-            ("obs4MIPs", "GPCP-V2-3", "v20250101", "pr_mon_GPCP-V2-3_gn_200001-200012.nc"),
+            "/data/ESMValTool/obs4MIPs/GPCP-V2.3/v20180519/pr_mon_GPCP-V2-3_gn_200001-200012.nc",
+            ("obs4MIPs", "GPCP-V2.3", "v20180519", "pr_mon_GPCP-V2-3_gn_200001-200012.nc"),
         ),
         # A relative path is handled the same way.
         (
@@ -30,22 +30,32 @@ from climate_ref_core.esmvaltool_reference import PROJECT_ANCHORS, relative_part
         ),
     ],
 )
-def test_relative_parts(path, expected):
-    assert relative_parts(path) == expected
+def test_drs_relative_parts(path, expected):
+    assert drs_relative_parts(path) == expected
 
 
-def test_relative_parts_anchors_on_the_last_project_directory():
+def test_drs_relative_parts_ignores_an_anchor_in_the_data_root():
     # A data root containing a directory named after a project must not truncate the
     # path at the root instead of at the real anchor.
     path = "/data/OBS/store/native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc"
 
-    assert relative_parts(path)[0] == "native6"
+    assert drs_relative_parts(path)[0] == "native6"
 
 
-def test_relative_parts_rejects_a_path_with_no_anchor():
+def test_drs_relative_parts_ignores_an_anchor_inside_the_tree():
+    # A dataset directory named after another project must not win over the real anchor,
+    # which would dispatch the file to the wrong parser and silently mis-read its metadata.
+    path = "/data/ESMValTool/OBS/Tier2/obs4MIPs/OBS_obs4MIPs_sat_Ed4.2_Amon_rlut_200003-202311.nc"
+
+    assert drs_relative_parts(path)[0] == "OBS"
+
+
+def test_drs_relative_parts_falls_back_to_the_leftmost_anchor():
+    # Nothing structurally fits, so the leftmost candidate is used and the caller's
+    # own parser reports what is wrong with it.
+    assert drs_relative_parts("/data/OBS/odd.nc") == ("OBS", "odd.nc")
+
+
+def test_drs_relative_parts_rejects_a_path_with_no_anchor():
     with pytest.raises(ValueError, match="not under a known ESMValTool reference project"):
-        relative_parts("/data/somewhere/mystery.nc")
-
-
-def test_project_anchors_are_the_documented_set():
-    assert PROJECT_ANCHORS == ("OBS", "native6", "obs4MIPs")
+        drs_relative_parts("/data/somewhere/mystery.nc")

--- a/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
+++ b/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
@@ -1,6 +1,24 @@
 import pytest
 
-from climate_ref_core.esmvaltool_reference import drs_relative_parts
+from climate_ref_core.esmvaltool_reference import drs_relative_parts, matches_project_layout
+
+
+@pytest.mark.parametrize(
+    "rel, expected",
+    [
+        (("OBS", "Tier2", "CERES-EBAF", "x.nc"), True),
+        # OBS tolerates extra directories between the dataset and the file.
+        (("OBS", "Tier2", "CERES-EBAF", "sub", "x.nc"), True),
+        (("OBS", "CERES-EBAF", "x.nc"), False),
+        (("native6", "Tier3", "ERA5", "v1", "mon", "tas", "x.nc"), True),
+        (("native6", "Tier3", "ERA5", "v1", "mon", "tas", "sub", "x.nc"), False),
+        (("obs4MIPs", "GPCP-V2.3", "v20180519", "x.nc"), True),
+        (("obs4MIPs", "Tier2", "GPCP-V2.3", "x.nc"), False),
+        (("obs4MIPs", "GPCP-V2.3", "x.nc"), False),
+    ],
+)
+def test_matches_project_layout(rel, expected):
+    assert matches_project_layout(rel) is expected
 
 
 @pytest.mark.parametrize(

--- a/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
+++ b/packages/climate-ref-core/tests/unit/test_esmvaltool_reference.py
@@ -29,6 +29,8 @@ def test_drs_relative_parts_accepts_each_project_layout(path):
     [
         # No tier directory under a tiered project.
         "/data/OBS/CERES-EBAF/x.nc",
+        # No dataset directory, which would otherwise read the filename as the dataset.
+        "/data/OBS/Tier2/OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc",
         # native6 and obs4MIPs are fixed depth, so neither may carry extra directories.
         "/data/native6/Tier3/ERA5/v1/mon/tas/sub/x.nc",
         "/data/obs4MIPs/GPCP-V2.3/x.nc",

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
@@ -82,11 +82,10 @@ for _diagnostic_cls_name in climate_ref_esmvaltool.diagnostics.__all__:
 
 # Register OBS, OBS6, and raw data as ESMValTool reference datasets.
 #
-# data.txt mixes OBS/OBS6 Tier2/3, native6 raw ERA5 and an obs4MIPs GPCP-V2.3 subset. The
-# ESMValCore-DRS adapter (`ESMValToolReferenceDatasetAdapter`) reads metadata from the DRS path
-# rather than the file contents, so the whole registry ingests as the `esmvaltool-reference`
-# source type. A diagnostic that declares an `esmvaltool-reference` data requirement is given
-# only the files the solver selected. One that does not gets the whole registry.
+# data.txt mixes OBS/OBS6 Tier2/3, native6 raw ERA5 and an obs4MIPs GPCP-V2.3 subset.
+# The ESMValCore-DRS adapter (`ESMValToolReferenceDatasetAdapter`) reads metadata from the DRS path
+# rather than the file contents, so the whole registry ingests as the `esmvaltool-reference` source type.
+# Declaring an `esmvaltool-reference` data requirement only gives the files the solver selected.
 dataset_registry_manager.register(
     name=_DATASETS_REGISTRY_NAME,
     base_url=DATASET_URL,

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
@@ -85,8 +85,8 @@ for _diagnostic_cls_name in climate_ref_esmvaltool.diagnostics.__all__:
 # data.txt mixes OBS/OBS6 Tier2/3, native6 raw ERA5 and an obs4MIPs GPCP-V2.3 subset. The
 # ESMValCore-DRS adapter (`ESMValToolReferenceDatasetAdapter`) reads metadata from the DRS path
 # rather than the file contents, so the whole registry ingests as the `esmvaltool-reference`
-# source type. Ingestion records these datasets for provenance. Solve-time selection is a
-# separate follow-up.
+# source type. A diagnostic that declares an `esmvaltool-reference` data requirement is given
+# only the files the solver selected. One that does not gets the whole registry.
 dataset_registry_manager.register(
     name=_DATASETS_REGISTRY_NAME,
     base_url=DATASET_URL,

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
@@ -264,8 +264,8 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
         recipe_path = self.write_recipe(definition)
         climate_data = definition.to_output_path("climate_data")
 
-        # ESMValCore finds reference data from its own DRS templates, so it gets its own
-        # rootpaths rather than sharing the instance_id tree that model data uses.
+        # ESMValCore finds reference data from its own DRS templates,
+        # so it gets its own rootpaths rather than sharing the instance_id tree that model data uses.
         data_dir = self._reference_data_root(definition)
 
         for source_type, metric_dataset in definition.datasets.items():

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
@@ -308,19 +308,9 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
         # Configure the paths to OBS/OBS6/native6 and non-compliant obs4MIPs data.
         # ESMValCore locates these from its own DRS templates rather than by instance_id,
         # so they get their own rootpaths rather than sharing the climate_data tree.
-        selected_reference_data = SourceDatasetType.ESMValToolReference in definition.datasets
-        if selected_reference_data:
-            data_dir = definition.to_output_path("reference_data")
-            prepare_reference_data(
-                definition.datasets[SourceDatasetType.ESMValToolReference].datasets,
-                reference_data_dir=data_dir,
-            )
-        else:
-            registry = dataset_registry_manager[_DATASETS_REGISTRY_NAME]
-            data_dir = registry.abspath / "ESMValTool"  # type: ignore[attr-defined]
-
-        if not data_dir.exists():
-            if selected_reference_data:
+        if SourceDatasetType.ESMValToolReference in definition.datasets:
+            selected = definition.datasets[SourceDatasetType.ESMValToolReference].datasets
+            if selected.empty:
                 # Carrying on would leave ESMValCore to fall back on its own default
                 # rootpaths, quietly running the recipe against whatever it finds there.
                 msg = (
@@ -328,6 +318,14 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
                     "but no files were selected for this execution."
                 )
                 raise ValueError(msg)
+
+            data_dir = definition.to_output_path("reference_data")
+            prepare_reference_data(selected, reference_data_dir=data_dir)
+        else:
+            registry = dataset_registry_manager[_DATASETS_REGISTRY_NAME]
+            data_dir = registry.abspath / "ESMValTool"  # type: ignore[attr-defined]
+
+        if not data_dir.exists():
             logger.warning(
                 "ESMValTool observational and reanalysis data is not available "
                 f"in {data_dir}, you may want to run the command "

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
@@ -308,26 +308,31 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
         # Configure the paths to OBS/OBS6/native6 and non-compliant obs4MIPs data.
         # ESMValCore locates these from its own DRS templates rather than by instance_id,
         # so they get their own rootpaths rather than sharing the climate_data tree.
-        if SourceDatasetType.ESMValToolReference in definition.datasets:
+        selected_reference_data = SourceDatasetType.ESMValToolReference in definition.datasets
+        if selected_reference_data:
             data_dir = definition.to_output_path("reference_data")
             prepare_reference_data(
                 definition.datasets[SourceDatasetType.ESMValToolReference].datasets,
                 reference_data_dir=data_dir,
             )
-            unavailable_message = (
-                f"No ESMValTool reference files were selected for this execution, so {data_dir} is empty."
-            )
         else:
             registry = dataset_registry_manager[_DATASETS_REGISTRY_NAME]
             data_dir = registry.abspath / "ESMValTool"  # type: ignore[attr-defined]
-            unavailable_message = (
+
+        if not data_dir.exists():
+            if selected_reference_data:
+                # Carrying on would leave ESMValCore to fall back on its own default
+                # rootpaths, quietly running the recipe against whatever it finds there.
+                msg = (
+                    "The diagnostic requested ESMValTool reference data "
+                    "but no files were selected for this execution."
+                )
+                raise ValueError(msg)
+            logger.warning(
                 "ESMValTool observational and reanalysis data is not available "
                 f"in {data_dir}, you may want to run the command "
                 f"`ref datasets fetch-data --registry {_DATASETS_REGISTRY_NAME}`."
             )
-
-        if not data_dir.exists():
-            logger.warning(unavailable_message)
         else:
             config["projects"]["OBS"] = {
                 "data": {

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
@@ -26,6 +26,7 @@ from climate_ref_esmvaltool.recipe import (
     fix_annual_statistics_keep_year,
     load_recipe,
     prepare_climate_data,
+    prepare_reference_data,
     rewrite_mip_for_cmip7,
 )
 from climate_ref_esmvaltool.types import MetricBundleArgs, OutputBundleArgs, Recipe
@@ -245,7 +246,12 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
         recipe_path = self.write_recipe(definition)
         climate_data = definition.to_output_path("climate_data")
 
-        for metric_dataset in definition.datasets.values():
+        for source_type, metric_dataset in definition.datasets.items():
+            # ESMValTool reference data is laid out separately below,
+            # into the DRS tree that ESMValCore's OBS/OBS6/native6 rootpaths point at,
+            # not by instance_id.
+            if source_type == SourceDatasetType.ESMValToolReference:
+                continue
             prepare_climate_data(
                 metric_dataset.datasets,
                 climate_data_dir=climate_data,
@@ -299,15 +305,29 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
             },
         }
 
-        # Configure the paths to OBS/OBS6/native6 and non-compliant obs4MIPs data
-        registry = dataset_registry_manager[_DATASETS_REGISTRY_NAME]
-        data_dir = registry.abspath / "ESMValTool"  # type: ignore[attr-defined]
-        if not data_dir.exists():
-            logger.warning(
+        # Configure the paths to OBS/OBS6/native6 and non-compliant obs4MIPs data.
+        # ESMValCore locates these from its own DRS templates rather than by instance_id,
+        # so they get their own rootpaths rather than sharing the climate_data tree.
+        if SourceDatasetType.ESMValToolReference in definition.datasets:
+            data_dir = definition.to_output_path("reference_data")
+            prepare_reference_data(
+                definition.datasets[SourceDatasetType.ESMValToolReference].datasets,
+                reference_data_dir=data_dir,
+            )
+            unavailable_message = (
+                f"No ESMValTool reference files were selected for this execution, so {data_dir} is empty."
+            )
+        else:
+            registry = dataset_registry_manager[_DATASETS_REGISTRY_NAME]
+            data_dir = registry.abspath / "ESMValTool"  # type: ignore[attr-defined]
+            unavailable_message = (
                 "ESMValTool observational and reanalysis data is not available "
                 f"in {data_dir}, you may want to run the command "
                 f"`ref datasets fetch-data --registry {_DATASETS_REGISTRY_NAME}`."
             )
+
+        if not data_dir.exists():
+            logger.warning(unavailable_message)
         else:
             config["projects"]["OBS"] = {
                 "data": {

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/base.py
@@ -229,6 +229,24 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
             file.write(recipe_txt)
         return recipe_path
 
+    @staticmethod
+    def _reference_data_root(definition: ExecutionDefinition) -> Path:
+        """Return the directory ESMValCore should read OBS/OBS6/native6/obs4MIPs data from.
+
+        A diagnostic that requested reference data gets a tree holding just its selection.
+        One that did not gets the whole downloaded registry.
+        """
+        if SourceDatasetType.ESMValToolReference in definition.datasets:
+            reference_data = definition.to_output_path("reference_data")
+            prepare_reference_data(
+                definition.datasets[SourceDatasetType.ESMValToolReference].datasets,
+                reference_data_dir=reference_data,
+            )
+            return reference_data
+
+        registry = dataset_registry_manager[_DATASETS_REGISTRY_NAME]
+        return registry.abspath / "ESMValTool"  # type: ignore[attr-defined,no-any-return]
+
     def build_cmd(self, definition: ExecutionDefinition) -> Iterable[str]:
         """
         Build the command to run an ESMValTool recipe.
@@ -246,10 +264,11 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
         recipe_path = self.write_recipe(definition)
         climate_data = definition.to_output_path("climate_data")
 
+        # ESMValCore finds reference data from its own DRS templates, so it gets its own
+        # rootpaths rather than sharing the instance_id tree that model data uses.
+        data_dir = self._reference_data_root(definition)
+
         for source_type, metric_dataset in definition.datasets.items():
-            # ESMValTool reference data is laid out separately below,
-            # into the DRS tree that ESMValCore's OBS/OBS6/native6 rootpaths point at,
-            # not by instance_id.
             if source_type == SourceDatasetType.ESMValToolReference:
                 continue
             prepare_climate_data(
@@ -304,26 +323,6 @@ class ESMValToolDiagnostic(CommandLineDiagnostic):
                 },
             },
         }
-
-        # Configure the paths to OBS/OBS6/native6 and non-compliant obs4MIPs data.
-        # ESMValCore locates these from its own DRS templates rather than by instance_id,
-        # so they get their own rootpaths rather than sharing the climate_data tree.
-        if SourceDatasetType.ESMValToolReference in definition.datasets:
-            selected = definition.datasets[SourceDatasetType.ESMValToolReference].datasets
-            if selected.empty:
-                # Carrying on would leave ESMValCore to fall back on its own default
-                # rootpaths, quietly running the recipe against whatever it finds there.
-                msg = (
-                    "The diagnostic requested ESMValTool reference data "
-                    "but no files were selected for this execution."
-                )
-                raise ValueError(msg)
-
-            data_dir = definition.to_output_path("reference_data")
-            prepare_reference_data(selected, reference_data_dir=data_dir)
-        else:
-            registry = dataset_registry_manager[_DATASETS_REGISTRY_NAME]
-            data_dir = registry.abspath / "ESMValTool"  # type: ignore[attr-defined]
 
         if not data_dir.exists():
             logger.warning(

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -466,6 +467,11 @@ def prepare_reference_data(datasets: pd.DataFrame, reference_data_dir: Path) -> 
         # default rootpaths and run the recipe against whatever it finds there.
         msg = "The diagnostic requested ESMValTool reference data but no files were selected."
         raise ValueError(msg)
+
+    # Start from an empty tree. A link left by an earlier run whose source still exists
+    # would otherwise survive, and ESMValCore would read data this run did not select.
+    if reference_data_dir.exists():
+        shutil.rmtree(reference_data_dir)
 
     cleaned_dirs: set[Path] = set()
 

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
@@ -407,8 +407,8 @@ def load_recipe(recipe: str) -> Recipe:
     return normalize(yaml.safe_load(Path(filename).read_text(encoding="utf-8")))  # type: ignore[no-any-return]
 
 
-def _row_path(row: Any) -> str:
-    """Return the ``path`` column of a catalog row, which is always a string."""
+def _require_path(row: Any) -> str:
+    """Return the ``path`` column of a catalog row, rejecting a row that has no usable path."""
     if not isinstance(row.path, str):  # pragma: no branch
         msg = f"Invalid path encountered in {row}"
         raise ValueError(msg)
@@ -444,9 +444,7 @@ def prepare_reference_data(datasets: pd.DataFrame, reference_data_dir: Path) -> 
     not by the ``instance_id`` layout used for model data.
     Each file already sits under one of the project anchors on disk,
     so the path from the anchor onward is replicated verbatim under ``reference_data_dir``.
-    This lays out exactly the subset the solver selected,
-    so :meth:`build_cmd` can point ESMValCore at a version-pinned tree
-    instead of the whole downloaded registry.
+    The tree therefore holds exactly the selected subset and nothing else.
 
     Parameters
     ----------
@@ -466,7 +464,7 @@ def prepare_reference_data(datasets: pd.DataFrame, reference_data_dir: Path) -> 
     cleaned_dirs: set[Path] = set()
 
     for row in datasets.itertuples():
-        path = _row_path(row)
+        path = _require_path(row)
         tgt = reference_data_dir.joinpath(*drs_relative_parts(path))
         _symlink_into_tree(tgt, path, cleaned_dirs)
 
@@ -491,7 +489,7 @@ def prepare_climate_data(datasets: pd.DataFrame, climate_data_dir: Path) -> None
         if not isinstance(row.instance_id, str):  # pragma: no branch
             msg = f"Invalid instance_id encountered in {row}"
             raise ValueError(msg)
-        path = _row_path(row)
+        path = _require_path(row)
         if row.instance_id.startswith("obs4MIPs."):
             version = row.instance_id.split(".")[-1]
             subdirs: list[str] = ["obs4MIPs", row.source_id, version]  # type: ignore[list-item]

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
@@ -9,6 +9,7 @@ import pandas as pd
 import yaml
 
 from climate_ref_core.dataset_registry import dataset_registry_manager
+from climate_ref_core.esmvaltool_reference import relative_parts
 from climate_ref_esmvaltool.types import Recipe
 
 if TYPE_CHECKING:
@@ -406,6 +407,65 @@ def load_recipe(recipe: str) -> Recipe:
     return normalize(yaml.safe_load(Path(filename).read_text(encoding="utf-8")))  # type: ignore[no-any-return]
 
 
+def _symlink_into_tree(tgt: Path, source: str, cleaned_dirs: set[Path]) -> None:
+    """Symlink ``tgt`` to ``source``, first clearing any stale symlinks in its directory.
+
+    ``cleaned_dirs`` records the parent directories already swept for dangling symlinks,
+    so each directory is scanned at most once across a batch of links.
+    """
+    tgt.parent.mkdir(parents=True, exist_ok=True)
+
+    # Remove any stale symlinks in the target directory to prevent
+    # ESMValCore from finding dangling symlinks from previous runs.
+    if tgt.parent not in cleaned_dirs:
+        for existing in tgt.parent.iterdir():
+            if existing.is_symlink() and not existing.resolve().exists():
+                existing.unlink()
+        cleaned_dirs.add(tgt.parent)
+
+    if tgt.is_symlink() or tgt.exists():
+        tgt.unlink()
+    tgt.symlink_to(source)
+
+
+def prepare_reference_data(datasets: pd.DataFrame, reference_data_dir: Path) -> None:
+    """Symlink solver-selected ESMValTool reference files into an ESMValCore DRS tree.
+
+    ESMValTool reference data (``OBS``/``OBS6``, ``native6`` and non-compliant ``obs4MIPs``)
+    is located by ESMValCore from its own directory templates,
+    not by the ``instance_id`` layout used for model data.
+    Each file already sits under one of the project anchors on disk,
+    so the path from the anchor onward is replicated verbatim under ``reference_data_dir``.
+    This lays out exactly the subset the solver selected,
+    so :meth:`build_cmd` can point ESMValCore at a version-pinned tree
+    instead of the whole downloaded registry.
+
+    Parameters
+    ----------
+    datasets
+        The pandas dataframe describing the selected ESMValTool reference files.
+    reference_data_dir
+        The directory to build the reference DRS tree in.
+        It mirrors the ``ESMValTool`` data root,
+        so ``OBS``/``native6``/``obs4MIPs`` sit directly beneath it.
+
+    Raises
+    ------
+    ValueError
+        If a selected file does not sit under a project anchor,
+        which would leave ESMValCore unable to find it.
+    """
+    cleaned_dirs: set[Path] = set()
+
+    for row in datasets.itertuples():
+        if not isinstance(row.path, str):  # pragma: no branch
+            msg = f"Invalid path encountered in {row}"
+            raise ValueError(msg)
+
+        tgt = reference_data_dir.joinpath(*relative_parts(row.path))
+        _symlink_into_tree(tgt, row.path, cleaned_dirs)
+
+
 def prepare_climate_data(datasets: pd.DataFrame, climate_data_dir: Path) -> None:
     """Symlink the input files from the Pandas dataframe into a directory tree.
 
@@ -437,16 +497,4 @@ def prepare_climate_data(datasets: pd.DataFrame, climate_data_dir: Path) -> None
         else:
             subdirs = row.instance_id.split(".")
         tgt = climate_data_dir.joinpath(*subdirs) / Path(row.path).name
-        tgt.parent.mkdir(parents=True, exist_ok=True)
-
-        # Remove any stale symlinks in the target directory to prevent
-        # ESMValCore from finding dangling symlinks from previous runs
-        if tgt.parent not in cleaned_dirs:
-            for existing in tgt.parent.iterdir():
-                if existing.is_symlink() and not existing.resolve().exists():
-                    existing.unlink()
-            cleaned_dirs.add(tgt.parent)
-
-        if tgt.is_symlink() or tgt.exists():
-            tgt.unlink()
-        tgt.symlink_to(row.path)
+        _symlink_into_tree(tgt, row.path, cleaned_dirs)

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
@@ -9,7 +9,7 @@ import pandas as pd
 import yaml
 
 from climate_ref_core.dataset_registry import dataset_registry_manager
-from climate_ref_core.esmvaltool_reference import relative_parts
+from climate_ref_core.esmvaltool_reference import drs_relative_parts
 from climate_ref_esmvaltool.types import Recipe
 
 if TYPE_CHECKING:
@@ -407,6 +407,14 @@ def load_recipe(recipe: str) -> Recipe:
     return normalize(yaml.safe_load(Path(filename).read_text(encoding="utf-8")))  # type: ignore[no-any-return]
 
 
+def _row_path(row: Any) -> str:
+    """Return the ``path`` column of a catalog row, which is always a string."""
+    if not isinstance(row.path, str):  # pragma: no branch
+        msg = f"Invalid path encountered in {row}"
+        raise ValueError(msg)
+    return row.path
+
+
 def _symlink_into_tree(tgt: Path, source: str, cleaned_dirs: set[Path]) -> None:
     """Symlink ``tgt`` to ``source``, first clearing any stale symlinks in its directory.
 
@@ -458,12 +466,9 @@ def prepare_reference_data(datasets: pd.DataFrame, reference_data_dir: Path) -> 
     cleaned_dirs: set[Path] = set()
 
     for row in datasets.itertuples():
-        if not isinstance(row.path, str):  # pragma: no branch
-            msg = f"Invalid path encountered in {row}"
-            raise ValueError(msg)
-
-        tgt = reference_data_dir.joinpath(*relative_parts(row.path))
-        _symlink_into_tree(tgt, row.path, cleaned_dirs)
+        path = _row_path(row)
+        tgt = reference_data_dir.joinpath(*drs_relative_parts(path))
+        _symlink_into_tree(tgt, path, cleaned_dirs)
 
 
 def prepare_climate_data(datasets: pd.DataFrame, climate_data_dir: Path) -> None:
@@ -486,9 +491,7 @@ def prepare_climate_data(datasets: pd.DataFrame, climate_data_dir: Path) -> None
         if not isinstance(row.instance_id, str):  # pragma: no branch
             msg = f"Invalid instance_id encountered in {row}"
             raise ValueError(msg)
-        if not isinstance(row.path, str):  # pragma: no branch
-            msg = f"Invalid path encountered in {row}"
-            raise ValueError(msg)
+        path = _row_path(row)
         if row.instance_id.startswith("obs4MIPs."):
             version = row.instance_id.split(".")[-1]
             subdirs: list[str] = ["obs4MIPs", row.source_id, version]  # type: ignore[list-item]
@@ -496,5 +499,5 @@ def prepare_climate_data(datasets: pd.DataFrame, climate_data_dir: Path) -> None
             subdirs = row.instance_id.split(".")
         else:
             subdirs = row.instance_id.split(".")
-        tgt = climate_data_dir.joinpath(*subdirs) / Path(row.path).name
-        _symlink_into_tree(tgt, row.path, cleaned_dirs)
+        tgt = climate_data_dir.joinpath(*subdirs) / Path(path).name
+        _symlink_into_tree(tgt, path, cleaned_dirs)

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/recipe.py
@@ -418,21 +418,21 @@ def _require_path(row: Any) -> str:
 def _symlink_into_tree(tgt: Path, source: str, cleaned_dirs: set[Path]) -> None:
     """Symlink ``tgt`` to ``source``, first clearing any stale symlinks in its directory.
 
-    ``cleaned_dirs`` records the parent directories already swept for dangling symlinks,
-    so each directory is scanned at most once across a batch of links.
+    ``cleaned_dirs`` records the parent directories already created and swept,
+    so each directory is handled at most once across a batch of links.
     """
-    tgt.parent.mkdir(parents=True, exist_ok=True)
-
-    # Remove any stale symlinks in the target directory to prevent
-    # ESMValCore from finding dangling symlinks from previous runs.
     if tgt.parent not in cleaned_dirs:
+        tgt.parent.mkdir(parents=True, exist_ok=True)
+
+        # Remove any stale symlinks in the target directory to prevent
+        # ESMValCore from finding dangling symlinks from previous runs.
+        # ``exists`` follows the link, so a dangling one reads as absent.
         for existing in tgt.parent.iterdir():
-            if existing.is_symlink() and not existing.resolve().exists():
+            if existing.is_symlink() and not existing.exists():
                 existing.unlink()
         cleaned_dirs.add(tgt.parent)
 
-    if tgt.is_symlink() or tgt.exists():
-        tgt.unlink()
+    tgt.unlink(missing_ok=True)
     tgt.symlink_to(source)
 
 
@@ -458,9 +458,15 @@ def prepare_reference_data(datasets: pd.DataFrame, reference_data_dir: Path) -> 
     Raises
     ------
     ValueError
-        If a selected file does not sit under a project anchor,
-        which would leave ESMValCore unable to find it.
+        If ``datasets`` is empty, or if a selected file does not fit a project layout,
+        either of which would leave ESMValCore unable to find the data it was asked for.
     """
+    if datasets.empty:
+        # Building an empty tree would leave ESMValCore to fall back on its own
+        # default rootpaths and run the recipe against whatever it finds there.
+        msg = "The diagnostic requested ESMValTool reference data but no files were selected."
+        raise ValueError(msg)
+
     cleaned_dirs: set[Path] = set()
 
     for row in datasets.itertuples():

--- a/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
@@ -1,5 +1,6 @@
 import json
 
+import attrs
 import climate_ref_esmvaltool.diagnostics.base
 import numpy as np
 import pandas
@@ -13,7 +14,7 @@ from climate_ref_esmvaltool.diagnostics.regional_historical_changes import (
 )
 from climate_ref_esmvaltool.types import Recipe
 
-from climate_ref_core.datasets import SourceDatasetType
+from climate_ref_core.datasets import DatasetCollection, ExecutionDatasetCollection, SourceDatasetType
 from climate_ref_core.diagnostics import CommandLineDiagnostic, ExecutionDefinition
 from climate_ref_core.metric_values import SeriesMetricValue as SeriesMetricValueType
 from climate_ref_core.metric_values.typing import SeriesDefinition
@@ -68,6 +69,59 @@ def test_build_cmd(mocker, tmp_path, metric_definition, mock_diagnostic, data_di
     assert "CMIP6" in config["projects"]
     assert "CMIP7" in config["projects"]
     assert "obs4MIPs" in config["projects"]
+
+
+def test_build_cmd_with_selected_reference_data(mocker, tmp_path, metric_definition, mock_diagnostic):
+    """When the solver selected ESMValTool reference data, ``build_cmd`` points ESMValCore at it.
+
+    The selected files are laid out under ``reference_data`` (not mixed into ``climate_data``),
+    and the OBS/OBS6/native6/obs4MIPs rootpaths use that tree instead of the bulk registry.
+    """
+    dataset_registry_manager = mocker.patch.object(
+        climate_ref_esmvaltool.diagnostics.base,
+        "dataset_registry_manager",
+    )
+    dataset_registry_manager.__getitem__.return_value.abspath = tmp_path / "registry"
+
+    ref_file = (
+        tmp_path
+        / "refsrc"
+        / "OBS"
+        / "Tier2"
+        / "CERES-EBAF"
+        / "OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc"
+    )
+    ref_file.parent.mkdir(parents=True)
+    ref_file.touch()
+    reference = DatasetCollection(
+        pandas.DataFrame(
+            {
+                "instance_id": ["esmvaltool-reference.OBS.CERES-EBAF.mon.rlut.Ed4.2"],
+                "path": [str(ref_file)],
+            }
+        ),
+        "instance_id",
+    )
+    datasets = dict(metric_definition.datasets.items())
+    datasets[SourceDatasetType.ESMValToolReference] = reference
+    definition = attrs.evolve(metric_definition, datasets=ExecutionDatasetCollection(datasets))
+    output_dir = definition.output_directory
+    output_dir.mkdir(parents=True)
+
+    mock_diagnostic.build_cmd(definition)
+
+    reference_data = output_dir / "reference_data"
+    laid_out = reference_data / "OBS" / "Tier2" / "CERES-EBAF" / ref_file.name
+    assert laid_out.is_symlink()
+    assert laid_out.resolve() == ref_file.resolve()
+    # The reference rows are not mixed into the model climate_data tree.
+    assert not list((output_dir / "climate_data").rglob(ref_file.name))
+
+    config = yaml.safe_load((output_dir / "config" / "config.yml").read_text(encoding="utf-8"))
+    assert config["projects"]["OBS"]["data"]["local"]["rootpath"] == str(reference_data / "OBS")
+    assert config["projects"]["OBS6"]["data"]["local"]["rootpath"] == str(reference_data / "OBS")
+    assert config["projects"]["native6"]["data"]["local"]["rootpath"] == str(reference_data / "native6")
+    assert config["projects"]["obs4MIPs"]["data"]["esmvaltool"]["rootpath"] == str(reference_data)
 
 
 def test_build_metric_result(metric_definition, mock_diagnostic):

--- a/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
@@ -124,6 +124,30 @@ def test_build_cmd_with_selected_reference_data(mocker, tmp_path, metric_definit
     assert config["projects"]["obs4MIPs"]["data"]["esmvaltool"]["rootpath"] == str(reference_data)
 
 
+def test_build_cmd_with_empty_selected_reference_data(mocker, tmp_path, metric_definition, mock_diagnostic):
+    """An opt-in diagnostic that selected no reference files fails rather than running blind.
+
+    Carrying on would leave ESMValCore to fall back on its own default rootpaths.
+    """
+    dataset_registry_manager = mocker.patch.object(
+        climate_ref_esmvaltool.diagnostics.base,
+        "dataset_registry_manager",
+    )
+    dataset_registry_manager.__getitem__.return_value.abspath = tmp_path / "registry"
+
+    reference = DatasetCollection(
+        pandas.DataFrame({"instance_id": [], "path": []}),
+        "instance_id",
+    )
+    datasets = dict(metric_definition.datasets.items())
+    datasets[SourceDatasetType.ESMValToolReference] = reference
+    definition = attrs.evolve(metric_definition, datasets=ExecutionDatasetCollection(datasets))
+    definition.output_directory.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="no files were selected"):
+        mock_diagnostic.build_cmd(definition)
+
+
 def test_build_metric_result(metric_definition, mock_diagnostic):
     results_dir = metric_definition.to_output_path("executions") / "recipe_test"
 

--- a/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/diagnostics/test_base.py
@@ -143,6 +143,8 @@ def test_build_cmd_with_empty_selected_reference_data(mocker, tmp_path, metric_d
     datasets[SourceDatasetType.ESMValToolReference] = reference
     definition = attrs.evolve(metric_definition, datasets=ExecutionDatasetCollection(datasets))
     definition.output_directory.mkdir(parents=True)
+    # A leftover tree from an earlier run must not disguise an empty selection.
+    (definition.output_directory / "reference_data").mkdir()
 
     with pytest.raises(ValueError, match="no files were selected"):
         mock_diagnostic.build_cmd(definition)

--- a/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
@@ -363,32 +363,39 @@ def test_prepare_reference_data_rejects_a_non_string_path(tmp_path):
         prepare_reference_data(datasets, tmp_path / "reference_data")
 
 
-def test_prepare_reference_data_clears_stale_symlinks(tmp_path):
+def test_prepare_reference_data_drops_files_the_run_did_not_select(tmp_path):
+    # Reusing an output directory must not leave ESMValCore able to read a file that
+    # an earlier run selected, whether or not that file still exists on disk.
     source_dir = tmp_path / "source" / "OBS" / "Tier2" / "CERES-EBAF"
     source_dir.mkdir(parents=True)
-    gone = source_dir / "OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc"
+    deselected = source_dir / "OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc"
+    removed = source_dir / "OBS_CERES-EBAF_sat_Ed4.2_Amon_rsdt_200003-202311.nc"
     kept = source_dir / "OBS_CERES-EBAF_sat_Ed4.2_Amon_rsut_200003-202311.nc"
-    gone.touch()
-    kept.touch()
+    for source in (deselected, removed, kept):
+        source.touch()
 
     reference_data_dir = tmp_path / "reference_data"
-    prepare_reference_data(pd.DataFrame({"path": [str(gone)]}), reference_data_dir)
+    prepare_reference_data(
+        pd.DataFrame({"path": [str(deselected), str(removed), str(kept)]}),
+        reference_data_dir,
+    )
 
-    # The first run's source disappears, leaving a dangling symlink behind.
-    gone.unlink()
+    # One source disappears, so its link dangles. The other two stay on disk.
+    removed.unlink()
     laid_out = reference_data_dir / "OBS" / "Tier2" / "CERES-EBAF"
-    assert (laid_out / gone.name).is_symlink()
+    assert (laid_out / deselected.name).is_symlink()
 
-    # A second run over the same directory sweeps it, and relinking an unchanged
-    # file replaces the existing symlink rather than failing.
+    # A second run selects only one of them. Relinking an unchanged file replaces the
+    # existing symlink rather than failing.
     prepare_reference_data(
         pd.DataFrame({"path": [str(kept), str(kept)]}),
         reference_data_dir,
     )
 
-    assert not (laid_out / gone.name).exists()
-    assert not (laid_out / gone.name).is_symlink()
     assert (laid_out / kept.name).resolve() == kept.resolve()
+    for dropped in (deselected, removed):
+        assert not (laid_out / dropped.name).exists()
+        assert not (laid_out / dropped.name).is_symlink()
 
 
 def test_prepare_reference_data_rejects_unknown_project(tmp_path):

--- a/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
@@ -405,20 +405,10 @@ def test_prepare_reference_data_rejects_unknown_project(tmp_path):
         prepare_reference_data(datasets, reference_data_dir)
 
 
-def test_prepare_reference_data_ignores_an_anchor_in_the_data_root(tmp_path):
-    # A data root that itself contains a directory named after a project must not
-    # truncate the DRS path at the root instead of at the real anchor.
-    rel = "OBS/store/native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc"
-    source = tmp_path / rel
-    source.parent.mkdir(parents=True)
-    source.touch()
-
-    reference_data_dir = tmp_path / "reference_data"
-    prepare_reference_data(pd.DataFrame({"path": [str(source)]}), reference_data_dir)
-
-    symlink = reference_data_dir / "native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc"
-    assert symlink.is_symlink()
-    assert symlink.resolve() == source.resolve()
+def test_prepare_reference_data_rejects_an_empty_selection(tmp_path):
+    # An empty tree would leave ESMValCore to fall back on its own default rootpaths.
+    with pytest.raises(ValueError, match="no files were selected"):
+        prepare_reference_data(pd.DataFrame({"path": []}), tmp_path / "reference_data")
 
 
 def _cmip7_recipe(diagnostic):

--- a/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
@@ -356,6 +356,41 @@ def test_prepare_reference_data(tmp_path):
         assert symlink.resolve() == source_path.resolve()
 
 
+def test_prepare_reference_data_rejects_a_non_string_path(tmp_path):
+    datasets = pd.DataFrame({"path": [123]})
+
+    with pytest.raises(ValueError, match="Invalid path encountered"):
+        prepare_reference_data(datasets, tmp_path / "reference_data")
+
+
+def test_prepare_reference_data_clears_stale_symlinks(tmp_path):
+    source_dir = tmp_path / "source" / "OBS" / "Tier2" / "CERES-EBAF"
+    source_dir.mkdir(parents=True)
+    gone = source_dir / "OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc"
+    kept = source_dir / "OBS_CERES-EBAF_sat_Ed4.2_Amon_rsut_200003-202311.nc"
+    gone.touch()
+    kept.touch()
+
+    reference_data_dir = tmp_path / "reference_data"
+    prepare_reference_data(pd.DataFrame({"path": [str(gone)]}), reference_data_dir)
+
+    # The first run's source disappears, leaving a dangling symlink behind.
+    gone.unlink()
+    laid_out = reference_data_dir / "OBS" / "Tier2" / "CERES-EBAF"
+    assert (laid_out / gone.name).is_symlink()
+
+    # A second run over the same directory sweeps it, and relinking an unchanged
+    # file replaces the existing symlink rather than failing.
+    prepare_reference_data(
+        pd.DataFrame({"path": [str(kept), str(kept)]}),
+        reference_data_dir,
+    )
+
+    assert not (laid_out / gone.name).exists()
+    assert not (laid_out / gone.name).is_symlink()
+    assert (laid_out / kept.name).resolve() == kept.resolve()
+
+
 def test_prepare_reference_data_rejects_unknown_project(tmp_path):
     source = tmp_path / "source" / "somewhere" / "mystery.nc"
     source.parent.mkdir(parents=True)

--- a/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
@@ -7,6 +7,7 @@ from climate_ref_esmvaltool.recipe import (
     as_facets,
     get_child_and_parent_dataset,
     prepare_climate_data,
+    prepare_reference_data,
     rewrite_mip_for_cmip7,
 )
 
@@ -320,6 +321,69 @@ def test_prepare_climate_data(tmp_path, datasets, expected):
     for source_path, symlink in zip(datasets["path"], expected):
         assert Path(symlink).is_symlink()
         assert Path(symlink).resolve() == Path(source_path).resolve()
+
+
+def test_prepare_reference_data(tmp_path):
+    # Each source path sits under a project anchor (OBS/native6/obs4MIPs).
+    # OBS6 data lives under the OBS directory, so its anchor is OBS too.
+    rel_paths = [
+        "ESMValTool/OBS/Tier2/CERES-EBAF/OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc",
+        "ESMValTool/OBS/Tier2/TROPFLUX/OBS6_TROPFLUX_reanaly_v1_Omon_tos_197901-201812.nc",
+        "ESMValTool/native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc",
+        "ESMValTool/obs4MIPs/GPCP-V2-3/v20250101/pr_mon_GPCP-V2-3_gn_200001-200012.nc",
+    ]
+    expected_rel = [
+        "OBS/Tier2/CERES-EBAF/OBS_CERES-EBAF_sat_Ed4.2_Amon_rlut_200003-202311.nc",
+        "OBS/Tier2/TROPFLUX/OBS6_TROPFLUX_reanaly_v1_Omon_tos_197901-201812.nc",
+        "native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc",
+        "obs4MIPs/GPCP-V2-3/v20250101/pr_mon_GPCP-V2-3_gn_200001-200012.nc",
+    ]
+
+    source_data_dir = tmp_path / "source_data"
+    source_paths = [source_data_dir / rel for rel in rel_paths]
+    for path in source_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+
+    datasets = pd.DataFrame({"path": [str(p) for p in source_paths]})
+    reference_data_dir = tmp_path / "reference_data"
+
+    prepare_reference_data(datasets, reference_data_dir)
+
+    for source_path, rel in zip(source_paths, expected_rel):
+        symlink = reference_data_dir / rel
+        assert symlink.is_symlink()
+        assert symlink.resolve() == source_path.resolve()
+
+
+def test_prepare_reference_data_rejects_unknown_project(tmp_path):
+    source = tmp_path / "source" / "somewhere" / "mystery.nc"
+    source.parent.mkdir(parents=True)
+    source.touch()
+
+    datasets = pd.DataFrame({"path": [str(source)]})
+    reference_data_dir = tmp_path / "reference_data"
+
+    # ESMValCore could never find such a file, so laying out a partial tree would
+    # fail later with a much less obvious error.
+    with pytest.raises(ValueError, match="not under a known ESMValTool reference project"):
+        prepare_reference_data(datasets, reference_data_dir)
+
+
+def test_prepare_reference_data_anchors_on_the_last_project_directory(tmp_path):
+    # A data root that itself contains a directory named after a project must not
+    # truncate the DRS path at the root instead of at the real anchor.
+    rel = "OBS/store/native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc"
+    source = tmp_path / rel
+    source.parent.mkdir(parents=True)
+    source.touch()
+
+    reference_data_dir = tmp_path / "reference_data"
+    prepare_reference_data(pd.DataFrame({"path": [str(source)]}), reference_data_dir)
+
+    symlink = reference_data_dir / "native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc"
+    assert symlink.is_symlink()
+    assert symlink.resolve() == source.resolve()
 
 
 def _cmip7_recipe(diagnostic):

--- a/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
+++ b/packages/climate-ref-esmvaltool/tests/unit/test_recipe.py
@@ -370,7 +370,7 @@ def test_prepare_reference_data_rejects_unknown_project(tmp_path):
         prepare_reference_data(datasets, reference_data_dir)
 
 
-def test_prepare_reference_data_anchors_on_the_last_project_directory(tmp_path):
+def test_prepare_reference_data_ignores_an_anchor_in_the_data_root(tmp_path):
     # A data root that itself contains a directory named after a project must not
     # truncate the DRS path at the root instead of at the real anchor.
     rel = "OBS/store/native6/Tier3/ERA5/v1/mon/tas/era5_tas_1980_monthly.nc"

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_catalog.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_catalog.py
@@ -120,14 +120,7 @@ def _fetch_and_build_catalog(
     :
         Tuple of (datasets, catalog_was_written)
     """
-    from climate_ref.datasets import (
-        CMIP6DatasetAdapter,
-        CMIP7DatasetAdapter,
-        ESMValToolReferenceDatasetAdapter,
-        Obs4MIPsDatasetAdapter,
-        Obs4REFDatasetAdapter,
-        PMPClimatologyDatasetAdapter,
-    )
+    from climate_ref.datasets import get_dataset_adapter
     from climate_ref_core.datasets import SourceDatasetType
     from climate_ref_core.esgf import ESGFFetcher
     from climate_ref_core.testing import TestCasePaths, save_datasets_to_yaml
@@ -146,29 +139,14 @@ def _fetch_and_build_catalog(
     data_catalog: dict[SourceDatasetType, pd.DataFrame] = {}
 
     for source_type, group_df in combined.groupby("source_type"):
+        # Requests name a source type by its enum name, adapters are keyed by its value.
+        # An unrecognised name is skipped, and falls out as the "no datasets" error below.
+        if source_type not in SourceDatasetType.__members__:
+            continue
+
         file_paths = [Path(p) for p in group_df["path"].unique().tolist()]
-
-        if source_type == "CMIP6":
-            data_catalog[SourceDatasetType.CMIP6] = _build_catalog(CMIP6DatasetAdapter(), file_paths)
-
-        elif source_type == "CMIP7":
-            data_catalog[SourceDatasetType.CMIP7] = _build_catalog(CMIP7DatasetAdapter(), file_paths)
-
-        elif source_type == "obs4MIPs":
-            data_catalog[SourceDatasetType.obs4MIPs] = _build_catalog(Obs4MIPsDatasetAdapter(), file_paths)
-
-        elif source_type == "PMPClimatology":
-            data_catalog[SourceDatasetType.PMPClimatology] = _build_catalog(
-                PMPClimatologyDatasetAdapter(), file_paths
-            )
-
-        elif source_type == "obs4REF":
-            data_catalog[SourceDatasetType.obs4REF] = _build_catalog(Obs4REFDatasetAdapter(), file_paths)
-
-        elif source_type == "ESMValToolReference":
-            data_catalog[SourceDatasetType.ESMValToolReference] = _build_catalog(
-                ESMValToolReferenceDatasetAdapter(), file_paths
-            )
+        source = SourceDatasetType[str(source_type)]
+        data_catalog[source] = _build_catalog(get_dataset_adapter(source.value), file_paths)
 
     if not data_catalog:
         raise DatasetResolutionError(

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_catalog.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_catalog.py
@@ -123,6 +123,7 @@ def _fetch_and_build_catalog(
     from climate_ref.datasets import (
         CMIP6DatasetAdapter,
         CMIP7DatasetAdapter,
+        ESMValToolReferenceDatasetAdapter,
         Obs4MIPsDatasetAdapter,
         Obs4REFDatasetAdapter,
         PMPClimatologyDatasetAdapter,
@@ -163,6 +164,11 @@ def _fetch_and_build_catalog(
 
         elif source_type == "obs4REF":
             data_catalog[SourceDatasetType.obs4REF] = _build_catalog(Obs4REFDatasetAdapter(), file_paths)
+
+        elif source_type == "ESMValToolReference":
+            data_catalog[SourceDatasetType.ESMValToolReference] = _build_catalog(
+                ESMValToolReferenceDatasetAdapter(), file_paths
+            )
 
     if not data_catalog:
         raise DatasetResolutionError(

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_catalog.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_catalog.py
@@ -6,9 +6,6 @@ These turn a diagnostic's test-data requests into a solved
 input catalog YAML next to the test case.
 """
 
-# ``from __future__ import annotations`` keeps the heavy signature types
-# (pandas, dataset adapters, diagnostics) under ``TYPE_CHECKING`` so importing
-# this module -- which happens on every ``ref`` invocation -- stays cheap.
 from __future__ import annotations
 
 from pathlib import Path

--- a/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
+++ b/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
@@ -31,10 +31,7 @@ from climate_ref.datasets.utils import (
     parse_drs_daterange,
 )
 from climate_ref.models.dataset import Dataset, ESMValToolReferenceDataset
-
-# Top-level ESMValTool reference project directories (relative to the ``ESMValTool`` data root).
-# ``OBS6`` data lives under the ``OBS`` directory. The project is recovered from the filename.
-_PROJECT_ANCHORS = ("OBS", "native6", "obs4MIPs")
+from climate_ref_core.esmvaltool_reference import relative_parts
 
 _SLUG_PREFIX = "esmvaltool-reference"
 
@@ -132,14 +129,7 @@ def parse_esmvaltool_reference(file: str, **kwargs: Any) -> dict[str, Any]:
     """
     try:
         path = Path(file)
-        parts = path.parts
-
-        anchor_idx = next((i for i, part in enumerate(parts) if part in _PROJECT_ANCHORS), None)
-        if anchor_idx is None:
-            raise ValueError(
-                f"{file} is not under a known ESMValTool reference project ({', '.join(_PROJECT_ANCHORS)})"
-            )
-        rel = parts[anchor_idx:]
+        rel = relative_parts(path)
         anchor = rel[0]
 
         if anchor == "OBS":

--- a/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
+++ b/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
@@ -31,7 +31,7 @@ from climate_ref.datasets.utils import (
     parse_drs_daterange,
 )
 from climate_ref.models.dataset import Dataset, ESMValToolReferenceDataset
-from climate_ref_core.esmvaltool_reference import relative_parts
+from climate_ref_core.esmvaltool_reference import drs_relative_parts
 
 _SLUG_PREFIX = "esmvaltool-reference"
 
@@ -129,7 +129,7 @@ def parse_esmvaltool_reference(file: str, **kwargs: Any) -> dict[str, Any]:
     """
     try:
         path = Path(file)
-        rel = relative_parts(path)
+        rel = drs_relative_parts(path)
         anchor = rel[0]
 
         if anchor == "OBS":

--- a/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
+++ b/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
@@ -31,7 +31,7 @@ from climate_ref.datasets.utils import (
     parse_drs_daterange,
 )
 from climate_ref.models.dataset import Dataset, ESMValToolReferenceDataset
-from climate_ref_core.esmvaltool_reference import drs_relative_parts
+from climate_ref_core.esmvaltool_reference import drs_relative_parts, matches_project_layout
 
 _SLUG_PREFIX = "esmvaltool-reference"
 
@@ -75,8 +75,6 @@ def _parse_obs(rel: tuple[str, ...], filename: str) -> dict[str, Any]:
 
 def _parse_native6(rel: tuple[str, ...]) -> dict[str, Any]:
     # rel == ("native6", "Tier{n}", "{dataset}", "{version}", "{frequency}", "{short_name}", filename)
-    if len(rel) < 7:  # noqa: PLR2004
-        raise ValueError(f"unexpected native6 path structure: {'/'.join(rel)}")
     tier = _tier_from_segment(rel[1])
     dataset, version, frequency, short_name = rel[2], rel[3], rel[4], rel[5]
     return {
@@ -95,8 +93,6 @@ def _parse_native6(rel: tuple[str, ...]) -> dict[str, Any]:
 
 def _parse_obs4mips(rel: tuple[str, ...], filename: str) -> dict[str, Any]:
     # rel == ("obs4MIPs", "{dataset}", "{version}", filename)
-    if len(rel) < 4:  # noqa: PLR2004
-        raise ValueError(f"unexpected obs4MIPs path structure: {'/'.join(rel)}")
     dataset, version = rel[1], rel[2]
     stem = filename[:-3] if filename.endswith(".nc") else filename
     tokens = stem.split("_")
@@ -131,6 +127,9 @@ def parse_esmvaltool_reference(file: str, **kwargs: Any) -> dict[str, Any]:
         path = Path(file)
         rel = drs_relative_parts(path)
         anchor = rel[0]
+
+        if not matches_project_layout(rel):
+            raise ValueError(f"unexpected {anchor} path structure: {'/'.join(rel)}")
 
         if anchor == "OBS":
             info = _parse_obs(rel, path.name)

--- a/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
+++ b/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
@@ -31,7 +31,7 @@ from climate_ref.datasets.utils import (
     parse_drs_daterange,
 )
 from climate_ref.models.dataset import Dataset, ESMValToolReferenceDataset
-from climate_ref_core.esmvaltool_reference import drs_relative_parts, matches_project_layout
+from climate_ref_core.esmvaltool_reference import drs_relative_parts, tier_from_segment
 
 _SLUG_PREFIX = "esmvaltool-reference"
 
@@ -39,16 +39,9 @@ _SLUG_PREFIX = "esmvaltool-reference"
 _INSTANCE_ID_FACETS = ("project", "source_id", "frequency", "variable_id", "version")
 
 
-def _tier_from_segment(segment: str) -> int | None:
-    """Parse ``Tier2`` -> ``2``, returning ``None`` if the segment is not a tier."""
-    if segment.startswith("Tier") and segment[4:].isdigit():
-        return int(segment[4:])
-    return None
-
-
 def _parse_obs(rel: tuple[str, ...], filename: str) -> dict[str, Any]:
     # rel == ("OBS", "Tier{n}", "{dataset}", ..., filename)
-    tier = _tier_from_segment(rel[1])
+    tier = tier_from_segment(rel[1])
     dataset = rel[2]
     stem = filename[:-3] if filename.endswith(".nc") else filename
     tokens = stem.split("_")
@@ -75,7 +68,7 @@ def _parse_obs(rel: tuple[str, ...], filename: str) -> dict[str, Any]:
 
 def _parse_native6(rel: tuple[str, ...]) -> dict[str, Any]:
     # rel == ("native6", "Tier{n}", "{dataset}", "{version}", "{frequency}", "{short_name}", filename)
-    tier = _tier_from_segment(rel[1])
+    tier = tier_from_segment(rel[1])
     dataset, version, frequency, short_name = rel[2], rel[3], rel[4], rel[5]
     return {
         "project": "native6",
@@ -127,9 +120,6 @@ def parse_esmvaltool_reference(file: str, **kwargs: Any) -> dict[str, Any]:
         path = Path(file)
         rel = drs_relative_parts(path)
         anchor = rel[0]
-
-        if not matches_project_layout(rel):
-            raise ValueError(f"unexpected {anchor} path structure: {'/'.join(rel)}")
 
         if anchor == "OBS":
             info = _parse_obs(rel, path.name)

--- a/packages/climate-ref/src/climate_ref/solve_helpers.py
+++ b/packages/climate-ref/src/climate_ref/solve_helpers.py
@@ -107,9 +107,8 @@ def load_solve_catalog(catalog_dir: Path) -> dict[SourceDatasetType, pd.DataFram
     """
     Load parquet catalog files from a directory.
 
-    Looks for ``cmip6_catalog.parquet``, ``cmip7_catalog.parquet``,
-    ``obs4mips_catalog.parquet``, ``pmp_climatology_catalog.parquet``,
-    and ``obs4ref_catalog.parquet``.
+    The filename for each source type is given by ``catalog_files`` below.
+    Missing files are skipped, so a partial catalog directory loads what it has.
 
     Parameters
     ----------
@@ -130,6 +129,7 @@ def load_solve_catalog(catalog_dir: Path) -> dict[SourceDatasetType, pd.DataFram
         SourceDatasetType.obs4MIPs: "obs4mips_catalog.parquet",
         SourceDatasetType.PMPClimatology: "pmp_climatology_catalog.parquet",
         SourceDatasetType.obs4REF: "obs4ref_catalog.parquet",
+        SourceDatasetType.ESMValToolReference: "esmvaltool_reference_catalog.parquet",
     }
 
     result: dict[SourceDatasetType, pd.DataFrame] = {}

--- a/packages/climate-ref/src/climate_ref/solve_helpers.py
+++ b/packages/climate-ref/src/climate_ref/solve_helpers.py
@@ -107,7 +107,8 @@ def load_solve_catalog(catalog_dir: Path) -> dict[SourceDatasetType, pd.DataFram
     """
     Load parquet catalog files from a directory.
 
-    The filename for each source type is given by ``catalog_files`` below.
+    Reads one parquet file per source type, named after the source type,
+    such as ``cmip6_catalog.parquet`` or ``esmvaltool_reference_catalog.parquet``.
     Missing files are skipped, so a partial catalog directory loads what it has.
 
     Parameters

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -21,6 +21,7 @@ from climate_ref.database import Database
 from climate_ref.datasets import (
     CMIP6DatasetAdapter,
     CMIP7DatasetAdapter,
+    ESMValToolReferenceDatasetAdapter,
     Obs4MIPsDatasetAdapter,
     Obs4REFDatasetAdapter,
     PMPClimatologyDatasetAdapter,
@@ -507,6 +508,9 @@ class ExecutionSolver:
                     database=db, adapter=PMPClimatologyDatasetAdapter()
                 ),
                 SourceDatasetType.obs4REF: DataCatalog(database=db, adapter=Obs4REFDatasetAdapter()),
+                SourceDatasetType.ESMValToolReference: DataCatalog(
+                    database=db, adapter=ESMValToolReferenceDatasetAdapter()
+                ),
             },
         )
 

--- a/packages/climate-ref/tests/unit/datasets/test_esmvaltool_reference.py
+++ b/packages/climate-ref/tests/unit/datasets/test_esmvaltool_reference.py
@@ -85,6 +85,13 @@ def test_parse_rejects_unknown_layout():
     assert result["INVALID_ASSET"] == "/root/somewhere/random.nc"
 
 
+def test_parse_rejects_a_path_that_does_not_fit_its_project_layout():
+    # A native6 path that is too shallow to carry the full DRS is flagged rather than
+    # read with whatever components happen to be present.
+    result = parse_esmvaltool_reference("/root/ESMValTool/native6/Tier3/ERA5/v1/tas.nc")
+    assert "INVALID_ASSET" in result
+
+
 def test_parse_rejects_malformed_obs_filename():
     result = parse_esmvaltool_reference("/root/ESMValTool/OBS/Tier2/FOO/OBS_FOO_sat.nc")
     assert "INVALID_ASSET" in result

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -89,6 +89,11 @@ class TestMetricSolver:
         assert SourceDatasetType.obs4REF in solver.data_catalog
         assert isinstance(solver.data_catalog[SourceDatasetType.obs4REF], DataCatalog)
 
+    def test_solver_build_from_db_includes_esmvaltool_reference(self, solver):
+        """``build_from_db`` must wire up ESMValToolReference, or it is a silently dead type."""
+        assert SourceDatasetType.ESMValToolReference in solver.data_catalog
+        assert isinstance(solver.data_catalog[SourceDatasetType.ESMValToolReference], DataCatalog)
+
     def test_build_from_db_refreshes_ignore_datasets(self, config, db_seeded, mocker):
         refresh_mock = mocker.patch("climate_ref.solver.refresh_ignore_datasets_file")
 
@@ -901,6 +906,38 @@ def test_solve_metric_executions_obs4ref(solver, mock_diagnostic, provider):
         "REF-OBS-A",
         "REF-OBS-B",
     }
+
+
+def test_solve_metric_executions_esmvaltool_reference(solver, mock_diagnostic, provider):
+    """A diagnostic with an ESMValToolReference ``DataRequirement`` resolves against the catalog.
+
+    Filtering and grouping behave like any other reference source type.
+    """
+    metric = mock_diagnostic
+    metric.data_requirements = (
+        DataRequirement(
+            source_type=SourceDatasetType.ESMValToolReference,
+            filters=(FacetFilter(facets={"variable_id": "tas"}),),
+            group_by=("project", "source_id"),
+        ),
+    )
+
+    data_catalog = {
+        SourceDatasetType.ESMValToolReference: pd.DataFrame(
+            {
+                "project": ["native6", "OBS6", "native6"],
+                "source_id": ["ERA5", "CERES-EBAF", "ERA5"],
+                "variable_id": ["tas", "tas", "pr"],
+                "frequency": ["mon", "mon", "mon"],
+            }
+        ),
+    }
+    executions = list(solve_executions(data_catalog, metric, provider))
+    assert len(executions) == 2
+    selectors = {
+        dict(e.datasets[SourceDatasetType.ESMValToolReference].selector)["source_id"] for e in executions
+    }
+    assert selectors == {"ERA5", "CERES-EBAF"}
 
 
 def test_solve_metric_executions_multiple_sets(solver, mock_diagnostic, provider):

--- a/scripts/generate_esgf_catalog.py
+++ b/scripts/generate_esgf_catalog.py
@@ -43,6 +43,13 @@ def main() -> None:
         help="Directory containing PMP climatology data (can be specified multiple times)",
     )
     parser.add_argument(
+        "--esmvaltool-reference-dir",
+        type=Path,
+        action="append",
+        default=[],
+        help="Directory containing ESMValTool reference data (can be specified multiple times)",
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
         required=True,
@@ -79,6 +86,15 @@ def main() -> None:
             "pmp-climatology", args.pmp_climatology_dir, strip_path_prefix=args.strip_prefix
         )
         out_path = output_dir / "pmp_climatology_catalog.parquet"
+        write_catalog_parquet(catalog, out_path)
+        print(f"  Wrote {len(catalog)} rows to {out_path}")
+
+    if args.esmvaltool_reference_dir:
+        print(f"Scanning ESMValTool reference directories: {args.esmvaltool_reference_dir}")
+        catalog = generate_catalog(
+            "esmvaltool-reference", args.esmvaltool_reference_dir, strip_path_prefix=args.strip_prefix
+        )
+        out_path = output_dir / "esmvaltool_reference_catalog.parquet"
         write_catalog_parquet(catalog, out_path)
         print(f"  Wrote {len(catalog)} rows to {out_path}")
 


### PR DESCRIPTION
Adds solve-time selection of ESMValTool reference data. Diagnostics can now request ESMValTool observational and reanalysis datasets the same way they request other reference data, so a request resolves against the tracked catalog instead of reaching for the whole downloaded registry.

Building on #815, which ingested this data for provenance only.

- Wires `SourceDatasetType.ESMValToolReference` into `ExecutionSolver.build_from_db` and into the parquet solve catalog, so an `esmvaltool-reference` `DataRequirement` filters and groups like any other source type.
- Adds `prepare_reference_data`, which symlinks the selected files into an ESMValCore DRS tree under `reference_data` and points the OBS/OBS6/native6/obs4MIPs rootpaths at it.
- A diagnostic that does not declare the requirement is unchanged and still gets the whole registry.
- An opt-in diagnostic that selects no files now fails instead of warning. Carrying on left ESMValCore to fall back on its own default rootpaths and run the recipe against whatever it found there.
- Moves the DRS anchor logic into `climate_ref_core.esmvaltool_reference`, shared by the ingest adapter and the diagnostic runner so the two cannot drift apart.
- Adds `--esmvaltool-reference-dir` to `scripts/generate_esgf_catalog.py`.

Anchor detection is the fiddly part. A path is matched against the full shape of each project rather than the first or last directory whose name happens to be `OBS`, `native6` or `obs4MIPs`, because a data root may contain such a directory and so may a dataset directory inside the tree. All 165 paths in the registry resolve exactly as they do on `main`.

No diagnostic declares the new requirement yet, so this adds the capability without changing any existing run. The layout and solve paths are covered by unit tests in the meantime.

Two known gaps, both waiting on a first adopter:

- Minting a baseline for an opt-in diagnostic is not yet possible. The test case catalog builder handles the new source type, but `RegistryRequest._get_parser` has no branch for the ESMValTool registry, so the fetch side returns nothing.
- Latest-version filtering still applies, so within a single dataset group a version like `L3B` loses to one like `v1`. Versions that share a scheme are unaffected, and the common ESMValTool forms (`Ed4.1` vs `Ed4.2`) both stay selectable. Changing it means turning off version dedup for this source type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostics can now request selected ESMValTool observational and reanalysis reference datasets.
  * Runs use only the solver-selected reference files, reducing unnecessary data preparation.
  * Added catalog generation support for ESMValTool reference data.

* **Bug Fixes**
  * Improved handling and validation of ESMValTool reference-data paths and layouts.
  * Invalid or empty reference-data selections now produce clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->