### PR TITLE
Rework how the CVs and grey list are distributed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,13 @@ repos:
       - id: trailing-whitespace
   - repo: local
     hooks:
+      # Keep the packaged copy of the grey list identical to the canonical one
+      - id: sync-grey-list
+        name: sync grey list into the climate_ref package
+        entry: python scripts/sync_grey_list.py
+        language: system
+        pass_filenames: false
+        files: "^(default_ignore_datasets\\.yaml|packages/climate-ref/src/climate_ref/default_ignore_datasets\\.yaml)$"
       # Prevent committing .rej files
       - id: forbidden-files
         name: forbidden files

--- a/changelog/840.fix.md
+++ b/changelog/840.fix.md
@@ -1,0 +1,9 @@
+Stops `climate_ref_pmp` downloading micromamba while the provider registry is built.
+
+`PMPDiagnosticProvider.configure` resolved its conda executable eagerly,
+which downloaded micromamba when it was missing or more than a week old.
+`configure` runs whenever the provider registry is built, so that download sat on the solve path
+and a solve on a host with no outbound network access failed there.
+
+It now records where the executable will be, using the new `CondaDiagnosticProvider.conda_exe_path`.
+The download stays in `ref providers setup`, and in the execute path that already installs on demand.

--- a/changelog/840.improvement.md
+++ b/changelog/840.improvement.md
@@ -7,32 +7,16 @@ Both now work on read-only filesystems and in air-gapped deployments.
 - The packaged copy is now the floor for both files,
   so neither the network nor a writable cache is needed to run.
 - `paths.dimensions_cv` and `ignore_datasets_file` are now optional.
-  Leaving them unset uses the packaged copy,
-  and no site-packages path is written into the saved configuration.
+  Leaving them unset uses the packaged copy.
 - A failed grey list refresh is no longer fatal.
   An unreachable network, an HTTP error and an unwritable cache
   all fall back to the cached or packaged copy with a warning.
-- The cached grey list is now written atomically,
-  so an interrupted download cannot leave a truncated file that shadows the packaged copy.
 - A cached grey list that has not been refreshed for 30 days is ignored in favour of the packaged copy.
 - The grey list cache moved under `REF_DATASET_CACHE_DIR`,
   so it shares one cache root with the dataset registries.
   The copy in the old location is left in place and is no longer read.
-- Earlier releases wrote the grey list cache path into every saved `ref.toml` as a default.
-  That inherited value is now cleared when the configuration is loaded,
-  so an upgraded installation is not pinned to a stale cache
-  and the value is not written out again.
 - `paths.dimensions_cv` is now resolved to an absolute path like every other path field,
   rather than being left relative.
-- Package data is now read through `importlib.resources` rather than `Path(str(...))`,
-  which was only correct for an install unpacked on disk.
 - Reading the configuration no longer imports the diagnostic bundle parsing machinery,
   so `climate_ref.config` no longer pulls in numpy and pydantic.
-- Adds `python -m climate_ref_core.pycmec.controlled_vocabulary`,
-  which writes the bundled controlled vocabulary to stdout
-  as the starting point for a custom one.
-- Adds a packaging test covering every data file the REF reads out of a package,
-  and a pre-commit hook that keeps the packaged grey list identical to the canonical copy.
-- Adds `tests/unit/test_offline.py`, which blocks outbound sockets rather than mocking
-  `requests`, so a call from any library is caught.
 - Removes `IgnoreDatasetsRefreshError`, which nothing raises any more.

--- a/changelog/840.improvement.md
+++ b/changelog/840.improvement.md
@@ -1,10 +1,15 @@
-Reworks how the controlled vocabulary and the grey list are distributed so they resolve the same way and work on read-only filesystems and in air-gapped deployments.
+Reworks how the controlled vocabulary and the grey list are distributed.
+Both now resolve the same way, and both work on read-only filesystems and in air-gapped deployments.
 
 - Adds `climate_ref_core.data` with `PackagedResource` and `LayeredResource`, which resolve a data file across an operator override, a local cache and the copy shipped in the package.
 - The packaged copy is now the floor for both files, so neither the network nor a writable cache is needed to run.
 - `paths.dimensions_cv` and `ignore_datasets_file` are now optional. Leaving them unset uses the packaged copy, and no site-packages path is written into the saved configuration.
 - A failed grey list refresh is no longer fatal. An unreachable network, an HTTP error and an unwritable cache all fall back to the cached or packaged copy with a warning.
-- The grey list cache moved under `REF_DATASET_CACHE_DIR`, so it shares one cache root with the dataset registries instead of using a second one.
+- The cached grey list is now written atomically, so an interrupted download cannot leave a truncated file that shadows the packaged copy.
+- A cached grey list that has not been refreshed for 30 days is ignored in favour of the packaged copy.
+- The grey list cache moved under `REF_DATASET_CACHE_DIR`, so it shares one cache root with the dataset registries. The copy in the old location is left in place and is no longer read.
+- Earlier releases wrote the grey list cache path into every saved `ref.toml` as a default. That inherited value is now recognised and ignored, so an upgraded installation is not pinned to a stale cache.
 - Package data is now read through `importlib.resources` rather than `Path(str(...))`, which was only correct for an install unpacked on disk.
+- Adds `python -m climate_ref_core.pycmec.controlled_vocabulary`, which writes the bundled controlled vocabulary to stdout as the starting point for a custom one.
 - Adds a packaging test covering every data file the REF reads out of a package, and a pre-commit hook that keeps the packaged grey list identical to the canonical copy at the repository root.
 - Removes `IgnoreDatasetsRefreshError`, which nothing raises any more.

--- a/changelog/840.improvement.md
+++ b/changelog/840.improvement.md
@@ -1,15 +1,31 @@
 Reworks how the controlled vocabulary and the grey list are distributed.
-Both now resolve the same way, and both work on read-only filesystems and in air-gapped deployments.
+Both now resolve the same way.
+Both now work on read-only filesystems and in air-gapped deployments.
 
-- Adds `climate_ref_core.data` with `PackagedResource` and `LayeredResource`, which resolve a data file across an operator override, a local cache and the copy shipped in the package.
-- The packaged copy is now the floor for both files, so neither the network nor a writable cache is needed to run.
-- `paths.dimensions_cv` and `ignore_datasets_file` are now optional. Leaving them unset uses the packaged copy, and no site-packages path is written into the saved configuration.
-- A failed grey list refresh is no longer fatal. An unreachable network, an HTTP error and an unwritable cache all fall back to the cached or packaged copy with a warning.
-- The cached grey list is now written atomically, so an interrupted download cannot leave a truncated file that shadows the packaged copy.
+- Adds `climate_ref_core.data` with `PackagedResource` and `LayeredResource`.
+  These resolve a data file across an operator override, a local cache and the copy shipped in the package.
+- The packaged copy is now the floor for both files,
+  so neither the network nor a writable cache is needed to run.
+- `paths.dimensions_cv` and `ignore_datasets_file` are now optional.
+  Leaving them unset uses the packaged copy,
+  and no site-packages path is written into the saved configuration.
+- A failed grey list refresh is no longer fatal.
+  An unreachable network, an HTTP error and an unwritable cache
+  all fall back to the cached or packaged copy with a warning.
+- The cached grey list is now written atomically,
+  so an interrupted download cannot leave a truncated file that shadows the packaged copy.
 - A cached grey list that has not been refreshed for 30 days is ignored in favour of the packaged copy.
-- The grey list cache moved under `REF_DATASET_CACHE_DIR`, so it shares one cache root with the dataset registries. The copy in the old location is left in place and is no longer read.
-- Earlier releases wrote the grey list cache path into every saved `ref.toml` as a default. That inherited value is now recognised and ignored, so an upgraded installation is not pinned to a stale cache.
-- Package data is now read through `importlib.resources` rather than `Path(str(...))`, which was only correct for an install unpacked on disk.
-- Adds `python -m climate_ref_core.pycmec.controlled_vocabulary`, which writes the bundled controlled vocabulary to stdout as the starting point for a custom one.
-- Adds a packaging test covering every data file the REF reads out of a package, and a pre-commit hook that keeps the packaged grey list identical to the canonical copy at the repository root.
+- The grey list cache moved under `REF_DATASET_CACHE_DIR`,
+  so it shares one cache root with the dataset registries.
+  The copy in the old location is left in place and is no longer read.
+- Earlier releases wrote the grey list cache path into every saved `ref.toml` as a default.
+  That inherited value is now recognised and ignored,
+  so an upgraded installation is not pinned to a stale cache.
+- Package data is now read through `importlib.resources` rather than `Path(str(...))`,
+  which was only correct for an install unpacked on disk.
+- Adds `python -m climate_ref_core.pycmec.controlled_vocabulary`,
+  which writes the bundled controlled vocabulary to stdout
+  as the starting point for a custom one.
+- Adds a packaging test covering every data file the REF reads out of a package,
+  and a pre-commit hook that keeps the packaged grey list identical to the canonical copy.
 - Removes `IgnoreDatasetsRefreshError`, which nothing raises any more.

--- a/changelog/840.improvement.md
+++ b/changelog/840.improvement.md
@@ -33,4 +33,6 @@ Both now work on read-only filesystems and in air-gapped deployments.
   as the starting point for a custom one.
 - Adds a packaging test covering every data file the REF reads out of a package,
   and a pre-commit hook that keeps the packaged grey list identical to the canonical copy.
+- Adds `tests/unit/test_offline.py`, which blocks outbound sockets rather than mocking
+  `requests`, so a call from any library is caught.
 - Removes `IgnoreDatasetsRefreshError`, which nothing raises any more.

--- a/changelog/840.improvement.md
+++ b/changelog/840.improvement.md
@@ -1,0 +1,10 @@
+Reworks how the controlled vocabulary and the grey list are distributed so they resolve the same way and work on read-only filesystems and in air-gapped deployments.
+
+- Adds `climate_ref_core.data` with `PackagedResource` and `LayeredResource`, which resolve a data file across an operator override, a local cache and the copy shipped in the package.
+- The packaged copy is now the floor for both files, so neither the network nor a writable cache is needed to run.
+- `paths.dimensions_cv` and `ignore_datasets_file` are now optional. Leaving them unset uses the packaged copy, and no site-packages path is written into the saved configuration.
+- A failed grey list refresh is no longer fatal. An unreachable network, an HTTP error and an unwritable cache all fall back to the cached or packaged copy with a warning.
+- The grey list cache moved under `REF_DATASET_CACHE_DIR`, so it shares one cache root with the dataset registries instead of using a second one.
+- Package data is now read through `importlib.resources` rather than `Path(str(...))`, which was only correct for an install unpacked on disk.
+- Adds a packaging test covering every data file the REF reads out of a package, and a pre-commit hook that keeps the packaged grey list identical to the canonical copy at the repository root.
+- Removes `IgnoreDatasetsRefreshError`, which nothing raises any more.

--- a/changelog/840.improvement.md
+++ b/changelog/840.improvement.md
@@ -19,10 +19,15 @@ Both now work on read-only filesystems and in air-gapped deployments.
   so it shares one cache root with the dataset registries.
   The copy in the old location is left in place and is no longer read.
 - Earlier releases wrote the grey list cache path into every saved `ref.toml` as a default.
-  That inherited value is now recognised and ignored,
-  so an upgraded installation is not pinned to a stale cache.
+  That inherited value is now cleared when the configuration is loaded,
+  so an upgraded installation is not pinned to a stale cache
+  and the value is not written out again.
+- `paths.dimensions_cv` is now resolved to an absolute path like every other path field,
+  rather than being left relative.
 - Package data is now read through `importlib.resources` rather than `Path(str(...))`,
   which was only correct for an install unpacked on disk.
+- Reading the configuration no longer imports the diagnostic bundle parsing machinery,
+  so `climate_ref.config` no longer pulls in numpy and pydantic.
 - Adds `python -m climate_ref_core.pycmec.controlled_vocabulary`,
   which writes the bundled controlled vocabulary to stdout
   as the starting point for a custom one.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,8 +131,8 @@ The grey list is a YAML file listing facets to exclude per provider, diagnostic 
 !!! note "Naming"
 
     The configuration values below are currently named `ignore_datasets_*` for historical reasons.
-    They will be renamed to `grey_list_*` in a future release;
-    the old names will continue to work for a deprecation period.
+    They will be renamed to `grey_list_*` in a future release.
+    The old names will continue to work for a deprecation period.
 
 The grey list is resolved from the first of three layers that is available:
 
@@ -145,11 +145,11 @@ so a solve never depends on the network or on a writable filesystem.
 
 Two configuration values control this behaviour:
 
-* `ignore_datasets_file` (env `REF_IGNORE_DATASETS_FILE`) —
+* `ignore_datasets_file` (env `REF_IGNORE_DATASETS_FILE`):
   a path to a grey list you manage yourself.
   Leave it unset to use the packaged copy.
   Setting it also disables fetching, because an explicit file is yours to manage.
-* `ignore_datasets_url` (env `REF_IGNORE_DATASETS_URL`) —
+* `ignore_datasets_url` (env `REF_IGNORE_DATASETS_URL`):
   the URL the grey list is refreshed from.
   It defaults to the copy served from the `main` branch of the Climate-REF repository.
 
@@ -164,6 +164,10 @@ An unreachable network, an unwritable cache directory, and an HTTP error are all
 The solve logs a warning and falls back to the cached copy if there is one,
 and to the packaged copy otherwise.
 Each provider logs which layer it read the grey list from at debug level.
+
+A cached copy that has not been refreshed for 30 days is ignored in favour of the packaged copy.
+Without that bound, a cache left behind by an older release would shadow the newer packaged
+copy indefinitely on a host that can never reach the network.
 
 ### Offline and air-gapped deployments
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,7 @@ Without that bound,
 a cache left behind by an older release would shadow the newer packaged copy indefinitely
 on a host that can never reach the network.
 On such a host the cache can still shadow a newer packaged copy for up to 30 days after an upgrade.
-Set `REF_IGNORE_DATASETS_URL=` to skip the refresh entirely and always read the packaged copy.
+Delete the cached file to read the packaged copy immediately.
 
 ### Offline and air-gapped deployments
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,8 +166,11 @@ and to the packaged copy otherwise.
 Each provider logs which layer it read the grey list from at debug level.
 
 A cached copy that has not been refreshed for 30 days is ignored in favour of the packaged copy.
-Without that bound, a cache left behind by an older release would shadow the newer packaged
-copy indefinitely on a host that can never reach the network.
+Without that bound,
+a cache left behind by an older release would shadow the newer packaged copy indefinitely
+on a host that can never reach the network.
+On such a host the cache can still shadow a newer packaged copy for up to 30 days after an upgrade.
+Set `REF_IGNORE_DATASETS_URL=` to skip the refresh entirely and always read the packaged copy.
 
 ### Offline and air-gapped deployments
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,6 @@ log = "${REF_CONFIGURATION}/log"
 scratch = "${REF_CONFIGURATION}/scratch"
 software = "${REF_CONFIGURATION}/software"
 results = "${REF_CONFIGURATION}/results"
-dimensions_cv = "${REF_INSTALLATION_DIR}/packages/climate-ref-core/src/climate_ref_core/pycmec/cv_cmip7_aft.yaml"
 
 [db]
 database_url = "sqlite:///${REF_CONFIGURATION}/db/climate_ref.db"
@@ -135,41 +134,51 @@ The grey list is a YAML file listing facets to exclude per provider, diagnostic 
     They will be renamed to `grey_list_*` in a future release;
     the old names will continue to work for a deprecation period.
 
+The grey list is resolved from the first of three layers that is available:
+
+1. `ignore_datasets_file`, if it is set.
+2. A copy refreshed from `ignore_datasets_url` into the local cache.
+3. The copy shipped inside the `climate_ref` package.
+
+The third layer is always available,
+so a solve never depends on the network or on a writable filesystem.
+
 Two configuration values control this behaviour:
 
 * `ignore_datasets_file` (env `REF_IGNORE_DATASETS_FILE`) —
-  the path to the grey list file.
-  It defaults to a location under the user cache directory
-  and is coerced to a filesystem path.
+  a path to a grey list you manage yourself.
+  Leave it unset to use the packaged copy.
+  Setting it also disables fetching, because an explicit file is yours to manage.
 * `ignore_datasets_url` (env `REF_IGNORE_DATASETS_URL`) —
-  the URL the grey list is fetched from.
-  It defaults to the copy shipped in the Climate-REF repository.
+  the URL the grey list is refreshed from.
+  It defaults to the copy served from the `main` branch of the Climate-REF repository.
 
-The grey list is fetched lazily during solving,
-not while the configuration is loaded.
-Read-only commands such as `ref providers list` and `ref datasets list` never perform network I/O.
+Refreshing happens lazily during solving, not while the configuration is loaded,
+so read-only commands such as `ref providers list` never perform network I/O.
 When a solve runs,
-the cached file is refreshed from `ignore_datasets_url` only if it is missing or older than six hours,
+the cached file is refreshed only if it is missing or older than six hours,
 so at most one download happens per six-hour window.
 
-If the download fails and a cached copy already exists,
-the cached copy is reused unchanged and a warning is logged.
-If the download fails and no cached copy exists,
-the solve fails with an error
-rather than silently running without the grey list protections.
+Refreshing is best effort.
+An unreachable network, an unwritable cache directory, and an HTTP error are all non-fatal.
+The solve logs a warning and falls back to the cached copy if there is one,
+and to the packaged copy otherwise.
+Each provider logs which layer it read the grey list from at debug level.
 
 ### Offline and air-gapped deployments
 
-On systems without outbound network access (for example an air-gapped HPC cluster),
-seed the grey list manually and disable fetching:
+Nothing needs to be configured.
+The grey list and the dimensions controlled vocabulary are both read straight out of the
+installed packages, so the REF runs with no outbound network access
+and on a read-only filesystem.
 
-1. Copy `default_ignore_datasets.yaml` to a writable location on the target system.
-2. Point `ignore_datasets_file` at that copy,
-   for example `REF_IGNORE_DATASETS_FILE=/shared/config/default_ignore_datasets.yaml`.
-3. Set `REF_IGNORE_DATASETS_URL=` (an empty string) to disable fetching entirely.
+On a host with no route to the internet,
+set `REF_IGNORE_DATASETS_URL=` (an empty string) to skip the refresh attempt.
+This avoids waiting for the request to time out on every solve.
+It changes nothing else, since a failed refresh already falls back to the packaged copy.
 
-With an empty URL the solver never touches the network
-and uses whatever grey list already exists at `ignore_datasets_file`.
+To pin the grey list to a version you control,
+point `REF_IGNORE_DATASETS_FILE` at your own copy.
 
 ## Configuration Options
 

--- a/docs/gen_config_stubs.py
+++ b/docs/gen_config_stubs.py
@@ -12,7 +12,6 @@ as a preview.
 from __future__ import annotations
 
 import ast
-import importlib.resources
 import inspect
 import os
 import textwrap
@@ -41,11 +40,6 @@ def _get_default_value(items: Sequence[str]) -> Any:
         value = getattr(value, item)
         if isinstance(value, list):
             value = value[0]
-
-    # We need to replace a path within the installation directory with a dummy values
-    ref_install_directory = str(importlib.resources.files("climate_ref_core.pycmec"))
-    if ref_install_directory in str(value):
-        return str(value).replace(ref_install_directory, "$REF_INSTALL_DIRECTORY")
 
     if "__REF_CONFIGURATION__" in str(value):
         return str(value).replace("/__REF_CONFIGURATION__", "$REF_CONFIGURATION")

--- a/docs/gen_config_stubs.py
+++ b/docs/gen_config_stubs.py
@@ -17,7 +17,8 @@ import os
 import textwrap
 from collections.abc import Sequence
 from itertools import pairwise
-from typing import Any, get_origin
+from types import UnionType
+from typing import Any, Union, get_args, get_origin
 
 import attrs
 import mkdocs_gen_files
@@ -136,6 +137,19 @@ def write_field_set(fh, field_parent_names: list[str], target: type[Any]) -> Non
         write_field_set(fh, [*field_parent_names, field.name], field_type)
 
 
+def _type_name(field_type: Any) -> str:
+    """
+    Render a field annotation for display.
+
+    Unions have no ``__name__``, so an optional field is rendered from its members.
+    """
+    if get_origin(field_type) in (UnionType, Union):
+        return " | ".join(_type_name(arg) for arg in get_args(field_type))
+    if field_type is type(None):
+        return "None"
+    return getattr(field_type, "__name__", str(field_type))
+
+
 def write_field(fh, field_parent_names: list[str], field, description: str) -> None:
     """
     Write a single field of the configuration.
@@ -158,7 +172,7 @@ def write_field(fh, field_parent_names: list[str], field, description: str) -> N
         default_value = _get_default_value([*field_parent_names, field.name])
         fh.write(f"**Default**: {default_value!r}\n\n")
 
-    fh.write(f"**Type**: `{field.type.__name__}`\n\n")
+    fh.write(f"**Type**: `{_type_name(field.type)}`\n\n")
 
     if field.metadata.get("env"):
         env_variable = f"{env_prefix}_{field.metadata.get('env')}"

--- a/docs/getting-started/01-configure.md
+++ b/docs/getting-started/01-configure.md
@@ -67,7 +67,6 @@ log = "$REF_CONFIGURATION/log"
 scratch = "$REF_CONFIGURATION/scratch"
 software = "$REF_CONFIGURATION/software"
 results = "$REF_CONFIGURATION/results"
-dimensions_cv = "$REF_INSTALL_DIR/climate-ref-core/src/climate_ref_core/pycmec/cv_cmip7_aft.yaml"
 
 [db]
 database_url = "sqlite:///$REF_CONFIGURATION/db/climate_ref.db"

--- a/docs/how-to-guides/adding_custom_diagnostics.md
+++ b/docs/how-to-guides/adding_custom_diagnostics.md
@@ -368,7 +368,7 @@ extend the controlled vocabulary in `climate-ref-core`:
 - Copy the default CV, which is shipped inside `climate_ref_core` and can be written out with:
 
 ```bash
-python -c "from climate_ref_core.pycmec.controlled_vocabulary import BUNDLED_CV; print(BUNDLED_CV.read_text())" > cv_custom.yaml
+python -m climate_ref_core.pycmec.controlled_vocabulary > cv_custom.yaml
 ```
 
   It is also visible on [GitHub](https://github.com/Climate-REF/climate-ref/blob/main/packages/climate-ref-core/src/climate_ref_core/pycmec/cv_cmip7_aft.yaml).

--- a/docs/how-to-guides/adding_custom_diagnostics.md
+++ b/docs/how-to-guides/adding_custom_diagnostics.md
@@ -150,7 +150,6 @@ class GlobalMeanTimeseries(Diagnostic):
 If your diagnostic must run in its own Conda environment,
 extend [CommandLineDiagnostic][climate_ref_core.diagnostics.CommandLineDiagnostic] instead.
 
-
 ## 4. Register your diagnostics
 
 In your package entry point (e.g. `__init__.py`), register all diagnostics:
@@ -192,7 +191,7 @@ These hooks are called by `ref providers setup` before any diagnostics are run.
 ### Available hooks
 
 | Hook | Purpose | When to use |
-|------|---------|-------------|
+| ------ | --------- | ------------- |
 | `setup_environment(config)` | Set up execution environment | Conda env creation, tool installation |
 | `fetch_data(config)` | Download required data | Reference datasets, auxiliary files |
 | `post_setup(config)` | Post-setup tasks | Tasks requiring both env and data |
@@ -204,11 +203,11 @@ All hooks receive the application `Config` object and **must be idempotent** (sa
 
 The REF provides several provider base classes depending on your needs:
 
-| Base Class | Use Case |
-|------------|----------|
-| `DiagnosticProvider` | Pure Python diagnostics, no special environment needed |
-| `CommandLineDiagnosticProvider` | Diagnostics that run via subprocess |
-| `CondaDiagnosticProvider` | Diagnostics requiring an isolated conda environment |
+| Base Class                      | Use Case                                               |
+| ------------------------------- | ------------------------------------------------------ |
+| `DiagnosticProvider`            | Pure Python diagnostics, no special environment needed |
+| `CommandLineDiagnosticProvider` | Diagnostics that run via subprocess                    |
+| `CondaDiagnosticProvider`       | Diagnostics requiring an isolated conda environment    |
 
 `CondaDiagnosticProvider` automatically implements `setup_environment()` to create conda environments.
 
@@ -366,7 +365,14 @@ Next time you run a `ref` command you should see your provider being added to th
 If your metrics use new facets in its metric output (e.g. custom experiment IDs or grid labels),
 extend the controlled vocabulary in `climate-ref-core`:
 
-- Copy the default CV (located in `packages/climate-ref-core/src/climate_ref_core/pycmec/cv_cmip7_aft.yaml` or on [GitHub](https://github.com/Climate-REF/climate-ref/blob/main/packages/climate-ref-core/src/climate_ref_core/pycmec/cv_cmip7_aft.yaml).
+- Copy the default CV, which is shipped inside `climate_ref_core` and can be written out with:
+
+```bash
+python -c "from climate_ref_core.pycmec.controlled_vocabulary import BUNDLED_CV; print(BUNDLED_CV.read_text())" > cv_custom.yaml
+```
+
+  It is also visible on [GitHub](https://github.com/Climate-REF/climate-ref/blob/main/packages/climate-ref-core/src/climate_ref_core/pycmec/cv_cmip7_aft.yaml).
+
 - Modify it to include your new facets or values.
 - Update your [configuration][paths_dimensions_cv] to point to your custom CV file:
 

--- a/packages/climate-ref-core/src/climate_ref_core/data.py
+++ b/packages/climate-ref-core/src/climate_ref_core/data.py
@@ -19,13 +19,15 @@ import importlib.resources
 import os
 import pathlib
 from collections.abc import Iterator
-from contextlib import contextmanager
-from typing import IO
+from contextlib import AbstractContextManager, contextmanager
+from typing import IO, Protocol, runtime_checkable
 
 import platformdirs
 from attrs import field, frozen
 
 from climate_ref_core.exceptions import RefException
+
+_RESOURCE_ERRORS = (ModuleNotFoundError, FileNotFoundError, OSError)
 
 
 class DataResourceError(RefException):
@@ -49,11 +51,35 @@ def resolve_cache_dir(cache_name: str) -> pathlib.Path:
         The resolved cache directory path.
     """
     if env_cache_dir := os.environ.get("REF_DATASET_CACHE_DIR"):
-        cache_dir = pathlib.Path(os.path.expandvars(env_cache_dir)).expanduser()
+        cache_dir = pathlib.Path(os.path.expandvars(env_cache_dir))
+        try:
+            cache_dir = cache_dir.expanduser()
+        except RuntimeError:
+            # An unresolvable ``~user`` is left as-is rather than failing the caller.
+            pass
     else:
         cache_dir = platformdirs.user_cache_path("climate_ref")
 
     return cache_dir / cache_name
+
+
+@runtime_checkable
+class Resource(Protocol):
+    """
+    A readable data file, wherever it happens to live
+    """
+
+    def exists(self) -> bool:
+        """Check whether the file can be read."""
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        """Read the file as text."""
+
+    def open_text(self, encoding: str = "utf-8") -> AbstractContextManager[IO[str]]:
+        """Open the file as a text stream."""
+
+    def as_path(self) -> AbstractContextManager[pathlib.Path]:
+        """Expose the file as a filesystem path."""
 
 
 @frozen
@@ -72,6 +98,28 @@ class PackagedResource:
     resource: str
     """Name of the file within that package, for example ``cv_cmip7_aft.yaml``."""
 
+    def _traversable(self, action: str) -> importlib.resources.abc.Traversable:
+        """
+        Locate the file within the installed package.
+
+        Parameters
+        ----------
+        action
+            Verb used in the error message when the lookup fails.
+
+        Returns
+        -------
+        :
+            The located file.
+        """
+        try:
+            return importlib.resources.files(self.package) / self.resource
+        except _RESOURCE_ERRORS as exc:
+            raise DataResourceError(
+                f"Could not {action} {self} from the installed package. "
+                "This usually means the package was built without its data files."
+            ) from exc
+
     def exists(self) -> bool:
         """
         Check whether the file is present in the installed package
@@ -82,8 +130,8 @@ class PackagedResource:
             True if the file can be read.
         """
         try:
-            return (importlib.resources.files(self.package) / self.resource).is_file()
-        except (ModuleNotFoundError, FileNotFoundError):
+            return self._traversable("locate").is_file()
+        except (DataResourceError, OSError):
             return False
 
     def read_text(self, encoding: str = "utf-8") -> str:
@@ -99,19 +147,12 @@ class PackagedResource:
         -------
         :
             The contents of the file.
-
-        Raises
-        ------
-        DataResourceError
-            If the file is missing from the installed package.
         """
+        traversable = self._traversable("read")
         try:
-            return (importlib.resources.files(self.package) / self.resource).read_text(encoding=encoding)
-        except (ModuleNotFoundError, FileNotFoundError, OSError) as exc:
-            raise DataResourceError(
-                f"Could not read {self} from the installed package. "
-                "This usually means the package was built without its data files."
-            ) from exc
+            return traversable.read_text(encoding=encoding)
+        except _RESOURCE_ERRORS as exc:
+            raise DataResourceError(f"Could not read {self} from the installed package.") from exc
 
     @contextmanager
     def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
@@ -128,9 +169,10 @@ class PackagedResource:
         :
             An open text stream positioned at the start of the file.
         """
+        traversable = self._traversable("open")
         try:
-            handle = (importlib.resources.files(self.package) / self.resource).open("r", encoding=encoding)
-        except (ModuleNotFoundError, FileNotFoundError, OSError) as exc:
+            handle = traversable.open("r", encoding=encoding)
+        except _RESOURCE_ERRORS as exc:
             raise DataResourceError(f"Could not open {self} from the installed package.") from exc
         try:
             yield handle
@@ -152,17 +194,96 @@ class PackagedResource:
         :
             A path that exists for the duration of the context.
         """
-        # Only the lookup is guarded. An exception raised in the caller's `with` body
-        # propagates back in through this yield, and must not be relabelled.
+        traversable = self._traversable("materialise")
         try:
-            manager = importlib.resources.as_file(importlib.resources.files(self.package) / self.resource)
-        except (ModuleNotFoundError, FileNotFoundError, OSError) as exc:
+            manager = importlib.resources.as_file(traversable)
+        except _RESOURCE_ERRORS as exc:
             raise DataResourceError(f"Could not materialise {self} as a filesystem path.") from exc
+        # The lookup is guarded, the body is not. An exception raised in the caller's
+        # `with` block propagates back in through this yield and must not be relabelled.
         with manager as path:
             yield path
 
     def __str__(self) -> str:
         return f"{self.package}/{self.resource}"
+
+
+@frozen
+class FileResource:
+    """
+    A data file at a plain filesystem path
+    """
+
+    path: pathlib.Path
+
+    def exists(self) -> bool:
+        """
+        Check whether the file exists
+
+        Returns
+        -------
+        :
+            True if the path points at a readable file.
+        """
+        return self.path.is_file()
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        """
+        Read the file as text
+
+        Parameters
+        ----------
+        encoding
+            Text encoding of the file.
+
+        Returns
+        -------
+        :
+            The contents of the file.
+        """
+        try:
+            return self.path.read_text(encoding=encoding)
+        except OSError as exc:
+            raise DataResourceError(f"Could not read {self}.") from exc
+
+    @contextmanager
+    def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
+        """
+        Open the file as a text stream
+
+        Parameters
+        ----------
+        encoding
+            Text encoding of the file.
+
+        Yields
+        ------
+        :
+            An open text stream positioned at the start of the file.
+        """
+        try:
+            handle = self.path.open("r", encoding=encoding)
+        except OSError as exc:
+            raise DataResourceError(f"Could not open {self}.") from exc
+        try:
+            yield handle
+        finally:
+            handle.close()
+
+    @contextmanager
+    def as_path(self) -> Iterator[pathlib.Path]:
+        """
+        Expose the file as a filesystem path
+
+        Yields
+        ------
+        :
+            The path itself, which already exists on disk.
+        """
+        yield self.path
+
+    def __str__(self) -> str:
+        return str(self.path)
 
 
 class ResourceOrigin(enum.Enum):
@@ -199,14 +320,14 @@ class LayeredResource:
     cache: pathlib.Path | None = field(default=None)
     """A local cache location. Used only when the file is actually present there."""
 
-    def resolve(self) -> tuple[ResourceOrigin, pathlib.Path | PackagedResource]:
+    def resolve(self) -> tuple[ResourceOrigin, Resource]:
         """
         Determine which layer supplies the file
 
         Returns
         -------
         :
-            The origin, and either a filesystem path or the packaged resource.
+            The origin, and the resource that supplies the file.
 
         Raises
         ------
@@ -220,10 +341,10 @@ class LayeredResource:
                     "Point it at an existing file, or remove the setting to use the copy "
                     f"shipped with the REF ({self.packaged})."
                 )
-            return ResourceOrigin.override, self.override
+            return ResourceOrigin.override, FileResource(self.override)
 
         if self.cache is not None and self.cache.is_file():
-            return ResourceOrigin.cache, self.cache
+            return ResourceOrigin.cache, FileResource(self.cache)
 
         return ResourceOrigin.package, self.packaged
 
@@ -266,13 +387,7 @@ class LayeredResource:
         :
             The contents of the file.
         """
-        _, source = self.resolve()
-        if isinstance(source, PackagedResource):
-            return source.read_text(encoding=encoding)
-        try:
-            return source.read_text(encoding=encoding)
-        except OSError as exc:
-            raise DataResourceError(f"Could not read {source}.") from exc
+        return self.resolve()[1].read_text(encoding=encoding)
 
     @contextmanager
     def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
@@ -289,13 +404,8 @@ class LayeredResource:
         :
             An open text stream positioned at the start of the file.
         """
-        _, source = self.resolve()
-        if isinstance(source, PackagedResource):
-            with source.open_text(encoding=encoding) as handle:
-                yield handle
-        else:
-            with source.open("r", encoding=encoding) as handle:
-                yield handle
+        with self.resolve()[1].open_text(encoding=encoding) as handle:
+            yield handle
 
     @contextmanager
     def as_path(self) -> Iterator[pathlib.Path]:
@@ -307,9 +417,5 @@ class LayeredResource:
         :
             A path that exists for the duration of the context.
         """
-        _, source = self.resolve()
-        if isinstance(source, PackagedResource):
-            with source.as_path() as path:
-                yield path
-        else:
-            yield source
+        with self.resolve()[1].as_path() as path:
+            yield path

--- a/packages/climate-ref-core/src/climate_ref_core/data.py
+++ b/packages/climate-ref-core/src/climate_ref_core/data.py
@@ -1,0 +1,315 @@
+"""
+Resolution of the data files that are distributed with the REF
+
+Several files the REF depends on are shipped inside the wheels:
+the controlled vocabulary, the grey list, and the dataset registry manifests.
+Some of them also have a newer copy available over the network.
+
+`LayeredResource` resolves one logical file across three layers:
+an operator override, a cached download, and the copy shipped in the package.
+The packaged copy is always present and always readable,
+so resolution never requires the network or a writable filesystem.
+
+Packaged files are read through `importlib.resources` rather than being converted
+to a filesystem path, so an installation that is not unpacked on disk still works.
+"""
+
+import enum
+import importlib.resources
+import os
+import pathlib
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import IO
+
+import platformdirs
+from attrs import field, frozen
+
+from climate_ref_core.exceptions import RefException
+
+
+class DataResourceError(RefException):
+    """Raised when a data file cannot be resolved or read."""
+
+
+def resolve_cache_dir(cache_name: str) -> pathlib.Path:
+    """
+    Resolve a cache directory used to hold downloaded data
+
+    If the ``REF_DATASET_CACHE_DIR`` environment variable is set, use that as the root.
+    Otherwise, fall back to the OS cache under ``climate_ref``.
+
+    Parameters
+    ----------
+    cache_name
+        Subdirectory name within the cache root.
+
+    Returns
+    -------
+        The resolved cache directory path.
+    """
+    if env_cache_dir := os.environ.get("REF_DATASET_CACHE_DIR"):
+        cache_dir = pathlib.Path(os.path.expandvars(env_cache_dir)).expanduser()
+    else:
+        cache_dir = platformdirs.user_cache_path("climate_ref")
+
+    return cache_dir / cache_name
+
+
+@frozen
+class PackagedResource:
+    """
+    A data file shipped inside an installed package
+
+    The file is always accessed through `importlib.resources`.
+    It is never converted to a filesystem path unless a caller explicitly asks for one
+    via `as_path`, which extracts it to a temporary location when needed.
+    """
+
+    package: str
+    """Import name of the package that contains the file, for example ``climate_ref_core.pycmec``."""
+
+    resource: str
+    """Name of the file within that package, for example ``cv_cmip7_aft.yaml``."""
+
+    def exists(self) -> bool:
+        """
+        Check whether the file is present in the installed package
+
+        Returns
+        -------
+        :
+            True if the file can be read.
+        """
+        try:
+            return (importlib.resources.files(self.package) / self.resource).is_file()
+        except (ModuleNotFoundError, FileNotFoundError):
+            return False
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        """
+        Read the file as text
+
+        Parameters
+        ----------
+        encoding
+            Text encoding of the file.
+
+        Returns
+        -------
+        :
+            The contents of the file.
+
+        Raises
+        ------
+        DataResourceError
+            If the file is missing from the installed package.
+        """
+        try:
+            return (importlib.resources.files(self.package) / self.resource).read_text(encoding=encoding)
+        except (ModuleNotFoundError, FileNotFoundError, OSError) as exc:
+            raise DataResourceError(
+                f"Could not read {self} from the installed package. "
+                "This usually means the package was built without its data files."
+            ) from exc
+
+    @contextmanager
+    def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
+        """
+        Open the file as a text stream
+
+        Parameters
+        ----------
+        encoding
+            Text encoding of the file.
+
+        Yields
+        ------
+        :
+            An open text stream positioned at the start of the file.
+        """
+        try:
+            handle = (importlib.resources.files(self.package) / self.resource).open("r", encoding=encoding)
+        except (ModuleNotFoundError, FileNotFoundError, OSError) as exc:
+            raise DataResourceError(f"Could not open {self} from the installed package.") from exc
+        try:
+            yield handle
+        finally:
+            handle.close()
+
+    @contextmanager
+    def as_path(self) -> Iterator[pathlib.Path]:
+        """
+        Expose the file as a filesystem path for the duration of the context
+
+        Prefer `read_text` or `open_text`.
+        Use this only for third-party APIs that insist on a path.
+        The path may point at a temporary file that is removed on exit,
+        so it must not be retained beyond the context.
+
+        Yields
+        ------
+        :
+            A path that exists for the duration of the context.
+        """
+        # Only the lookup is guarded. An exception raised in the caller's `with` body
+        # propagates back in through this yield, and must not be relabelled.
+        try:
+            manager = importlib.resources.as_file(importlib.resources.files(self.package) / self.resource)
+        except (ModuleNotFoundError, FileNotFoundError, OSError) as exc:
+            raise DataResourceError(f"Could not materialise {self} as a filesystem path.") from exc
+        with manager as path:
+            yield path
+
+    def __str__(self) -> str:
+        return f"{self.package}/{self.resource}"
+
+
+class ResourceOrigin(enum.Enum):
+    """
+    Which layer a resolved data file came from
+    """
+
+    override = "override"
+    """An explicit path supplied by the operator via configuration or an environment variable."""
+
+    cache = "cache"
+    """A copy downloaded into the local cache."""
+
+    package = "package"
+    """The copy shipped inside the installed package."""
+
+
+@frozen
+class LayeredResource:
+    """
+    A data file resolved across an override, a cache, and the packaged copy
+
+    Resolution happens on every access rather than being fixed at construction,
+    so a cache that is populated after the object is built is picked up
+    without the object being rebuilt.
+    """
+
+    packaged: PackagedResource
+    """The copy shipped in the package. This is the floor, and is always available."""
+
+    override: pathlib.Path | None = field(default=None)
+    """An explicit path supplied by the operator. Takes precedence over everything else."""
+
+    cache: pathlib.Path | None = field(default=None)
+    """A local cache location. Used only when the file is actually present there."""
+
+    def resolve(self) -> tuple[ResourceOrigin, pathlib.Path | PackagedResource]:
+        """
+        Determine which layer supplies the file
+
+        Returns
+        -------
+        :
+            The origin, and either a filesystem path or the packaged resource.
+
+        Raises
+        ------
+        DataResourceError
+            If an override was supplied but does not point at a readable file.
+        """
+        if self.override is not None:
+            if not self.override.is_file():
+                raise DataResourceError(
+                    f"The configured file {self.override} does not exist. "
+                    "Point it at an existing file, or remove the setting to use the copy "
+                    f"shipped with the REF ({self.packaged})."
+                )
+            return ResourceOrigin.override, self.override
+
+        if self.cache is not None and self.cache.is_file():
+            return ResourceOrigin.cache, self.cache
+
+        return ResourceOrigin.package, self.packaged
+
+    @property
+    def origin(self) -> ResourceOrigin:
+        """
+        The layer that currently supplies the file
+        """
+        return self.resolve()[0]
+
+    def describe(self) -> str:
+        """
+        Describe where the file is being read from
+
+        This never raises, so it is safe to use when building a log message
+        for a resolution that has itself failed.
+
+        Returns
+        -------
+        :
+            A short description suitable for a log message.
+        """
+        try:
+            origin, source = self.resolve()
+        except DataResourceError:
+            return f"{self.override} (missing)"
+        return f"{source} ({origin.value})"
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        """
+        Read the file as text from whichever layer supplies it
+
+        Parameters
+        ----------
+        encoding
+            Text encoding of the file.
+
+        Returns
+        -------
+        :
+            The contents of the file.
+        """
+        _, source = self.resolve()
+        if isinstance(source, PackagedResource):
+            return source.read_text(encoding=encoding)
+        try:
+            return source.read_text(encoding=encoding)
+        except OSError as exc:
+            raise DataResourceError(f"Could not read {source}.") from exc
+
+    @contextmanager
+    def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
+        """
+        Open the file as a text stream from whichever layer supplies it
+
+        Parameters
+        ----------
+        encoding
+            Text encoding of the file.
+
+        Yields
+        ------
+        :
+            An open text stream positioned at the start of the file.
+        """
+        _, source = self.resolve()
+        if isinstance(source, PackagedResource):
+            with source.open_text(encoding=encoding) as handle:
+                yield handle
+        else:
+            with source.open("r", encoding=encoding) as handle:
+                yield handle
+
+    @contextmanager
+    def as_path(self) -> Iterator[pathlib.Path]:
+        """
+        Expose the file as a filesystem path for the duration of the context
+
+        Yields
+        ------
+        :
+            A path that exists for the duration of the context.
+        """
+        _, source = self.resolve()
+        if isinstance(source, PackagedResource):
+            with source.as_path() as path:
+                yield path
+        else:
+            yield source

--- a/packages/climate-ref-core/src/climate_ref_core/data.py
+++ b/packages/climate-ref-core/src/climate_ref_core/data.py
@@ -18,7 +18,7 @@ import enum
 import importlib.resources
 import os
 import pathlib
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from typing import Protocol
 
@@ -159,7 +159,7 @@ class PackagedResource:
             raise DataResourceError(f"Could not read {self} from the installed package.") from exc
 
     @contextmanager
-    def as_path(self) -> Iterator[pathlib.Path]:
+    def as_path(self) -> Generator[pathlib.Path]:
         """
         Expose the file as a filesystem path for the duration of the context
 
@@ -237,7 +237,7 @@ class FileResource:
             raise DataResourceError(f"Could not read {self}.") from exc
 
     @contextmanager
-    def as_path(self) -> Iterator[pathlib.Path]:
+    def as_path(self) -> Generator[pathlib.Path]:
         """
         Expose the file as a filesystem path
 

--- a/packages/climate-ref-core/src/climate_ref_core/data.py
+++ b/packages/climate-ref-core/src/climate_ref_core/data.py
@@ -20,7 +20,7 @@ import os
 import pathlib
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
-from typing import IO, Protocol, runtime_checkable
+from typing import Protocol
 
 import platformdirs
 from attrs import field, frozen
@@ -63,7 +63,6 @@ def resolve_cache_dir(cache_name: str) -> pathlib.Path:
     return cache_dir / cache_name
 
 
-@runtime_checkable
 class Resource(Protocol):
     """
     A readable data file, wherever it happens to live
@@ -74,9 +73,6 @@ class Resource(Protocol):
 
     def read_text(self, encoding: str = "utf-8") -> str:
         """Read the file as text."""
-
-    def open_text(self, encoding: str = "utf-8") -> AbstractContextManager[IO[str]]:
-        """Open the file as a text stream."""
 
     def as_path(self) -> AbstractContextManager[pathlib.Path]:
         """Expose the file as a filesystem path."""
@@ -155,36 +151,11 @@ class PackagedResource:
             raise DataResourceError(f"Could not read {self} from the installed package.") from exc
 
     @contextmanager
-    def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
-        """
-        Open the file as a text stream
-
-        Parameters
-        ----------
-        encoding
-            Text encoding of the file.
-
-        Yields
-        ------
-        :
-            An open text stream positioned at the start of the file.
-        """
-        traversable = self._traversable("open")
-        try:
-            handle = traversable.open("r", encoding=encoding)
-        except _RESOURCE_ERRORS as exc:
-            raise DataResourceError(f"Could not open {self} from the installed package.") from exc
-        try:
-            yield handle
-        finally:
-            handle.close()
-
-    @contextmanager
     def as_path(self) -> Iterator[pathlib.Path]:
         """
         Expose the file as a filesystem path for the duration of the context
 
-        Prefer `read_text` or `open_text`.
+        Prefer `read_text`.
         Use this only for third-party APIs that insist on a path.
         The path may point at a temporary file that is removed on exit,
         so it must not be retained beyond the context.
@@ -245,30 +216,6 @@ class FileResource:
             return self.path.read_text(encoding=encoding)
         except OSError as exc:
             raise DataResourceError(f"Could not read {self}.") from exc
-
-    @contextmanager
-    def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
-        """
-        Open the file as a text stream
-
-        Parameters
-        ----------
-        encoding
-            Text encoding of the file.
-
-        Yields
-        ------
-        :
-            An open text stream positioned at the start of the file.
-        """
-        try:
-            handle = self.path.open("r", encoding=encoding)
-        except OSError as exc:
-            raise DataResourceError(f"Could not open {self}.") from exc
-        try:
-            yield handle
-        finally:
-            handle.close()
 
     @contextmanager
     def as_path(self) -> Iterator[pathlib.Path]:
@@ -388,24 +335,6 @@ class LayeredResource:
             The contents of the file.
         """
         return self.resolve()[1].read_text(encoding=encoding)
-
-    @contextmanager
-    def open_text(self, encoding: str = "utf-8") -> Iterator[IO[str]]:
-        """
-        Open the file as a text stream from whichever layer supplies it
-
-        Parameters
-        ----------
-        encoding
-            Text encoding of the file.
-
-        Yields
-        ------
-        :
-            An open text stream positioned at the start of the file.
-        """
-        with self.resolve()[1].open_text(encoding=encoding) as handle:
-            yield handle
 
     @contextmanager
     def as_path(self) -> Iterator[pathlib.Path]:

--- a/packages/climate-ref-core/src/climate_ref_core/data.py
+++ b/packages/climate-ref-core/src/climate_ref_core/data.py
@@ -19,7 +19,7 @@ import importlib.resources
 import os
 import pathlib
 from collections.abc import Iterator
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import contextmanager
 from typing import Protocol
 
 import platformdirs
@@ -65,17 +65,17 @@ def resolve_cache_dir(cache_name: str) -> pathlib.Path:
 
 class Resource(Protocol):
     """
-    A readable data file, wherever it happens to live
-    """
+    Something a data file can be read from
 
-    def exists(self) -> bool:
-        """Check whether the file can be read."""
+    This is the contract `LayeredResource` resolves to,
+    and the narrowest one its consumers need.
+    """
 
     def read_text(self, encoding: str = "utf-8") -> str:
         """Read the file as text."""
 
-    def as_path(self) -> AbstractContextManager[pathlib.Path]:
-        """Expose the file as a filesystem path."""
+    def describe(self) -> str:
+        """Describe where the file is read from, for a log or error message."""
 
 
 @frozen
@@ -94,14 +94,9 @@ class PackagedResource:
     resource: str
     """Name of the file within that package, for example ``cv_cmip7_aft.yaml``."""
 
-    def _traversable(self, action: str) -> importlib.resources.abc.Traversable:
+    def _traversable(self) -> importlib.resources.abc.Traversable:
         """
         Locate the file within the installed package.
-
-        Parameters
-        ----------
-        action
-            Verb used in the error message when the lookup fails.
 
         Returns
         -------
@@ -112,7 +107,7 @@ class PackagedResource:
             return importlib.resources.files(self.package) / self.resource
         except _RESOURCE_ERRORS as exc:
             raise DataResourceError(
-                f"Could not {action} {self} from the installed package. "
+                f"Could not read {self} from the installed package. "
                 "This usually means the package was built without its data files."
             ) from exc
 
@@ -126,7 +121,7 @@ class PackagedResource:
             True if the file can be read.
         """
         try:
-            return self._traversable("locate").is_file()
+            return self._traversable().is_file()
         except (DataResourceError, OSError):
             return False
 
@@ -144,7 +139,7 @@ class PackagedResource:
         :
             The contents of the file.
         """
-        traversable = self._traversable("read")
+        traversable = self._traversable()
         try:
             return traversable.read_text(encoding=encoding)
         except _RESOURCE_ERRORS as exc:
@@ -165,7 +160,7 @@ class PackagedResource:
         :
             A path that exists for the duration of the context.
         """
-        traversable = self._traversable("materialise")
+        traversable = self._traversable()
         try:
             manager = importlib.resources.as_file(traversable)
         except _RESOURCE_ERRORS as exc:
@@ -174,6 +169,17 @@ class PackagedResource:
         # `with` block propagates back in through this yield and must not be relabelled.
         with manager as path:
             yield path
+
+    def describe(self) -> str:
+        """
+        Describe where the file is read from
+
+        Returns
+        -------
+        :
+            The package and file name.
+        """
+        return str(self)
 
     def __str__(self) -> str:
         return f"{self.package}/{self.resource}"
@@ -228,6 +234,17 @@ class FileResource:
             The path itself, which already exists on disk.
         """
         yield self.path
+
+    def describe(self) -> str:
+        """
+        Describe where the file is read from
+
+        Returns
+        -------
+        :
+            The path.
+        """
+        return str(self)
 
     def __str__(self) -> str:
         return str(self.path)
@@ -335,16 +352,3 @@ class LayeredResource:
             The contents of the file.
         """
         return self.resolve()[1].read_text(encoding=encoding)
-
-    @contextmanager
-    def as_path(self) -> Iterator[pathlib.Path]:
-        """
-        Expose the file as a filesystem path for the duration of the context
-
-        Yields
-        ------
-        :
-            A path that exists for the duration of the context.
-        """
-        with self.resolve()[1].as_path() as path:
-            yield path

--- a/packages/climate-ref-core/src/climate_ref_core/data.py
+++ b/packages/climate-ref-core/src/climate_ref_core/data.py
@@ -19,7 +19,7 @@ import importlib.resources
 import os
 import pathlib
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from typing import Protocol
 
 import platformdirs
@@ -98,18 +98,30 @@ class PackagedResource:
         """
         Locate the file within the installed package.
 
+        Existence is checked here rather than at each accessor,
+        because `importlib.resources.as_file` happily hands back a path that does not exist.
+
         Returns
         -------
         :
             The located file.
+
+        Raises
+        ------
+        DataResourceError
+            If the file is not present in the installed package.
         """
+        missing = DataResourceError(
+            f"Could not read {self} from the installed package. "
+            "This usually means the package was built without its data files."
+        )
         try:
-            return importlib.resources.files(self.package) / self.resource
+            located = importlib.resources.files(self.package) / self.resource
+            if not located.is_file():
+                raise missing
         except _RESOURCE_ERRORS as exc:
-            raise DataResourceError(
-                f"Could not read {self} from the installed package. "
-                "This usually means the package was built without its data files."
-            ) from exc
+            raise missing from exc
+        return located
 
     def exists(self) -> bool:
         """
@@ -121,9 +133,10 @@ class PackagedResource:
             True if the file can be read.
         """
         try:
-            return self._traversable().is_file()
-        except (DataResourceError, OSError):
+            self._traversable()
+        except DataResourceError:
             return False
+        return True
 
     def read_text(self, encoding: str = "utf-8") -> str:
         """
@@ -161,13 +174,13 @@ class PackagedResource:
             A path that exists for the duration of the context.
         """
         traversable = self._traversable()
-        try:
-            manager = importlib.resources.as_file(traversable)
-        except _RESOURCE_ERRORS as exc:
-            raise DataResourceError(f"Could not materialise {self} as a filesystem path.") from exc
-        # The lookup is guarded, the body is not. An exception raised in the caller's
-        # `with` block propagates back in through this yield and must not be relabelled.
-        with manager as path:
+        with ExitStack() as stack:
+            try:
+                path = stack.enter_context(importlib.resources.as_file(traversable))
+            except _RESOURCE_ERRORS as exc:
+                raise DataResourceError(f"Could not materialise {self} as a filesystem path.") from exc
+            # Only the lookup is guarded. An exception raised in the caller's `with`
+            # block propagates back in through this yield and must not be relabelled.
             yield path
 
     def describe(self) -> str:

--- a/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
+++ b/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
@@ -290,8 +290,7 @@ class DatasetRegistryManager:
                 old_path = legacy_dir / key
                 if old_path.exists():
                     # Registration happens at import time, so a read-only cache must not
-                    # stop the package from importing. The file stays where it is and
-                    # will be refetched if it is ever actually needed.
+                    # stop the package from importing.
                     try:
                         new_path.parent.mkdir(parents=True, exist_ok=True)
                         logger.info(f"Migrating cached file {key}: {old_path} -> {new_path}")

--- a/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
+++ b/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
@@ -7,7 +7,6 @@ before it is included in any published data catalogs.
 """
 
 import enum
-import importlib.resources
 import os
 import pathlib
 import shutil
@@ -19,6 +18,7 @@ from attrs import frozen
 from loguru import logger
 from rich.progress import track
 
+from climate_ref_core.data import PackagedResource, resolve_cache_dir
 from climate_ref_core.env import env
 from climate_ref_core.source_types import SourceDatasetType
 
@@ -65,30 +65,6 @@ class RegistryEntry:
 
     use_case: RegistryUseCase
     """Whether the registry's contents are catalog-ingestable or fetch-only."""
-
-
-def resolve_cache_dir(cache_name: str) -> pathlib.Path:
-    """
-    Resolve the cache directory for a registry.
-
-    If the ``REF_DATASET_CACHE_DIR`` environment variable is set, use that as the root.
-    Otherwise, fall back to the OS cache under ``climate_ref``.
-
-    Parameters
-    ----------
-    cache_name
-        Subdirectory name within the cache root.
-
-    Returns
-    -------
-        The resolved cache directory path.
-    """
-    if env_cache_dir := os.environ.get("REF_DATASET_CACHE_DIR"):
-        cache_dir = pathlib.Path(os.path.expandvars(env_cache_dir)).expanduser()
-    else:
-        cache_dir = pooch.os_cache("climate_ref")
-
-    return cache_dir / cache_name
 
 
 def _verify_hash_matches(fname: str | pathlib.Path, known_hash: str) -> bool:
@@ -313,9 +289,16 @@ class DatasetRegistryManager:
             for legacy_dir in legacy_cache_dirs:
                 old_path = legacy_dir / key
                 if old_path.exists():
-                    new_path.parent.mkdir(parents=True, exist_ok=True)
-                    logger.info(f"Migrating cached file {key}: {old_path} -> {new_path}")
-                    shutil.move(str(old_path), str(new_path))
+                    # Registration happens at import time, so a read-only cache must not
+                    # stop the package from importing. The file stays where it is and
+                    # will be refetched if it is ever actually needed.
+                    try:
+                        new_path.parent.mkdir(parents=True, exist_ok=True)
+                        logger.info(f"Migrating cached file {key}: {old_path} -> {new_path}")
+                        shutil.move(str(old_path), str(new_path))
+                    except OSError as exc:
+                        logger.warning(f"Could not migrate cached file {key} to {new_path}: {exc}")
+                        return
                     break
 
     def register(  # noqa: PLR0913
@@ -398,7 +381,9 @@ class DatasetRegistryManager:
             version=version,
             retry_if_failed=10,
         )
-        registry.load_registry(str(importlib.resources.files(package) / resource))
+        # pooch reads the manifest eagerly, so the temporary path only has to outlive the call.
+        with PackagedResource(package, resource).as_path() as manifest:
+            registry.load_registry(manifest)
 
         if cache_path != default_legacy:
             self._migrate_cache(registry, all_legacy_dirs)

--- a/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
+++ b/packages/climate-ref-core/src/climate_ref_core/dataset_registry.py
@@ -404,8 +404,8 @@ def iter_reference_registries(
     Yield the ``(registry, source_type)`` pairs for all catalog-ingestable registries.
 
     Registries whose ``use_case`` is not ``reference``, or whose ``source_type`` is
-    ``None`` (e.g. registries that mix source types and so cannot be catalogued as
-    a whole), are skipped.
+    ``None`` (e.g. registries that mix source types and so cannot be catalogued as a whole),
+    are skipped.
     A later ingest driver can pass the yielded ``source_type`` to
     :func:`climate_ref.datasets.get_dataset_adapter` to select the parsing adapter.
 

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
@@ -24,7 +24,7 @@ from climate_ref_core.cmip6_to_cmip7 import (
     shift_time_axis_end,
     suppress_bounds_coordinates,
 )
-from climate_ref_core.dataset_registry import resolve_cache_dir
+from climate_ref_core.data import resolve_cache_dir
 from climate_ref_core.esgf.cmip6 import CMIP6Request
 
 

--- a/packages/climate-ref-core/src/climate_ref_core/exceptions.py
+++ b/packages/climate-ref-core/src/climate_ref_core/exceptions.py
@@ -103,9 +103,3 @@ class DatasetResolutionError(TestCaseError):
     """Raised when datasets cannot be resolved for a test case."""
 
     pass
-
-
-class IgnoreDatasetsRefreshError(RefException):
-    """Raised when the ignore datasets file cannot be refreshed and no cached copy is available."""
-
-    pass

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -99,6 +99,10 @@ class DiagnosticProvider:
             except (DataResourceError, yaml.YAMLError) as exc:
                 logger.warning(f"Could not read the grey list from {candidate.describe()}: {exc}")
                 continue
+            if not isinstance(ignore_datasets_all, dict):
+                logger.warning(f"The grey list at {candidate.describe()} is not a mapping, ignoring it")
+                ignore_datasets_all = {}
+                continue
             source = candidate.describe()
             break
         else:

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -486,6 +486,16 @@ class CondaDiagnosticProvider(CommandLineDiagnosticProvider):
     def prefix(self, path: Path) -> None:
         self._prefix = path
 
+    @property
+    def conda_exe_path(self) -> Path:
+        """
+        Where the conda executable lives, whether or not it has been installed yet.
+
+        Use this when only the location is needed.
+        `get_conda_exe` installs the executable, which requires network access.
+        """
+        return self.prefix / "micromamba"
+
     def configure(self, config: Any) -> None:
         """Configure the provider."""
         super().configure(config)
@@ -521,7 +531,7 @@ class CondaDiagnosticProvider(CommandLineDiagnosticProvider):
             The path to the executable.
 
         """
-        conda_exe = self.prefix / "micromamba"
+        conda_exe = self.conda_exe_path
 
         if not conda_exe.exists() or update or self._is_stale(conda_exe):
             logger.info("Installing conda")

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -92,7 +92,7 @@ class DiagnosticProvider:
         # The packaged copy is tried second so a mistyped `ignore_datasets_file`
         # cannot silently drop the grey list protections.
         ignore_datasets_all: dict[str, Any] = {}
-        source = str(grey_list.packaged)
+        source = "nothing"
         for candidate in (grey_list, grey_list.packaged):
             try:
                 ignore_datasets_all = yaml.safe_load(candidate.read_text()) or {}
@@ -101,6 +101,8 @@ class DiagnosticProvider:
                 continue
             source = candidate.describe()
             break
+        else:
+            logger.warning(f"No grey list could be read for provider {self.slug}, ignoring no datasets")
         logger.debug(f"Configuring provider {self.slug} using the grey list from {source}")
 
         ignore_datasets = ignore_datasets_all.get(self.slug, {})

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -27,6 +27,7 @@ from attrs import evolve
 from loguru import logger
 
 from climate_ref_core.constraints import IgnoreFacets
+from climate_ref_core.data import DataResourceError
 from climate_ref_core.datasets import SourceDatasetType
 from climate_ref_core.diagnostics import Diagnostic
 from climate_ref_core.exceptions import (
@@ -79,27 +80,26 @@ class DiagnosticProvider:
         config :
             A configuration.
         """
-        logger.debug(
-            f"Configuring provider {self.slug} using ignore_datasets_file {config.ignore_datasets_file}"
-        )
+        grey_list = config.ignore_datasets_resource
+        source = grey_list.describe()
+        logger.debug(f"Configuring provider {self.slug} using the grey list from {source}")
+
         # The format of the configuration file is:
         # provider:
         #   diagnostic:
         #     source_type:
         #       - facet: value
         #       - other_facet: [other_value1, other_value2]
-        ignore_datasets_file = config.ignore_datasets_file
-        if ignore_datasets_file.is_file():
-            ignore_datasets_all = yaml.safe_load(ignore_datasets_file.read_text(encoding="utf-8")) or {}
-        else:
-            logger.warning(
-                f"Ignore datasets file {ignore_datasets_file} not found; no datasets will be ignored"
-            )
+        try:
+            ignore_datasets_all = yaml.safe_load(grey_list.read_text()) or {}
+        except (DataResourceError, yaml.YAMLError) as exc:
+            logger.warning(f"Could not read the grey list from {source}, no datasets will be ignored: {exc}")
             ignore_datasets_all = {}
+
         ignore_datasets = ignore_datasets_all.get(self.slug, {})
         if unknown_slugs := {slug for slug in ignore_datasets} - {d.slug for d in self.diagnostics()}:
             logger.warning(
-                f"Unknown diagnostics found in {config.ignore_datasets_file} "
+                f"Unknown diagnostics found in {source} "
                 f"for provider {self.slug}: {', '.join(sorted(unknown_slugs))}"
             )
 
@@ -108,7 +108,7 @@ class DiagnosticProvider:
             if diagnostic.slug in ignore_datasets:
                 if unknown_source_types := set(ignore_datasets[diagnostic.slug]) - known_source_types:
                     logger.warning(
-                        f"Unknown source types found in {config.ignore_datasets_file} for "
+                        f"Unknown source types found in {source} for "
                         f"diagnostic '{diagnostic.slug}' by provider {self.slug}: "
                         f"{', '.join(sorted(unknown_source_types))}"
                     )

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -81,8 +81,6 @@ class DiagnosticProvider:
             A configuration.
         """
         grey_list = config.ignore_datasets_resource
-        source = grey_list.describe()
-        logger.debug(f"Configuring provider {self.slug} using the grey list from {source}")
 
         # The format of the configuration file is:
         # provider:
@@ -90,18 +88,20 @@ class DiagnosticProvider:
         #     source_type:
         #       - facet: value
         #       - other_facet: [other_value1, other_value2]
-        try:
-            ignore_datasets_all = yaml.safe_load(grey_list.read_text()) or {}
-        except (DataResourceError, yaml.YAMLError) as exc:
-            # Falling through to the packaged copy rather than to an empty grey list,
-            # so a mistyped path cannot silently drop the grey list protections.
-            source = str(grey_list.packaged)
-            logger.warning(f"Could not read the grey list, falling back to {source}: {exc}")
+        #
+        # The packaged copy is tried second so a mistyped `ignore_datasets_file`
+        # cannot silently drop the grey list protections.
+        ignore_datasets_all: dict[str, Any] = {}
+        source = str(grey_list.packaged)
+        for candidate in (grey_list, grey_list.packaged):
             try:
-                ignore_datasets_all = yaml.safe_load(grey_list.packaged.read_text()) or {}
-            except (DataResourceError, yaml.YAMLError) as packaged_exc:
-                logger.warning(f"Could not read {source} either, no datasets will be ignored: {packaged_exc}")
-                ignore_datasets_all = {}
+                ignore_datasets_all = yaml.safe_load(candidate.read_text()) or {}
+            except (DataResourceError, yaml.YAMLError) as exc:
+                logger.warning(f"Could not read the grey list from {candidate.describe()}: {exc}")
+                continue
+            source = candidate.describe()
+            break
+        logger.debug(f"Configuring provider {self.slug} using the grey list from {source}")
 
         ignore_datasets = ignore_datasets_all.get(self.slug, {})
         if unknown_slugs := {slug for slug in ignore_datasets} - {d.slug for d in self.diagnostics()}:

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -93,8 +93,15 @@ class DiagnosticProvider:
         try:
             ignore_datasets_all = yaml.safe_load(grey_list.read_text()) or {}
         except (DataResourceError, yaml.YAMLError) as exc:
-            logger.warning(f"Could not read the grey list from {source}, no datasets will be ignored: {exc}")
-            ignore_datasets_all = {}
+            # Falling through to the packaged copy rather than to an empty grey list,
+            # so a mistyped path cannot silently drop the grey list protections.
+            source = str(grey_list.packaged)
+            logger.warning(f"Could not read the grey list, falling back to {source}: {exc}")
+            try:
+                ignore_datasets_all = yaml.safe_load(grey_list.packaged.read_text()) or {}
+            except (DataResourceError, yaml.YAMLError) as packaged_exc:
+                logger.warning(f"Could not read {source} either, no datasets will be ignored: {packaged_exc}")
+                ignore_datasets_all = {}
 
         ignore_datasets = ignore_datasets_all.get(self.slug, {})
         if unknown_slugs := {slug for slug in ignore_datasets} - {d.slug for d in self.diagnostics()}:

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/__init__.py
@@ -4,7 +4,7 @@ CMEC python package
 
 from climate_ref_core.data import PackagedResource
 
-BUNDLED_CV = PackagedResource("climate_ref_core.pycmec", "cv_cmip7_aft.yaml")
+BUNDLED_AFT_CV = PackagedResource("climate_ref_core.pycmec", "cv_cmip7_aft.yaml")
 """
 The controlled vocabulary for the CMIP7 Assessment Fast Track diagnostics.
 

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/__init__.py
@@ -1,3 +1,14 @@
 """
 CMEC python package
 """
+
+from climate_ref_core.data import PackagedResource
+
+BUNDLED_CV = PackagedResource("climate_ref_core.pycmec", "cv_cmip7_aft.yaml")
+"""
+The controlled vocabulary for the CMIP7 Assessment Fast Track diagnostics.
+
+This ships inside `climate_ref_core` and is used unless an operator overrides it.
+It is declared here rather than alongside `CV` so that reading the configuration
+does not pull in the parsing machinery.
+"""

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
@@ -7,9 +7,17 @@ from cattrs import Converter, transform_error
 from loguru import logger
 from yaml import safe_load
 
+from climate_ref_core.data import LayeredResource, PackagedResource
 from climate_ref_core.exceptions import ResultValidationError
 from climate_ref_core.metric_values import ScalarMetricValue, SeriesMetricValue
 from climate_ref_core.pycmec.metric import CMECMetric
+
+BUNDLED_CV = PackagedResource("climate_ref_core.pycmec", "cv_cmip7_aft.yaml")
+"""
+The controlled vocabulary for the CMIP7 Assessment Fast Track diagnostics.
+
+This ships inside `climate_ref_core` and is used unless an operator overrides it.
+"""
 
 RESERVED_DIMENSION_NAMES = {"attributes", "json_structure", "created_at", "updated_at", "value", "id"}
 """
@@ -169,6 +177,50 @@ class CV:
             self._validate_value(result)
 
     @staticmethod
+    def from_text(contents: str, source: str = "<string>") -> "CV":
+        """
+        Parse a CV from YAML text
+
+        Parameters
+        ----------
+        contents
+            The YAML document describing the controlled vocabulary.
+        source
+            Description of where the text came from, used in error messages.
+
+        Returns
+        -------
+            A new CV instance
+        """
+        convertor = Converter(forbid_extra_keys=True)
+
+        try:
+            return convertor.structure(safe_load(contents), CV)
+        except Exception as exc:
+            logger.error(f"Error loading CV from {source}")
+            for error in transform_error(exc):
+                logger.error(error)
+            raise
+
+    @staticmethod
+    def load(resource: LayeredResource) -> "CV":
+        """
+        Load a CV from a layered resource
+
+        The CV may come from an operator override or from the copy shipped with the REF.
+
+        Parameters
+        ----------
+        resource
+            The resource describing where the CV may be found.
+
+        Returns
+        -------
+            A new CV instance
+        """
+        return CV.from_text(resource.read_text(), source=resource.describe())
+
+    @staticmethod
     def load_from_file(filename: pathlib.Path | str) -> "CV":
         """
         Load a CV from disk
@@ -178,13 +230,7 @@ class CV:
             A new CV instance
 
         """
-        convertor = Converter(forbid_extra_keys=True)
-
-        try:
-            contents = safe_load(pathlib.Path(filename).read_text(encoding="utf-8"))
-            return convertor.structure(contents, CV)
-        except Exception as exc:
-            logger.error(f"Error loading CV from {filename}")
-            for error in transform_error(exc):
-                logger.error(error)
-            raise
+        return CV.from_text(
+            pathlib.Path(filename).read_text(encoding="utf-8"),
+            source=str(filename),
+        )

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
@@ -237,5 +237,4 @@ class CV:
 
 
 if __name__ == "__main__":
-    # Write the bundled CV to stdout so it can be copied and extended.
     print(BUNDLED_CV.read_text())

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
@@ -7,17 +7,11 @@ from cattrs import Converter, transform_error
 from loguru import logger
 from yaml import safe_load
 
-from climate_ref_core.data import LayeredResource, PackagedResource
+from climate_ref_core.data import FileResource, Resource
 from climate_ref_core.exceptions import ResultValidationError
 from climate_ref_core.metric_values import ScalarMetricValue, SeriesMetricValue
+from climate_ref_core.pycmec import BUNDLED_CV
 from climate_ref_core.pycmec.metric import CMECMetric
-
-BUNDLED_CV = PackagedResource("climate_ref_core.pycmec", "cv_cmip7_aft.yaml")
-"""
-The controlled vocabulary for the CMIP7 Assessment Fast Track diagnostics.
-
-This ships inside `climate_ref_core` and is used unless an operator overrides it.
-"""
 
 RESERVED_DIMENSION_NAMES = {"attributes", "json_structure", "created_at", "updated_at", "value", "id"}
 """
@@ -203,9 +197,9 @@ class CV:
             raise
 
     @staticmethod
-    def load(resource: LayeredResource) -> "CV":
+    def load(resource: Resource) -> "CV":
         """
-        Load a CV from a layered resource
+        Load a CV from a resource
 
         The CV may come from an operator override or from the copy shipped with the REF.
 
@@ -230,10 +224,7 @@ class CV:
             A new CV instance
 
         """
-        return CV.from_text(
-            pathlib.Path(filename).read_text(encoding="utf-8"),
-            source=str(filename),
-        )
+        return CV.load(FileResource(pathlib.Path(filename)))
 
 
 if __name__ == "__main__":

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
@@ -227,5 +227,5 @@ class CV:
         return CV.load(FileResource(pathlib.Path(filename)))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(BUNDLED_CV.read_text())

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
@@ -234,3 +234,8 @@ class CV:
             pathlib.Path(filename).read_text(encoding="utf-8"),
             source=str(filename),
         )
+
+
+if __name__ == "__main__":
+    # Write the bundled CV to stdout so it can be copied and extended.
+    print(BUNDLED_CV.read_text())

--- a/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
+++ b/packages/climate-ref-core/src/climate_ref_core/pycmec/controlled_vocabulary.py
@@ -10,7 +10,6 @@ from yaml import safe_load
 from climate_ref_core.data import FileResource, Resource
 from climate_ref_core.exceptions import ResultValidationError
 from climate_ref_core.metric_values import ScalarMetricValue, SeriesMetricValue
-from climate_ref_core.pycmec import BUNDLED_CV
 from climate_ref_core.pycmec.metric import CMECMetric
 
 RESERVED_DIMENSION_NAMES = {"attributes", "json_structure", "created_at", "updated_at", "value", "id"}
@@ -225,7 +224,3 @@ class CV:
 
         """
         return CV.load(FileResource(pathlib.Path(filename)))
-
-
-if __name__ == "__main__":  # pragma: no cover
-    print(BUNDLED_CV.read_text())

--- a/packages/climate-ref-core/src/climate_ref_core/testing.py
+++ b/packages/climate-ref-core/src/climate_ref_core/testing.py
@@ -20,7 +20,7 @@ import yaml
 from attrs import field, frozen
 from loguru import logger
 
-from climate_ref_core.dataset_registry import resolve_cache_dir
+from climate_ref_core.data import resolve_cache_dir
 from climate_ref_core.datasets import (
     DatasetCollection,
     ExecutionDatasetCollection,

--- a/packages/climate-ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
+++ b/packages/climate-ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
@@ -1,7 +1,7 @@
 import pytest
 
 from climate_ref_core.exceptions import ResultValidationError
-from climate_ref_core.pycmec import BUNDLED_CV
+from climate_ref_core.pycmec import BUNDLED_AFT_CV
 from climate_ref_core.pycmec.controlled_vocabulary import CV, Dimension
 from climate_ref_core.pycmec.metric import CMECMetric
 
@@ -119,6 +119,6 @@ def test_missing_value(cv, cmec_metric):
 def test_load_from_file_round_trips(tmp_path):
     """The path-based loader is kept for callers outside this repository."""
     source = tmp_path / "cv.yaml"
-    source.write_text(BUNDLED_CV.read_text(), encoding="utf-8")
+    source.write_text(BUNDLED_AFT_CV.read_text(), encoding="utf-8")
 
-    assert CV.load_from_file(source) == CV.load(BUNDLED_CV)
+    assert CV.load_from_file(source) == CV.load(BUNDLED_AFT_CV)

--- a/packages/climate-ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
+++ b/packages/climate-ref-core/tests/unit/pycmec/test_controlled_vocabulary.py
@@ -1,6 +1,7 @@
 import pytest
 
 from climate_ref_core.exceptions import ResultValidationError
+from climate_ref_core.pycmec import BUNDLED_CV
 from climate_ref_core.pycmec.controlled_vocabulary import CV, Dimension
 from climate_ref_core.pycmec.metric import CMECMetric
 
@@ -113,3 +114,11 @@ def test_missing_value(cv, cmec_metric):
     )
     with pytest.raises(ResultValidationError, match="Unknown value 'unknown' for dimension 'statistic'"):
         cv.validate_metrics(cmec_metric)
+
+
+def test_load_from_file_round_trips(tmp_path):
+    """The path-based loader is kept for callers outside this repository."""
+    source = tmp_path / "cv.yaml"
+    source.write_text(BUNDLED_CV.read_text(), encoding="utf-8")
+
+    assert CV.load_from_file(source) == CV.load(BUNDLED_CV)

--- a/packages/climate-ref-core/tests/unit/test_data.py
+++ b/packages/climate-ref-core/tests/unit/test_data.py
@@ -38,6 +38,14 @@ class TestPackagedResource:
             assert path.is_file()
             assert path.read_text(encoding="utf-8") == CV.read_text()
 
+    def test_as_path_missing_resource_raises_data_resource_error(self):
+        # as_file() hands back a path that does not exist, so the lookup has to check.
+        missing = PackagedResource("climate_ref_core.pycmec", "nope.yaml")
+
+        with pytest.raises(DataResourceError, match="Could not read"):
+            with missing.as_path():
+                pass
+
     def test_as_path_does_not_swallow_body_errors(self):
         # An OSError raised by the caller must propagate unchanged, not be relabelled
         # as a resolution failure.

--- a/packages/climate-ref-core/tests/unit/test_data.py
+++ b/packages/climate-ref-core/tests/unit/test_data.py
@@ -6,8 +6,10 @@ import pytest
 
 from climate_ref_core.data import (
     DataResourceError,
+    FileResource,
     LayeredResource,
     PackagedResource,
+    Resource,
     ResourceOrigin,
     resolve_cache_dir,
 )
@@ -50,6 +52,40 @@ class TestPackagedResource:
 
     def test_str(self):
         assert str(CV) == "climate_ref_core.pycmec/cv_cmip7_aft.yaml"
+
+
+class TestFileResource:
+    def test_satisfies_the_resource_protocol(self):
+        assert isinstance(FileResource(Path("/nowhere")), Resource)
+        assert isinstance(CV, Resource)
+
+    def test_read_text(self, tmp_path):
+        target = tmp_path / "a.yaml"
+        target.write_text("contents", encoding="utf-8")
+
+        assert FileResource(target).read_text() == "contents"
+
+    def test_exists(self, tmp_path):
+        assert not FileResource(tmp_path / "missing.yaml").exists()
+
+    def test_read_missing_raises(self, tmp_path):
+        with pytest.raises(DataResourceError, match="Could not read"):
+            FileResource(tmp_path / "missing.yaml").read_text()
+
+    def test_open_missing_raises(self, tmp_path):
+        with pytest.raises(DataResourceError, match="Could not open"):
+            with FileResource(tmp_path / "missing.yaml").open_text():
+                pass
+
+    def test_as_path_returns_the_path_itself(self, tmp_path):
+        target = tmp_path / "a.yaml"
+        target.write_text("contents", encoding="utf-8")
+
+        with FileResource(target).as_path() as path:
+            assert path == target
+
+    def test_str(self, tmp_path):
+        assert str(FileResource(tmp_path / "a.yaml")) == str(tmp_path / "a.yaml")
 
 
 class TestLayeredResource:

--- a/packages/climate-ref-core/tests/unit/test_data.py
+++ b/packages/climate-ref-core/tests/unit/test_data.py
@@ -9,7 +9,6 @@ from climate_ref_core.data import (
     FileResource,
     LayeredResource,
     PackagedResource,
-    Resource,
     ResourceOrigin,
     resolve_cache_dir,
 )
@@ -34,10 +33,6 @@ class TestPackagedResource:
         with pytest.raises(DataResourceError, match="Could not read"):
             PackagedResource("climate_ref_core.pycmec", "nope.yaml").read_text()
 
-    def test_open_text(self):
-        with CV.open_text() as handle:
-            assert handle.read() == CV.read_text()
-
     def test_as_path(self):
         with CV.as_path() as path:
             assert path.is_file()
@@ -55,10 +50,6 @@ class TestPackagedResource:
 
 
 class TestFileResource:
-    def test_satisfies_the_resource_protocol(self):
-        assert isinstance(FileResource(Path("/nowhere")), Resource)
-        assert isinstance(CV, Resource)
-
     def test_read_text(self, tmp_path):
         target = tmp_path / "a.yaml"
         target.write_text("contents", encoding="utf-8")
@@ -71,11 +62,6 @@ class TestFileResource:
     def test_read_missing_raises(self, tmp_path):
         with pytest.raises(DataResourceError, match="Could not read"):
             FileResource(tmp_path / "missing.yaml").read_text()
-
-    def test_open_missing_raises(self, tmp_path):
-        with pytest.raises(DataResourceError, match="Could not open"):
-            with FileResource(tmp_path / "missing.yaml").open_text():
-                pass
 
     def test_as_path_returns_the_path_itself(self, tmp_path):
         target = tmp_path / "a.yaml"
@@ -140,15 +126,6 @@ class TestLayeredResource:
         resource = LayeredResource(packaged=CV, override=tmp_path / "missing.yaml")
 
         assert resource.describe() == f"{tmp_path / 'missing.yaml'} (missing)"
-
-    def test_open_text_from_each_layer(self, tmp_path):
-        override = tmp_path / "override.yaml"
-        override.write_text("override", encoding="utf-8")
-
-        with LayeredResource(packaged=CV).open_text() as handle:
-            assert handle.read() == CV.read_text()
-        with LayeredResource(packaged=CV, override=override).open_text() as handle:
-            assert handle.read() == "override"
 
     def test_as_path_from_each_layer(self, tmp_path):
         override = tmp_path / "override.yaml"

--- a/packages/climate-ref-core/tests/unit/test_data.py
+++ b/packages/climate-ref-core/tests/unit/test_data.py
@@ -143,6 +143,12 @@ class TestResolveCacheDir:
 
         assert resolve_cache_dir("grey_list") == Path("/somewhere/else/grey_list")
 
+    def test_unresolvable_user_is_left_alone(self, monkeypatch):
+        # `~nosuchuser` cannot be expanded. That must not fail the caller.
+        monkeypatch.setenv("REF_DATASET_CACHE_DIR", "~nosuchuser12345/cache")
+
+        assert resolve_cache_dir("grey_list").parts[-2:] == ("cache", "grey_list")
+
     def test_environment_variable_expansion(self, monkeypatch):
         monkeypatch.setenv("A_ROOT", "/expanded")
         monkeypatch.setenv("REF_DATASET_CACHE_DIR", "$A_ROOT/cache")

--- a/packages/climate-ref-core/tests/unit/test_data.py
+++ b/packages/climate-ref-core/tests/unit/test_data.py
@@ -127,15 +127,6 @@ class TestLayeredResource:
 
         assert resource.describe() == f"{tmp_path / 'missing.yaml'} (missing)"
 
-    def test_as_path_from_each_layer(self, tmp_path):
-        override = tmp_path / "override.yaml"
-        override.write_text("override", encoding="utf-8")
-
-        with LayeredResource(packaged=CV).as_path() as path:
-            assert path.read_text(encoding="utf-8") == CV.read_text()
-        with LayeredResource(packaged=CV, override=override).as_path() as path:
-            assert path == override
-
 
 class TestResolveCacheDir:
     def test_default_root(self, monkeypatch, mocker):

--- a/packages/climate-ref-core/tests/unit/test_data.py
+++ b/packages/climate-ref-core/tests/unit/test_data.py
@@ -1,0 +1,146 @@
+"""Tests for the layered resolution of data files distributed with the REF."""
+
+from pathlib import Path
+
+import pytest
+
+from climate_ref_core.data import (
+    DataResourceError,
+    LayeredResource,
+    PackagedResource,
+    ResourceOrigin,
+    resolve_cache_dir,
+)
+
+CV = PackagedResource("climate_ref_core.pycmec", "cv_cmip7_aft.yaml")
+
+
+class TestPackagedResource:
+    def test_exists(self):
+        assert CV.exists()
+
+    def test_missing_resource_does_not_exist(self):
+        assert not PackagedResource("climate_ref_core.pycmec", "nope.yaml").exists()
+
+    def test_missing_package_does_not_exist(self):
+        assert not PackagedResource("climate_ref_core.not_a_package", "nope.yaml").exists()
+
+    def test_read_text(self):
+        assert "dimensions" in CV.read_text()
+
+    def test_read_missing_raises(self):
+        with pytest.raises(DataResourceError, match="Could not read"):
+            PackagedResource("climate_ref_core.pycmec", "nope.yaml").read_text()
+
+    def test_open_text(self):
+        with CV.open_text() as handle:
+            assert handle.read() == CV.read_text()
+
+    def test_as_path(self):
+        with CV.as_path() as path:
+            assert path.is_file()
+            assert path.read_text(encoding="utf-8") == CV.read_text()
+
+    def test_as_path_does_not_swallow_body_errors(self):
+        # An OSError raised by the caller must propagate unchanged, not be relabelled
+        # as a resolution failure.
+        with pytest.raises(OSError, match="from the body"):
+            with CV.as_path():
+                raise OSError("from the body")
+
+    def test_str(self):
+        assert str(CV) == "climate_ref_core.pycmec/cv_cmip7_aft.yaml"
+
+
+class TestLayeredResource:
+    def test_falls_back_to_package(self):
+        resource = LayeredResource(packaged=CV)
+
+        assert resource.origin == ResourceOrigin.package
+        assert resource.read_text() == CV.read_text()
+        assert resource.describe() == f"{CV} (package)"
+
+    def test_cache_wins_over_package(self, tmp_path):
+        cache = tmp_path / "cached.yaml"
+        cache.write_text("cached", encoding="utf-8")
+
+        resource = LayeredResource(packaged=CV, cache=cache)
+
+        assert resource.origin == ResourceOrigin.cache
+        assert resource.read_text() == "cached"
+
+    def test_absent_cache_falls_through(self, tmp_path):
+        resource = LayeredResource(packaged=CV, cache=tmp_path / "missing.yaml")
+
+        assert resource.origin == ResourceOrigin.package
+
+    def test_cache_populated_later_is_picked_up(self, tmp_path):
+        cache = tmp_path / "cached.yaml"
+        resource = LayeredResource(packaged=CV, cache=cache)
+        assert resource.origin == ResourceOrigin.package
+
+        cache.write_text("cached", encoding="utf-8")
+
+        assert resource.origin == ResourceOrigin.cache
+
+    def test_override_wins_over_cache(self, tmp_path):
+        cache = tmp_path / "cached.yaml"
+        cache.write_text("cached", encoding="utf-8")
+        override = tmp_path / "override.yaml"
+        override.write_text("override", encoding="utf-8")
+
+        resource = LayeredResource(packaged=CV, override=override, cache=cache)
+
+        assert resource.origin == ResourceOrigin.override
+        assert resource.read_text() == "override"
+
+    def test_missing_override_raises_with_guidance(self, tmp_path):
+        resource = LayeredResource(packaged=CV, override=tmp_path / "missing.yaml")
+
+        with pytest.raises(DataResourceError, match="does not exist"):
+            resource.read_text()
+
+    def test_describe_never_raises_for_a_missing_override(self, tmp_path):
+        resource = LayeredResource(packaged=CV, override=tmp_path / "missing.yaml")
+
+        assert resource.describe() == f"{tmp_path / 'missing.yaml'} (missing)"
+
+    def test_open_text_from_each_layer(self, tmp_path):
+        override = tmp_path / "override.yaml"
+        override.write_text("override", encoding="utf-8")
+
+        with LayeredResource(packaged=CV).open_text() as handle:
+            assert handle.read() == CV.read_text()
+        with LayeredResource(packaged=CV, override=override).open_text() as handle:
+            assert handle.read() == "override"
+
+    def test_as_path_from_each_layer(self, tmp_path):
+        override = tmp_path / "override.yaml"
+        override.write_text("override", encoding="utf-8")
+
+        with LayeredResource(packaged=CV).as_path() as path:
+            assert path.read_text(encoding="utf-8") == CV.read_text()
+        with LayeredResource(packaged=CV, override=override).as_path() as path:
+            assert path == override
+
+
+class TestResolveCacheDir:
+    def test_default_root(self, monkeypatch, mocker):
+        monkeypatch.delenv("REF_DATASET_CACHE_DIR", raising=False)
+        mocker.patch(
+            "climate_ref_core.data.platformdirs.user_cache_path",
+            return_value=Path("/cache/climate_ref"),
+        )
+
+        assert resolve_cache_dir("grey_list") == Path("/cache/climate_ref/grey_list")
+
+    def test_environment_variable_root(self, monkeypatch):
+        monkeypatch.setenv("REF_DATASET_CACHE_DIR", "/somewhere/else")
+
+        assert resolve_cache_dir("grey_list") == Path("/somewhere/else/grey_list")
+
+    def test_environment_variable_expansion(self, monkeypatch):
+        monkeypatch.setenv("A_ROOT", "/expanded")
+        monkeypatch.setenv("REF_DATASET_CACHE_DIR", "$A_ROOT/cache")
+
+        assert resolve_cache_dir("grey_list") == Path("/expanded/cache/grey_list")

--- a/packages/climate-ref-core/tests/unit/test_dataset_registry/test_dataset_registry.py
+++ b/packages/climate-ref-core/tests/unit/test_dataset_registry/test_dataset_registry.py
@@ -1,4 +1,5 @@
 import importlib.resources
+import logging
 from pathlib import Path
 
 import pytest
@@ -126,12 +127,15 @@ class TestDatasetRegistry:
         base_url = "http://example.com"
 
         mock_pooch = mocker.patch("climate_ref_core.dataset_registry.pooch")
-        mock_pooch.os_cache.return_value = Path("/path/to/climate_ref")
+        mock_cache = mocker.patch(
+            "climate_ref_core.data.platformdirs.user_cache_path",
+            return_value=Path("/path/to/climate_ref"),
+        )
         package, resource = self.setup_registry_file(fake_registry_file)
 
         registry.register(name, base_url, package, resource, cache_name=cache_name)
 
-        mock_pooch.os_cache.assert_called_with("climate_ref")
+        mock_cache.assert_called_with("climate_ref")
         assert name in registry._registries
         expected_kwargs = {
             "base_url": "http://example.com",
@@ -160,7 +164,10 @@ class TestDatasetRegistry:
         base_url = "http://example.com"
 
         mock_pooch = mocker.patch("climate_ref_core.dataset_registry.pooch")
-        mock_pooch.os_cache.return_value = Path("/path/to/climate_ref")
+        mocker.patch(
+            "climate_ref_core.data.platformdirs.user_cache_path",
+            return_value=Path("/path/to/climate_ref"),
+        )
         package, resource = self.setup_registry_file(fake_registry_file)
 
         registry.register(name, base_url, package, resource)
@@ -274,6 +281,36 @@ class TestMigrateCache:
         DatasetRegistryManager._migrate_cache(mock_registry, [legacy_dir])
 
         assert not (new_dir / "file1.txt").exists()
+
+    def test_migrate_unwritable_target_is_not_fatal(self, tmp_path, caplog):
+        """Registration happens at import time, so a read-only cache must not break importing."""
+        legacy_dir = tmp_path / "old_cache"
+        legacy_dir.mkdir()
+        (legacy_dir / "file1.txt").write_text("legacy_data")
+
+        readonly_root = tmp_path / "readonly"
+        readonly_root.mkdir()
+        readonly_root.chmod(0o500)
+        new_dir = readonly_root / "new_cache"
+
+        mock_registry = type(
+            "R",
+            (),
+            {
+                "abspath": new_dir,
+                "registry": {"file1.txt": "sha256:a"},
+            },
+        )()
+
+        try:
+            with caplog.at_level(logging.WARNING):
+                DatasetRegistryManager._migrate_cache(mock_registry, [legacy_dir])
+        finally:
+            readonly_root.chmod(0o700)
+
+        # The legacy file is left untouched and will be refetched if it is ever needed.
+        assert (legacy_dir / "file1.txt").read_text() == "legacy_data"
+        assert "Could not migrate cached file" in caplog.text
 
     def test_register_with_legacy_cache_dirs(self, tmp_path, mocker, fake_registry_file):
         """Integration test: register() with legacy_cache_dirs triggers migration."""

--- a/packages/climate-ref-core/tests/unit/test_packaging.py
+++ b/packages/climate-ref-core/tests/unit/test_packaging.py
@@ -1,11 +1,35 @@
 """
-Tests that guard the shape of the installed ``climate_ref_core`` package.
+Tests that guard the data files shipped inside the installed packages.
+
+None of these files are configured explicitly in any `pyproject.toml`.
+They ride on the hatchling default of including everything under `src/<package>`,
+so a build backend change or a stray exclude would drop them silently.
+Every file the REF reads out of a package at runtime is listed here.
 """
 
 import importlib.resources
 
 import pytest
 import yaml
+
+from climate_ref_core.data import PackagedResource
+
+# Every data file the REF reads out of an installed package at runtime.
+BUNDLED_FILES = [
+    ("climate_ref_core.pycmec", "cv_cmip7_aft.yaml"),
+    ("climate_ref_core", "data/cmip6_cmip7_variable_map.json"),
+    ("climate_ref", "default_ignore_datasets.yaml"),
+    ("climate_ref.dataset_registry", "obs4ref_reference.txt"),
+    ("climate_ref.dataset_registry", "sample_data.txt"),
+    ("climate_ref.dataset_registry", "quickstart.txt"),
+    ("climate_ref_ilamb.dataset_registry", "ilamb.txt"),
+    ("climate_ref_ilamb.dataset_registry", "ilamb_regions.txt"),
+    ("climate_ref_ilamb.configure", "ilamb.yaml"),
+    ("climate_ref_ilamb.configure", "iomb.yaml"),
+    ("climate_ref_pmp.dataset_registry", "pmp_climatology.txt"),
+    ("climate_ref_esmvaltool.dataset_registry", "data.txt"),
+    ("climate_ref_esmvaltool", "recipes.txt"),
+]
 
 
 def test_pycmec_package_data_is_importable():
@@ -14,16 +38,36 @@ def test_pycmec_package_data_is_importable():
     assert files.is_dir()
 
 
-@pytest.mark.parametrize("filename", ["cv_cmip7_aft.yaml"])
-def test_bundled_data_files_resolve(filename):
+def _require(package: str) -> None:
+    """Skip when the owning package is not installed, so core can be tested on its own."""
+    pytest.importorskip(package.split(".", maxsplit=1)[0])
+
+
+@pytest.mark.parametrize("package, resource", BUNDLED_FILES, ids=lambda value: value)
+def test_bundled_data_files_resolve(package, resource):
     """Bundled package-data files must resolve and be readable from the wheel."""
-    resource = importlib.resources.files("climate_ref_core.pycmec") / filename
+    _require(package)
+    packaged = PackagedResource(package, resource)
 
-    assert resource.is_file(), f"{filename} is missing from the installed climate_ref_core package"
+    assert packaged.exists(), f"{packaged} is missing from the installed package"
 
-    contents = resource.read_text(encoding="utf-8")
-    assert contents, f"{filename} resolved but is empty"
+    contents = packaged.read_text()
+    assert contents, f"{packaged} resolved but is empty"
 
-    # The CV YAML must parse — a truncated or corrupt file would break startup.
-    parsed = yaml.safe_load(contents)
+
+@pytest.mark.parametrize(
+    "package, resource",
+    [
+        ("climate_ref_core.pycmec", "cv_cmip7_aft.yaml"),
+        ("climate_ref", "default_ignore_datasets.yaml"),
+        ("climate_ref_ilamb.configure", "ilamb.yaml"),
+        ("climate_ref_ilamb.configure", "iomb.yaml"),
+    ],
+    ids=lambda value: value,
+)
+def test_bundled_yaml_files_parse(package, resource):
+    """A truncated or corrupt YAML file would break startup, so parse each one."""
+    _require(package)
+    parsed = yaml.safe_load(PackagedResource(package, resource).read_text())
+
     assert isinstance(parsed, dict)

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -111,10 +111,12 @@ class TestDiagnosticProvider:
             override=mock_config.ignore_datasets_file,
         )
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             provider.configure(mock_config)
 
-        assert "falling back to climate_ref/default_ignore_datasets.yaml" in caplog.text
+        # The override is reported as unreadable, and the packaged copy is used instead.
+        assert f"Could not read the grey list from {mock_config.ignore_datasets_file}" in caplog.text
+        assert "using the grey list from climate_ref/default_ignore_datasets.yaml" in caplog.text
 
     def test_configure_unknown_diagnostic(self, provider, mock_config, caplog):
         mock_config.ignore_datasets_file.write_text(

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -12,6 +12,7 @@ from requests import Response
 
 import climate_ref_core.providers
 from climate_ref_core.constraints import IgnoreFacets
+from climate_ref_core.data import LayeredResource, PackagedResource
 from climate_ref_core.diagnostics import CommandLineDiagnostic, Diagnostic
 from climate_ref_core.exceptions import (
     CondaCommandError,
@@ -28,6 +29,12 @@ def mock_config(tmp_path, mocker):
     config.paths.software = tmp_path / "software"
     config.ignore_datasets_file = tmp_path / "ignore_datasets.yaml"
     config.ignore_datasets_file.touch()
+    # The grey list is resolved through a real LayeredResource so the tests exercise
+    # the same resolution the application uses.
+    config.ignore_datasets_resource = LayeredResource(
+        packaged=PackagedResource("climate_ref_core.pycmec", "cv_cmip7_aft.yaml"),
+        override=config.ignore_datasets_file,
+    )
     return config
 
 
@@ -91,7 +98,8 @@ class TestDiagnosticProvider:
         mock_config.ignore_datasets_file.unlink()
         with caplog.at_level(logging.WARNING):
             provider.configure(mock_config)
-        assert f"Ignore datasets file {mock_config.ignore_datasets_file} not found" in caplog.text
+        assert "Could not read the grey list" in caplog.text
+        assert str(mock_config.ignore_datasets_file) in caplog.text
 
     def test_configure_unknown_diagnostic(self, provider, mock_config, caplog):
         mock_config.ignore_datasets_file.write_text(
@@ -108,7 +116,7 @@ class TestDiagnosticProvider:
         with caplog.at_level(logging.WARNING):
             provider.configure(mock_config)
         expected_msg = (
-            f"Unknown diagnostics found in {mock_config.ignore_datasets_file} "
+            f"Unknown diagnostics found in {mock_config.ignore_datasets_file} (override) "
             "for provider mock_provider: invalid_diagnostic"
         )
         assert expected_msg in caplog.text
@@ -128,7 +136,7 @@ class TestDiagnosticProvider:
         with caplog.at_level(logging.WARNING):
             provider.configure(mock_config)
         expected_msg = (
-            f"Unknown source types found in {mock_config.ignore_datasets_file} "
+            f"Unknown source types found in {mock_config.ignore_datasets_file} (override) "
             "for diagnostic 'mock' by provider mock_provider: invalid_source_type"
         )
         assert expected_msg in caplog.text

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -140,6 +140,15 @@ class TestDiagnosticProvider:
 
         assert "No grey list could be read" in caplog.text
 
+    def test_configure_ignores_a_grey_list_that_is_not_a_mapping(self, provider, mock_config, caplog):
+        # A hand-edited list at the top level must not crash the provider.
+        mock_config.ignore_datasets_file.write_text("- not: a mapping\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            provider.configure(mock_config)
+
+        assert "is not a mapping" in caplog.text
+
     def test_configure_unknown_diagnostic(self, provider, mock_config, caplog):
         mock_config.ignore_datasets_file.write_text(
             textwrap.dedent(

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -101,6 +101,21 @@ class TestDiagnosticProvider:
         assert "Could not read the grey list" in caplog.text
         assert str(mock_config.ignore_datasets_file) in caplog.text
 
+    def test_configure_missing_override_falls_back_to_the_packaged_grey_list(
+        self, provider, mock_config, caplog
+    ):
+        # A mistyped ignore_datasets_file must not silently drop the grey list protections.
+        mock_config.ignore_datasets_file.unlink()
+        mock_config.ignore_datasets_resource = LayeredResource(
+            packaged=PackagedResource("climate_ref", "default_ignore_datasets.yaml"),
+            override=mock_config.ignore_datasets_file,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            provider.configure(mock_config)
+
+        assert "falling back to climate_ref/default_ignore_datasets.yaml" in caplog.text
+
     def test_configure_unknown_diagnostic(self, provider, mock_config, caplog):
         mock_config.ignore_datasets_file.write_text(
             textwrap.dedent(

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -12,7 +12,7 @@ from requests import Response
 
 import climate_ref_core.providers
 from climate_ref_core.constraints import IgnoreFacets
-from climate_ref_core.data import LayeredResource, PackagedResource
+from climate_ref_core.data import DataResourceError, LayeredResource, PackagedResource
 from climate_ref_core.diagnostics import CommandLineDiagnostic, Diagnostic
 from climate_ref_core.exceptions import (
     CondaCommandError,
@@ -117,6 +117,28 @@ class TestDiagnosticProvider:
         # The override is reported as unreadable, and the packaged copy is used instead.
         assert f"Could not read the grey list from {mock_config.ignore_datasets_file}" in caplog.text
         assert "using the grey list from climate_ref/default_ignore_datasets.yaml" in caplog.text
+
+    def test_configure_warns_when_no_grey_list_can_be_read(self, provider, mock_config, caplog, mocker):
+        # Both the override and the packaged copy failing must be said out loud.
+        mock_config.ignore_datasets_file.unlink()
+        packaged = mocker.Mock()
+        packaged.read_text.side_effect = DataResourceError("packaged copy is missing")
+        packaged.describe.return_value = "packaged"
+        packaged.__str__ = mocker.Mock(return_value="packaged")
+        mock_config.ignore_datasets_resource = LayeredResource(
+            packaged=PackagedResource("climate_ref", "default_ignore_datasets.yaml"),
+            override=mock_config.ignore_datasets_file,
+        )
+        mocker.patch.object(
+            type(mock_config.ignore_datasets_resource.packaged),
+            "read_text",
+            side_effect=DataResourceError("packaged copy is missing"),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            provider.configure(mock_config)
+
+        assert "No grey list could be read" in caplog.text
 
     def test_configure_unknown_diagnostic(self, provider, mock_config, caplog):
         mock_config.ignore_datasets_file.write_text(

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/__init__.py
@@ -11,12 +11,12 @@ import pooch
 from loguru import logger
 
 import climate_ref_esmvaltool.diagnostics
+from climate_ref_core.data import resolve_cache_dir
 from climate_ref_core.dataset_registry import (
     DATASET_URL,
     RegistryUseCase,
     dataset_registry_manager,
     fetch_all_files,
-    resolve_cache_dir,
     validate_registry_cache,
 )
 from climate_ref_core.providers import CondaDiagnosticProvider

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
@@ -15,12 +15,12 @@ from typing import TYPE_CHECKING
 import yaml
 from loguru import logger
 
+from climate_ref_core.data import resolve_cache_dir
 from climate_ref_core.dataset_registry import (
     DATASET_URL,
     RegistryUseCase,
     dataset_registry_manager,
     fetch_all_files,
-    resolve_cache_dir,
     validate_registry_cache,
 )
 from climate_ref_core.providers import DiagnosticProvider
@@ -106,10 +106,17 @@ dataset_registry_manager.register(
     use_case=RegistryUseCase.support,
 )
 
-# Dynamically register ILAMB diagnostics
-for yaml_file in importlib.resources.files("climate_ref_ilamb.configure").iterdir():
-    with open(str(yaml_file)) as fin:
-        metrics = yaml.safe_load(fin)
+# Dynamically register ILAMB diagnostics.
+# Sorted so the registration order does not depend on the filesystem,
+# and restricted to YAML so a stray __pycache__ entry is never opened.
+_configure_files = sorted(
+    (entry for entry in importlib.resources.files("climate_ref_ilamb.configure").iterdir()),
+    key=lambda entry: entry.name,
+)
+for yaml_file in _configure_files:
+    if not yaml_file.name.endswith(".yaml"):
+        continue
+    metrics = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
     realm = metrics.pop("realm")
     region_masks = metrics.pop("region_masks", None)
     for metric, options in metrics.items():

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
 
 __version__ = importlib.metadata.version("climate-ref-ilamb")
 
-# Registry names used by ILAMB
 _REGISTRY_NAMES = ("ilamb-test", "ilamb", "ilamb-regions")
 
 
@@ -65,11 +64,9 @@ class ILAMBProvider(DiagnosticProvider):
     def get_data_path(self) -> Path | None:
         """Get the path where ILAMB data is cached."""
         # The "ilamb-regions" registry is registered with cache_name="ilamb" so its
-        # files (region masks) land in the same cache directory as the "ilamb"
-        # registry (reference obs).
+        # files (region masks) land in the same cache directory as the "ilamb" registry (reference obs).
         # Together those two registries are the data an ingest or `ref providers setup` run cares about,
-        # so this single path covers them both. The small "ilamb-test" fixture registry keeps
-        # its own "ilamb-test" cache directory and is intentionally not reported here.
+        # so this single path covers them both.
         return resolve_cache_dir("ilamb")
 
 
@@ -87,28 +84,23 @@ dataset_registry_manager.register(
     base_url=DATASET_URL,
     package="climate_ref_ilamb.dataset_registry",
     resource="ilamb.txt",
-    # A plain fetch registry, with no source type (its use case defaults to ``support``), so it
-    # is not a reference source type. It holds the few reference observations that ILAMB still
-    # needs but that are not yet published to obs4MIPs/obs4REF (currently WangMao, GLEAMv3 and
-    # CRU4.02). The provider fetches these at execute time via registry_to_collection; they are
-    # not ingested. As each dataset is published, it moves to the obs4ref registry and drops out
-    # of ilamb.txt.
+    # Holds the few reference observations  that are not yet published to obs4MIPs/obs4REF
+    # (currently WangMao, GLEAMv3 and CRU4.02).
+    # The provider fetches these at execute time via registry_to_collection; they are not ingested.
+    # As each dataset is published, it moves to the obs4ref registry and drops out of ilamb.txt.
 )
 dataset_registry_manager.register(
     "ilamb-regions",
     base_url=DATASET_URL,
     package="climate_ref_ilamb.dataset_registry",
     resource="ilamb_regions.txt",
-    # Shares the "ilamb" cache directory: these masks were fetched under it
-    # before the registry was split, and the two registries are covered
-    # together by get_data_path() above.
+    # Shares the "ilamb" cache directory for legacy reasons.
     cache_name="ilamb",
     use_case=RegistryUseCase.support,
 )
 
 # Dynamically register ILAMB diagnostics.
-# Sorted so the registration order does not depend on the filesystem,
-# and restricted to YAML so a stray __pycache__ entry is never opened.
+# Sorted so the registration order does not depend on the filesystem
 _configure_files = sorted(
     importlib.resources.files("climate_ref_ilamb.configure").iterdir(),
     key=lambda entry: entry.name,

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/__init__.py
@@ -110,7 +110,7 @@ dataset_registry_manager.register(
 # Sorted so the registration order does not depend on the filesystem,
 # and restricted to YAML so a stray __pycache__ entry is never opened.
 _configure_files = sorted(
-    (entry for entry in importlib.resources.files("climate_ref_ilamb.configure").iterdir()),
+    importlib.resources.files("climate_ref_ilamb.configure").iterdir(),
     key=lambda entry: entry.name,
 )
 for yaml_file in _configure_files:

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
@@ -20,7 +20,8 @@ from loguru import logger
 
 from climate_ref_core.cmip6_to_cmip7 import get_dreq_entry
 from climate_ref_core.constraints import AddSupplementaryDataset, RequireFacets
-from climate_ref_core.dataset_registry import dataset_registry_manager, resolve_cache_dir
+from climate_ref_core.data import resolve_cache_dir
+from climate_ref_core.dataset_registry import dataset_registry_manager
 from climate_ref_core.datasets import (
     DatasetCollection,
     ExecutionDatasetCollection,

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
@@ -41,7 +41,10 @@ class PMPDiagnosticProvider(CondaDiagnosticProvider):
     def configure(self, config: Config) -> None:
         """Configure the provider."""
         super().configure(config)
-        self.env_vars["PCMDI_CONDA_EXE"] = str(self.get_conda_exe())
+        # The path, not the executable. Installing it here would put a download on the
+        # solve path, since the provider registry configures every provider it builds.
+        # The subprocesses that read this variable all run after `setup_environment`.
+        self.env_vars["PCMDI_CONDA_EXE"] = str(self.conda_exe_path)
         # This is a workaround for a fatal error in internal_Finalize of MPICH
         # when running in a conda environment on MacOS.
         # It is not clear if this is a bug in MPICH or a problem with the conda environment.

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
@@ -41,9 +41,6 @@ class PMPDiagnosticProvider(CondaDiagnosticProvider):
     def configure(self, config: Config) -> None:
         """Configure the provider."""
         super().configure(config)
-        # The path, not the executable. Installing it here would put a download on the
-        # solve path, since the provider registry configures every provider it builds.
-        # The subprocesses that read this variable all run after `setup_environment`.
         self.env_vars["PCMDI_CONDA_EXE"] = str(self.conda_exe_path)
         # This is a workaround for a fatal error in internal_Finalize of MPICH
         # when running in a conda environment on MacOS.

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
@@ -11,12 +11,12 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from climate_ref_core.data import resolve_cache_dir
 from climate_ref_core.dataset_registry import (
     DATASET_URL,
     RegistryUseCase,
     dataset_registry_manager,
     fetch_all_files,
-    resolve_cache_dir,
     validate_registry_cache,
 )
 from climate_ref_core.providers import CondaDiagnosticProvider

--- a/packages/climate-ref-pmp/tests/unit/test_provider.py
+++ b/packages/climate-ref-pmp/tests/unit/test_provider.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pooch
 from climate_ref_pmp import PMPDiagnosticProvider, __version__, provider
 
+from climate_ref_core.data import LayeredResource, PackagedResource
+
 
 def test_provider():
     assert provider.name == "PMP"
@@ -94,6 +96,10 @@ class TestPMPProviderHooks:
         mock_config.paths.software = tmp_path / "software"
         mock_config.ignore_datasets_file = tmp_path / "ignore.yaml"
         mock_config.ignore_datasets_file.touch()
+        mock_config.ignore_datasets_resource = LayeredResource(
+            packaged=PackagedResource("climate_ref", "default_ignore_datasets.yaml"),
+            override=mock_config.ignore_datasets_file,
+        )
 
         mocker.patch.object(test_provider, "get_conda_exe", return_value=Path("/path/to/conda"))
 

--- a/packages/climate-ref-pmp/tests/unit/test_provider.py
+++ b/packages/climate-ref-pmp/tests/unit/test_provider.py
@@ -101,12 +101,13 @@ class TestPMPProviderHooks:
             override=mock_config.ignore_datasets_file,
         )
 
-        mocker.patch.object(test_provider, "get_conda_exe", return_value=Path("/path/to/conda"))
-
         test_provider.configure(mock_config)
 
         assert "PCMDI_CONDA_EXE" in test_provider.env_vars
-        assert test_provider.env_vars["PCMDI_CONDA_EXE"] == "/path/to/conda"
+        # The path is recorded without installing anything, so `configure` stays offline.
+        assert test_provider.env_vars["PCMDI_CONDA_EXE"] == str(
+            mock_config.paths.software / "conda/micromamba"
+        )
         assert "FI_PROVIDER" in test_provider.env_vars
         assert test_provider.env_vars["FI_PROVIDER"] == "tcp"
 

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -28,7 +28,7 @@ from climate_ref_core.cmip6_to_cmip7 import (
     create_cmip7_path,
     format_cmip7_time_range,
 )
-from climate_ref_core.pycmec import BUNDLED_CV
+from climate_ref_core.pycmec import BUNDLED_AFT_CV
 from climate_ref_core.pycmec.controlled_vocabulary import CV
 
 # Ignore the alembic folder
@@ -111,7 +111,7 @@ def invoke_cli_unmigrated(config: Config, cli_runner: Callable[..., Any]) -> Cal
 
 @pytest.fixture(scope="session")
 def cmip7_aft_cv() -> CV:
-    return CV.load(BUNDLED_CV)
+    return CV.load(BUNDLED_AFT_CV)
 
 
 @pytest.fixture(scope="session")

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -28,7 +28,8 @@ from climate_ref_core.cmip6_to_cmip7 import (
     create_cmip7_path,
     format_cmip7_time_range,
 )
-from climate_ref_core.pycmec.controlled_vocabulary import BUNDLED_CV, CV
+from climate_ref_core.pycmec import BUNDLED_CV
+from climate_ref_core.pycmec.controlled_vocabulary import CV
 
 # Ignore the alembic folder
 collect_ignore = ["src/climate_ref/migrations"]
@@ -110,7 +111,7 @@ def invoke_cli_unmigrated(config: Config, cli_runner: Callable[..., Any]) -> Cal
 
 @pytest.fixture(scope="session")
 def cmip7_aft_cv() -> CV:
-    return CV.from_text(BUNDLED_CV.read_text(), source=str(BUNDLED_CV))
+    return CV.load(BUNDLED_CV)
 
 
 @pytest.fixture(scope="session")

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -1,5 +1,4 @@
 import dataclasses
-import importlib.resources
 import shutil
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -29,7 +28,7 @@ from climate_ref_core.cmip6_to_cmip7 import (
     create_cmip7_path,
     format_cmip7_time_range,
 )
-from climate_ref_core.pycmec.controlled_vocabulary import CV
+from climate_ref_core.pycmec.controlled_vocabulary import BUNDLED_CV, CV
 
 # Ignore the alembic folder
 collect_ignore = ["src/climate_ref/migrations"]
@@ -62,10 +61,8 @@ def _clone_db(target_db_url: str, template_db_path: Path) -> None:
 def migrated_db_template(tmp_path_session: Path) -> Path:
     """Build the current database schema once for reuse by isolated test databases."""
     template_db_path = tmp_path_session / "climate_ref_template.db"
+    # dimensions_cv is left unset so the CV shipped in climate_ref_core is used.
     template_config = Config()
-    template_config.paths.dimensions_cv = Path(
-        str(importlib.resources.files("climate_ref_core.pycmec") / "cv_cmip7_aft.yaml")
-    )
     template_config.db.database_url = f"sqlite:///{template_db_path}"
 
     database = Database.from_config(template_config, run_migrations=True, skip_backup=True)
@@ -113,9 +110,7 @@ def invoke_cli_unmigrated(config: Config, cli_runner: Callable[..., Any]) -> Cal
 
 @pytest.fixture(scope="session")
 def cmip7_aft_cv() -> CV:
-    cv_file = str(importlib.resources.files("climate_ref_core.pycmec") / "cv_cmip7_aft.yaml")
-
-    return CV.load_from_file(cv_file)
+    return CV.from_text(BUNDLED_CV.read_text(), source=str(BUNDLED_CV))
 
 
 @pytest.fixture(scope="session")

--- a/packages/climate-ref/src/climate_ref/_config_helpers.py
+++ b/packages/climate-ref/src/climate_ref/_config_helpers.py
@@ -25,6 +25,29 @@ def _pop_empty(d: dict[str, Any]) -> None:
                 d.pop(key)
 
 
+def _pop_none(d: dict[str, Any]) -> None:
+    """
+    Remove keys whose value is None, recursively
+
+    TOML has no null, so an unset value is represented by the absence of the key.
+
+    Parameters
+    ----------
+    d
+        The unstructured configuration, modified in place.
+    """
+    for key in list(d.keys()):
+        value = d[key]
+        if value is None:
+            d.pop(key)
+        elif isinstance(value, dict):
+            _pop_none(value)
+        elif isinstance(value, list):
+            for entry in value:
+                if isinstance(entry, dict):
+                    _pop_none(entry)
+
+
 def _format_key_exception(exc: BaseException, _: type | None) -> str | None:
     """Format a n error exception."""
     if isinstance(exc, ForbiddenExtraKeysError):

--- a/packages/climate-ref/src/climate_ref/_config_helpers.py
+++ b/packages/climate-ref/src/climate_ref/_config_helpers.py
@@ -15,14 +15,39 @@ T = TypeVar("T")
 C = TypeVar("C", bound=type)
 
 
-def _pop_empty(d: dict[str, Any]) -> None:
-    keys = list(d.keys())
-    for key in keys:
+def _prune(d: dict[str, Any], should_drop: Callable[[Any], bool]) -> None:
+    """
+    Remove entries matching a predicate, recursively
+
+    Parameters
+    ----------
+    d
+        The unstructured configuration, modified in place.
+    should_drop
+        Returns True for values that should be removed.
+    """
+    for key in list(d.keys()):
         value = d[key]
         if isinstance(value, dict):
-            _pop_empty(value)
-            if not value:
-                d.pop(key)
+            _prune(value, should_drop)
+        elif isinstance(value, list):
+            for entry in value:
+                if isinstance(entry, dict):
+                    _prune(entry, should_drop)
+        if should_drop(d[key]):
+            d.pop(key)
+
+
+def _pop_empty(d: dict[str, Any]) -> None:
+    """
+    Remove keys whose value is an empty mapping, recursively
+
+    Parameters
+    ----------
+    d
+        The unstructured configuration, modified in place.
+    """
+    _prune(d, lambda value: isinstance(value, dict) and not value)
 
 
 def _pop_none(d: dict[str, Any]) -> None:
@@ -36,16 +61,7 @@ def _pop_none(d: dict[str, Any]) -> None:
     d
         The unstructured configuration, modified in place.
     """
-    for key in list(d.keys()):
-        value = d[key]
-        if value is None:
-            d.pop(key)
-        elif isinstance(value, dict):
-            _pop_none(value)
-        elif isinstance(value, list):
-            for entry in value:
-                if isinstance(entry, dict):
-                    _pop_none(entry)
+    _prune(d, lambda value: value is None)
 
 
 def _format_key_exception(exc: BaseException, _: type | None) -> str | None:

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -563,7 +563,10 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
         _write_atomically(path, response.content)
     except Exception as exc:
         # The packaged copy is always available, so a failed refresh is never fatal.
-        fallback = path if path is not None and path.is_file() else BUNDLED_IGNORE_DATASETS
+        usable_cache = (
+            path is not None and path.is_file() and _cache_age(path) <= DEFAULT_IGNORE_DATASETS_MAX_STALE
+        )
+        fallback = path if usable_cache else BUNDLED_IGNORE_DATASETS
         logger.warning(f"Could not refresh the grey list from {url}, using {fallback}: {exc}")
 
 
@@ -611,9 +614,8 @@ def _write_atomically(path: Path, content: bytes) -> None:
         # multi-user host, so it has to stay readable by them.
         temporary.chmod(0o644)
         temporary.replace(path)
-    except OSError:
+    finally:
         temporary.unlink(missing_ok=True)
-        raise
 
 
 @define(auto_attribs=True)

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -46,7 +46,7 @@ from climate_ref_core.data import LayeredResource, PackagedResource, resolve_cac
 from climate_ref_core.env import env
 from climate_ref_core.exceptions import InvalidExecutorException
 from climate_ref_core.logging import DEFAULT_LOG_FORMAT
-from climate_ref_core.pycmec.controlled_vocabulary import BUNDLED_CV
+from climate_ref_core.pycmec import BUNDLED_CV
 
 if TYPE_CHECKING:
     from climate_ref.database import Database
@@ -95,11 +95,9 @@ def _optional_path(path: str | Path | None) -> Path | None:
     """
     if path is None:
         return None
-    if isinstance(path, str):
-        if not path.strip():
-            return None
-        path = Path(path)
-    return Path(os.path.expandvars(str(path))).expanduser()
+    if isinstance(path, str) and not path.strip():
+        return None
+    return ensure_absolute_path(Path(path).expanduser())
 
 
 @config(prefix=env_prefix)
@@ -434,15 +432,20 @@ def default_providers() -> list[DiagnosticProviderConfig]:
 def _load_config(config_file: str | Path, doc: dict[str, Any]) -> "Config":
     # Try loading the configuration with strict validation
     try:
-        return _converter_defaults.structure(doc, Config)
+        loaded = _converter_defaults.structure(doc, Config)
     except Exception as exc:
         # Find the extra key errors which are displayed as warnings
         key_validation_errors = transform_error(exc, format_exception=_format_key_exception)
         for key_error in key_validation_errors:
             logger.warning(f"Error loading configuration from {config_file}: {key_error}")
+    else:
+        _drop_inherited_defaults(loaded)
+        return loaded
 
     # Try again with relaxed validation
-    return _converter_defaults_relaxed.structure(doc, Config)
+    loaded = _converter_defaults_relaxed.structure(doc, Config)
+    _drop_inherited_defaults(loaded)
+    return loaded
 
 
 DEFAULT_IGNORE_DATASETS_REFRESH_INTERVAL = datetime.timedelta(hours=6)
@@ -490,33 +493,29 @@ def _legacy_ignore_datasets_file() -> Path:
     return platformdirs.user_cache_path("climate_ref") / DEFAULT_IGNORE_DATASETS_FILENAME
 
 
-def _configured_ignore_datasets_file(config: "Config") -> Path | None:
+def _drop_inherited_defaults(config: "Config") -> None:
     """
-    Return the operator's chosen grey list, ignoring an inherited legacy default
+    Clear configuration values that only exist because an older release wrote its default out
 
     Before the grey list gained a packaged fallback its cache path was a config *default*,
     so `Config.save()` baked it into every `ref.toml`.
     Treating that value as a deliberate override would pin those installations to a stale
-    cache and silently disable refreshing, so it is treated as unset.
+    cache and silently disable refreshing.
+
+    Clearing it here rather than at each read site keeps `ref config get` honest
+    and stops `Config.save()` from writing the stale value out again.
 
     Parameters
     ----------
     config
-        The configuration to read `ignore_datasets_file` from.
-
-    Returns
-    -------
-    :
-        The configured path, or None when nothing was deliberately chosen.
+        The freshly loaded configuration, modified in place.
     """
-    configured = config.ignore_datasets_file
-    if configured is not None and configured == _legacy_ignore_datasets_file():
+    if config.ignore_datasets_file == _optional_path(_legacy_ignore_datasets_file()):
         logger.debug(
-            f"Ignoring inherited grey list default {configured}. "
-            "Remove `ignore_datasets_file` from your configuration to silence this."
+            f"Ignoring the inherited grey list default {config.ignore_datasets_file}. "
+            "It was written out by an older release rather than chosen."
         )
-        return None
-    return configured
+        config.ignore_datasets_file = None
 
 
 def refresh_ignore_datasets_file(config: "Config") -> None:
@@ -543,7 +542,7 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
     """
     url = config.ignore_datasets_url
 
-    if not url or _configured_ignore_datasets_file(config) is not None:
+    if not url or config.ignore_datasets_file is not None:
         return
 
     path: Path | None = None
@@ -730,7 +729,7 @@ class Config:
 
         return LayeredResource(
             packaged=BUNDLED_IGNORE_DATASETS,
-            override=_configured_ignore_datasets_file(self),
+            override=self.ignore_datasets_file,
             cache=cache,
         )
 

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -46,7 +46,7 @@ from climate_ref_core.data import LayeredResource, PackagedResource, resolve_cac
 from climate_ref_core.env import env
 from climate_ref_core.exceptions import InvalidExecutorException
 from climate_ref_core.logging import DEFAULT_LOG_FORMAT
-from climate_ref_core.pycmec import BUNDLED_CV
+from climate_ref_core.pycmec import BUNDLED_AFT_CV
 
 if TYPE_CHECKING:
     from climate_ref.database import Database
@@ -194,7 +194,7 @@ class PathConfig:
         :
             The resolved controlled vocabulary resource.
         """
-        return LayeredResource(packaged=BUNDLED_CV, override=self.dimensions_cv)
+        return LayeredResource(packaged=BUNDLED_AFT_CV, override=self.dimensions_cv)
 
 
 @config(prefix=env_prefix)

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -445,7 +445,7 @@ def _load_config(config_file: str | Path, doc: dict[str, Any]) -> "Config":
     return _converter_defaults_relaxed.structure(doc, Config)
 
 
-DEFAULT_IGNORE_DATASETS_MAX_AGE = datetime.timedelta(hours=6)
+DEFAULT_IGNORE_DATASETS_REFRESH_INTERVAL = datetime.timedelta(hours=6)
 DEFAULT_IGNORE_DATASETS_FILENAME = "default_ignore_datasets.yaml"
 DEFAULT_IGNORE_DATASETS_URL = f"https://raw.githubusercontent.com/Climate-REF/climate-ref/refs/heads/main/{DEFAULT_IGNORE_DATASETS_FILENAME}"
 
@@ -524,7 +524,7 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
     Refresh the cached grey list from `config.ignore_datasets_url`.
 
     This is called at solve time so that configuration loading never performs network I/O.
-    The download happens at most once every `DEFAULT_IGNORE_DATASETS_MAX_AGE`.
+    The download happens at most once every `DEFAULT_IGNORE_DATASETS_REFRESH_INTERVAL`.
     A fresh cached file is reused untouched.
 
     Refreshing is best effort.
@@ -546,6 +546,7 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
     if not url or _configured_ignore_datasets_file(config) is not None:
         return
 
+    path: Path | None = None
     try:
         path = _ignore_datasets_cache_file()
 
@@ -553,7 +554,7 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
             logger.warning(f"The grey list cache path {path} is a directory, not a file. Skipping refresh.")
             return
 
-        if _cache_age(path) < DEFAULT_IGNORE_DATASETS_MAX_AGE:
+        if _cache_age(path) < DEFAULT_IGNORE_DATASETS_REFRESH_INTERVAL:
             return
 
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -563,7 +564,8 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
         _write_atomically(path, response.content)
     except Exception as exc:
         # The packaged copy is always available, so a failed refresh is never fatal.
-        logger.warning(f"Could not refresh the grey list from {url}: {exc}")
+        fallback = path if path is not None and path.is_file() else BUNDLED_IGNORE_DATASETS
+        logger.warning(f"Could not refresh the grey list from {url}, using {fallback}: {exc}")
 
 
 def _cache_age(path: Path) -> datetime.timedelta:
@@ -606,6 +608,11 @@ def _write_atomically(path: Path, content: bytes) -> None:
     try:
         with os.fdopen(handle, "wb") as file:
             file.write(content)
+        # mkstemp creates the file 0600. The cache is shared between users on a
+        # multi-user host, so restore the mode a plain open would have given.
+        umask = os.umask(0)
+        os.umask(umask)
+        temporary.chmod(0o666 & ~umask)
         temporary.replace(path)
     except OSError:
         temporary.unlink(missing_ok=True)
@@ -708,17 +715,19 @@ class Config:
         and finally to the copy shipped inside `climate_ref`.
 
         A cache that has not been refreshed for `DEFAULT_IGNORE_DATASETS_MAX_STALE` is skipped.
-        Without that bound a copy left behind by an older release would shadow the newer
-        packaged copy indefinitely on a host that can never reach the network.
+        Without that bound,
+        a copy left behind by an older release would shadow the newer packaged copy
+        indefinitely on a host that can never reach the network.
 
         Returns
         -------
         :
             The resolved grey list resource.
         """
-        cache: Path | None = _ignore_datasets_cache_file()
-        if cache is not None and _cache_age(cache) > DEFAULT_IGNORE_DATASETS_MAX_STALE:
-            logger.debug(f"Ignoring the grey list cache at {cache} because it is too old to trust.")
+        cached = _ignore_datasets_cache_file()
+        cache: Path | None = cached
+        if _cache_age(cached) > DEFAULT_IGNORE_DATASETS_MAX_STALE:
+            logger.debug(f"Ignoring the grey list cache at {cached} because it is too old to trust.")
             cache = None
 
         return LayeredResource(

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -17,9 +17,11 @@ which always take precedence over any other configuration values.
 import datetime
 import importlib.metadata
 import os
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+import platformdirs
 import requests
 import tomlkit
 from attr import Factory
@@ -456,6 +458,9 @@ It is always readable, so a solve never depends on the network or on a writable 
 """
 
 
+DEFAULT_IGNORE_DATASETS_MAX_STALE = datetime.timedelta(days=30)
+
+
 def _ignore_datasets_cache_file() -> Path:
     """
     Return the location the fetched copy of the grey list is cached at
@@ -468,6 +473,50 @@ def _ignore_datasets_cache_file() -> Path:
         Path to the cached grey list, under the shared REF dataset cache.
     """
     return resolve_cache_dir("grey_list") / DEFAULT_IGNORE_DATASETS_FILENAME
+
+
+def _legacy_ignore_datasets_file() -> Path:
+    """
+    Return the cache location used before the grey list moved under the REF dataset cache
+
+    Releases up to 0.16 wrote this path into every saved configuration file as a default,
+    so an upgraded installation has it recorded as though the operator had chosen it.
+
+    Returns
+    -------
+    :
+        The pre-0.17 cache location.
+    """
+    return platformdirs.user_cache_path("climate_ref") / DEFAULT_IGNORE_DATASETS_FILENAME
+
+
+def _configured_ignore_datasets_file(config: "Config") -> Path | None:
+    """
+    Return the operator's chosen grey list, ignoring an inherited legacy default
+
+    Before the grey list gained a packaged fallback its cache path was a config *default*,
+    so `Config.save()` baked it into every `ref.toml`.
+    Treating that value as a deliberate override would pin those installations to a stale
+    cache and silently disable refreshing, so it is treated as unset.
+
+    Parameters
+    ----------
+    config
+        The configuration to read `ignore_datasets_file` from.
+
+    Returns
+    -------
+    :
+        The configured path, or None when nothing was deliberately chosen.
+    """
+    configured = config.ignore_datasets_file
+    if configured is not None and configured == _legacy_ignore_datasets_file():
+        logger.debug(
+            f"Ignoring inherited grey list default {configured}. "
+            "Remove `ignore_datasets_file` from your configuration to silence this."
+        )
+        return None
+    return configured
 
 
 def refresh_ignore_datasets_file(config: "Config") -> None:
@@ -494,32 +543,73 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
     """
     url = config.ignore_datasets_url
 
-    if not url or config.ignore_datasets_file is not None:
+    if not url or _configured_ignore_datasets_file(config) is not None:
         return
-
-    path = _ignore_datasets_cache_file()
-
-    if path.is_dir():
-        logger.warning(f"The grey list cache path {path} is a directory, not a file. Skipping refresh.")
-        return
-
-    if path.is_file():
-        modification_time = datetime.datetime.fromtimestamp(path.stat().st_mtime)
-        age = datetime.datetime.now() - modification_time
-        if age < DEFAULT_IGNORE_DATASETS_MAX_AGE:
-            return
 
     try:
+        path = _ignore_datasets_cache_file()
+
+        if path.is_dir():
+            logger.warning(f"The grey list cache path {path} is a directory, not a file. Skipping refresh.")
+            return
+
+        if _cache_age(path) < DEFAULT_IGNORE_DATASETS_MAX_AGE:
+            return
+
         path.parent.mkdir(parents=True, exist_ok=True)
         logger.info(f"Downloading the grey list from {url} to {path}")
         response = requests.get(url, timeout=120)
         response.raise_for_status()
-        with path.open(mode="wb") as file:
-            file.write(response.content)
-    except (requests.RequestException, OSError) as exc:
+        _write_atomically(path, response.content)
+    except Exception as exc:
         # The packaged copy is always available, so a failed refresh is never fatal.
-        fallback = path if path.is_file() else BUNDLED_IGNORE_DATASETS
-        logger.warning(f"Could not refresh the grey list from {url}, using {fallback}: {exc}")
+        logger.warning(f"Could not refresh the grey list from {url}: {exc}")
+
+
+def _cache_age(path: Path) -> datetime.timedelta:
+    """
+    Return how old a cached file is, treating an unreadable one as infinitely old
+
+    Parameters
+    ----------
+    path
+        The cached file.
+
+    Returns
+    -------
+    :
+        The age of the file, or `datetime.timedelta.max` if it cannot be read.
+    """
+    try:
+        modification_time = datetime.datetime.fromtimestamp(path.stat().st_mtime)
+    except OSError:
+        return datetime.timedelta.max
+    return datetime.datetime.now() - modification_time
+
+
+def _write_atomically(path: Path, content: bytes) -> None:
+    """
+    Write a file via a temporary file and a rename
+
+    A partial write would otherwise leave a truncated file with a fresh modification time,
+    which would then shadow the packaged copy until the cache window expired.
+
+    Parameters
+    ----------
+    path
+        Destination file.
+    content
+        Bytes to write.
+    """
+    handle, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(handle, "wb") as file:
+            file.write(content)
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise
 
 
 @define(auto_attribs=True)
@@ -617,15 +707,24 @@ class Config:
         then to a copy refreshed from `ignore_datasets_url`,
         and finally to the copy shipped inside `climate_ref`.
 
+        A cache that has not been refreshed for `DEFAULT_IGNORE_DATASETS_MAX_STALE` is skipped.
+        Without that bound a copy left behind by an older release would shadow the newer
+        packaged copy indefinitely on a host that can never reach the network.
+
         Returns
         -------
         :
             The resolved grey list resource.
         """
+        cache: Path | None = _ignore_datasets_cache_file()
+        if cache is not None and _cache_age(cache) > DEFAULT_IGNORE_DATASETS_MAX_STALE:
+            logger.debug(f"Ignoring the grey list cache at {cache} because it is too old to trust.")
+            cache = None
+
         return LayeredResource(
             packaged=BUNDLED_IGNORE_DATASETS,
-            override=self.ignore_datasets_file,
-            cache=_ignore_datasets_cache_file(),
+            override=_configured_ignore_datasets_file(self),
+            cache=cache,
         )
 
     @classmethod

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -15,12 +15,11 @@ which always take precedence over any other configuration values.
 # https://github.com/ESGF/esgf-download/blob/main/esgpull/config.py
 
 import datetime
-import importlib.resources
+import importlib.metadata
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-import platformdirs
 import requests
 import tomlkit
 from attr import Factory
@@ -35,15 +34,17 @@ from climate_ref._config_helpers import (
     _format_exception,
     _format_key_exception,
     _pop_empty,
+    _pop_none,
     config,
     env_field,
     transform_error,
 )
 from climate_ref.constants import CONFIG_FILENAME
-from climate_ref_core.dataset_registry import resolve_cache_dir
+from climate_ref_core.data import LayeredResource, PackagedResource, resolve_cache_dir
 from climate_ref_core.env import env
-from climate_ref_core.exceptions import IgnoreDatasetsRefreshError, InvalidExecutorException
+from climate_ref_core.exceptions import InvalidExecutorException
 from climate_ref_core.logging import DEFAULT_LOG_FORMAT
+from climate_ref_core.pycmec.controlled_vocabulary import BUNDLED_CV
 
 if TYPE_CHECKING:
     from climate_ref.database import Database
@@ -72,6 +73,31 @@ def ensure_absolute_path(path: str | Path) -> Path:
         path = Path(path)
     path = Path(*[os.path.expandvars(p) for p in path.parts])
     return path.resolve()
+
+
+def _optional_path(path: str | Path | None) -> Path | None:
+    """
+    Convert a value to a path, treating an unset or empty value as "not configured"
+
+    An empty string is treated as unset so that an environment variable can clear
+    a value that is set in the configuration file.
+
+    Parameters
+    ----------
+    path
+        Path to convert
+
+    Returns
+    -------
+        The path, or None if no path was configured
+    """
+    if path is None:
+        return None
+    if isinstance(path, str):
+        if not path.strip():
+            return None
+        path = Path(path)
+    return Path(os.path.expandvars(str(path))).expanduser()
 
 
 @config(prefix=env_prefix)
@@ -125,16 +151,18 @@ class PathConfig:
     Path to store the executions
     """
 
-    dimensions_cv: Path = env_field(name="DIMENSIONS_CV_PATH", converter=Path)
+    dimensions_cv: Path | None = env_field(name="DIMENSIONS_CV_PATH", converter=_optional_path, default=None)
     """
     Path to a file containing the controlled vocabulary for the dimensions in a CMEC diagnostics bundle
 
-    This defaults to the controlled vocabulary for the CMIP7 Assessment Fast Track diagnostics,
-    which is included in the `climate_ref_core` package.
+    Leave this unset to use the controlled vocabulary for the CMIP7 Assessment Fast Track
+    diagnostics, which is shipped inside the `climate_ref_core` package.
+    That copy is read straight out of the installed package,
+    so it needs no network access and no writable filesystem.
 
     This controlled vocabulary is used to validate the dimensions in the diagnostics bundle.
     If custom diagnostics are implemented,
-    this file may need to be extended to include any new dimensions.
+    point this at a copy that has been extended with any new dimensions.
     """
 
     @log.default
@@ -153,10 +181,20 @@ class PathConfig:
     def _results_factory(self) -> Path:
         return env.path("REF_CONFIGURATION").resolve() / "results"
 
-    @dimensions_cv.default
-    def _dimensions_cv_factory(self) -> Path:
-        filename = "cv_cmip7_aft.yaml"
-        return Path(str(importlib.resources.files("climate_ref_core.pycmec") / filename))
+    @property
+    def dimensions_cv_resource(self) -> LayeredResource:
+        """
+        The controlled vocabulary to validate diagnostic bundles against
+
+        Resolves to `dimensions_cv` if it is set, and to the copy shipped
+        inside `climate_ref_core` otherwise.
+
+        Returns
+        -------
+        :
+            The resolved controlled vocabulary resource.
+        """
+        return LayeredResource(packaged=BUNDLED_CV, override=self.dimensions_cv)
 
 
 @config(prefix=env_prefix)
@@ -409,58 +447,61 @@ DEFAULT_IGNORE_DATASETS_MAX_AGE = datetime.timedelta(hours=6)
 DEFAULT_IGNORE_DATASETS_FILENAME = "default_ignore_datasets.yaml"
 DEFAULT_IGNORE_DATASETS_URL = f"https://raw.githubusercontent.com/Climate-REF/climate-ref/refs/heads/main/{DEFAULT_IGNORE_DATASETS_FILENAME}"
 
+BUNDLED_IGNORE_DATASETS = PackagedResource("climate_ref", DEFAULT_IGNORE_DATASETS_FILENAME)
+"""
+The grey list shipped inside the `climate_ref` package.
 
-def _get_default_ignore_datasets_file() -> Path:
+This is the copy that was current when the installed version was released.
+It is always readable, so a solve never depends on the network or on a writable cache.
+"""
+
+
+def _ignore_datasets_cache_file() -> Path:
     """
-    Return the default location of the ignore datasets file.
+    Return the location the fetched copy of the grey list is cached at
 
     This is a pure path computation with no filesystem or network access.
-    The file itself is fetched lazily at solve time via `refresh_ignore_datasets_file`.
 
     Returns
     -------
     :
-        Path to the ignore datasets file under the user cache directory.
+        Path to the cached grey list, under the shared REF dataset cache.
     """
-    return platformdirs.user_cache_path("climate_ref") / DEFAULT_IGNORE_DATASETS_FILENAME
+    return resolve_cache_dir("grey_list") / DEFAULT_IGNORE_DATASETS_FILENAME
 
 
 def refresh_ignore_datasets_file(config: "Config") -> None:
     """
-    Refresh the cached ignore datasets file from `config.ignore_datasets_url`.
+    Refresh the cached grey list from `config.ignore_datasets_url`.
 
     This is called at solve time so that configuration loading never performs network I/O.
-    The download happens at most once every `DEFAULT_IGNORE_DATASETS_MAX_AGE`;
-    a fresh cached file is reused untouched.
+    The download happens at most once every `DEFAULT_IGNORE_DATASETS_MAX_AGE`.
+    A fresh cached file is reused untouched.
 
-    If `config.ignore_datasets_url` is empty the function returns immediately
-    without touching the filesystem,
-    which supports offline and air-gapped deployments that manage the file manually.
+    Refreshing is best effort.
+    An unset URL, an unreachable network, and an unwritable cache directory are all
+    non-fatal: the solve falls back to the cached copy if there is one,
+    and to the copy shipped in the package otherwise.
+    This keeps read-only and air-gapped deployments working without any configuration.
 
-    On download failure an existing cached copy is reused unchanged
-    (its content and modification time are preserved,
-    so a transient failure does not extend the cache window).
-    If no cached copy exists an `IgnoreDatasetsRefreshError` is raised
-    so the solver fails loudly rather than silently running without ignore-dataset protections.
+    Refreshing is skipped entirely when `ignore_datasets_file` is set,
+    since an explicit file is the operator's to manage.
 
     Parameters
     ----------
     config
         The configuration providing `ignore_datasets_file` and `ignore_datasets_url`.
-
-    Raises
-    ------
-    IgnoreDatasetsRefreshError
-        If the URL is set, the download fails, and no cached file exists.
     """
-    path = config.ignore_datasets_file
     url = config.ignore_datasets_url
 
-    if not url:
+    if not url or config.ignore_datasets_file is not None:
         return
 
+    path = _ignore_datasets_cache_file()
+
     if path.is_dir():
-        raise IgnoreDatasetsRefreshError(f"The ignore datasets file path {path} is a directory, not a file.")
+        logger.warning(f"The grey list cache path {path} is a directory, not a file. Skipping refresh.")
+        return
 
     if path.is_file():
         modification_time = datetime.datetime.fromtimestamp(path.stat().st_mtime)
@@ -470,23 +511,15 @@ def refresh_ignore_datasets_file(config: "Config") -> None:
 
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        logger.info(f"Downloading default ignore datasets file from {url} to {path}")
+        logger.info(f"Downloading the grey list from {url} to {path}")
         response = requests.get(url, timeout=120)
         response.raise_for_status()
-    except (requests.RequestException, OSError) as exc:
-        if path.is_file():
-            logger.warning(
-                f"Failed to refresh ignore datasets file from {url}; using cached copy at {path}: {exc}"
-            )
-            return
-        raise IgnoreDatasetsRefreshError(
-            f"Failed to download the ignore datasets file from {url} and no cached copy exists at {path}. "
-            "Point `ignore_datasets_file` (or `REF_IGNORE_DATASETS_FILE`) at a writable location "
-            "or a manually seeded file, or set `REF_IGNORE_DATASETS_URL=` (empty) to opt out of fetching."
-        ) from exc
-    else:
         with path.open(mode="wb") as file:
             file.write(response.content)
+    except (requests.RequestException, OSError) as exc:
+        # The packaged copy is always available, so a failed refresh is never fatal.
+        fallback = path if path.is_file() else BUNDLED_IGNORE_DATASETS
+        logger.warning(f"Could not refresh the grey list from {url}, using {fallback}: {exc}")
 
 
 @define(auto_attribs=True)
@@ -531,13 +564,13 @@ class Config:
     - `complete`: Use the complete parser, which parses the dataset based on all available metadata.
     """
 
-    ignore_datasets_file: Path = env_field(  # noqa: RUF009
+    ignore_datasets_file: Path | None = env_field(  # noqa: RUF009
         "IGNORE_DATASETS_FILE",
-        factory=_get_default_ignore_datasets_file,
-        converter=Path,
+        converter=_optional_path,
+        default=None,
     )
     """
-    Path to the file containing the ignore datasets
+    Path to a file containing the grey list
 
     This file is a YAML file that contains a list of facets to ignore per diagnostic.
 
@@ -550,22 +583,21 @@ class Config:
           - another_facet: [another_value1, another_value2]
     ```
 
-    Defaults to a path under the user cache directory.
-    The file is fetched lazily from `ignore_datasets_url` at solve time
-    if it is missing or older than 6 hours,
-    so this location must be writable unless the file is seeded manually.
+    Leave this unset to use the grey list shipped inside the `climate_ref` package,
+    refreshed from `ignore_datasets_url` when that is possible.
+    Setting it pins the grey list to a file you manage, and disables fetching.
     """
 
     ignore_datasets_url: str = env_field("IGNORE_DATASETS_URL", default=DEFAULT_IGNORE_DATASETS_URL)
     """
-    URL to fetch the ignore datasets file from at solve time.
+    URL to refresh the grey list from at solve time.
 
     The download happens during solving only, at most once every 6 hours,
     and never during configuration loading.
+    A failed download is not an error, since the copy shipped in the package is used instead.
 
-    Set to an empty string (e.g. `REF_IGNORE_DATASETS_URL=`) to disable fetching entirely;
-    in that case the solver uses whatever file already exists at `ignore_datasets_file`,
-    which supports offline and air-gapped deployments.
+    Set to an empty string (e.g. `REF_IGNORE_DATASETS_URL=`) to skip the attempt entirely,
+    which avoids the request timeout on a host with no route to the internet.
     """
 
     paths: PathConfig = Factory(PathConfig)
@@ -575,6 +607,26 @@ class Config:
     diagnostic_providers: list[DiagnosticProviderConfig] = Factory(default_providers)  # noqa: RUF009, RUF100
     _raw: TOMLDocument | None = field(init=False, default=None, repr=False)
     _config_file: Path | None = field(init=False, default=None, repr=False)
+
+    @property
+    def ignore_datasets_resource(self) -> LayeredResource:
+        """
+        The grey list to apply when solving
+
+        Resolves to `ignore_datasets_file` if it is set,
+        then to a copy refreshed from `ignore_datasets_url`,
+        and finally to the copy shipped inside `climate_ref`.
+
+        Returns
+        -------
+        :
+            The resolved grey list resource.
+        """
+        return LayeredResource(
+            packaged=BUNDLED_IGNORE_DATASETS,
+            override=self.ignore_datasets_file,
+            cache=_ignore_datasets_cache_file(),
+        )
 
     @classmethod
     def load(cls, config_file: Path, allow_missing: bool = True) -> "Config":
@@ -740,6 +792,8 @@ class Config:
         else:
             converter = _converter_no_defaults
         dump = converter.unstructure(self)
+        # TOML cannot express null, so an unset value is written as an absent key.
+        _pop_none(dump)
         if not defaults:
             _pop_empty(dump)
         doc = TOMLDocument()

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -609,10 +609,8 @@ def _write_atomically(path: Path, content: bytes) -> None:
         with os.fdopen(handle, "wb") as file:
             file.write(content)
         # mkstemp creates the file 0600. The cache is shared between users on a
-        # multi-user host, so restore the mode a plain open would have given.
-        umask = os.umask(0)
-        os.umask(umask)
-        temporary.chmod(0o666 & ~umask)
+        # multi-user host, so it has to stay readable by them.
+        temporary.chmod(0o644)
         temporary.replace(path)
     except OSError:
         temporary.unlink(missing_ok=True)

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -26,11 +26,11 @@ Provided fixtures
 
 from __future__ import annotations
 
-import importlib.resources
 import os
 import re
 import tempfile
 from collections.abc import Callable, Iterator
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
 
@@ -42,7 +42,12 @@ from loguru import logger
 from typer.testing import CliRunner
 
 from climate_ref import cli
-from climate_ref.config import DEFAULT_IGNORE_DATASETS_FILENAME, Config, DiagnosticProviderConfig
+from climate_ref.config import (
+    BUNDLED_IGNORE_DATASETS,
+    DEFAULT_IGNORE_DATASETS_FILENAME,
+    Config,
+    DiagnosticProviderConfig,
+)
 from climate_ref.datasets.cmip6 import CMIP6DatasetAdapter
 from climate_ref.datasets.obs4mips import Obs4MIPsDatasetAdapter
 from climate_ref.models import Execution
@@ -232,36 +237,32 @@ def data_catalog(
     }
 
 
+@lru_cache(maxsize=1)
 def packaged_ignore_datasets_file() -> Path:
     """
-    Locate the ``default_ignore_datasets.yaml`` shipped inside the ``climate_ref`` package.
+    Materialise the grey list shipped inside the ``climate_ref`` package as a real file.
+
+    The content is copied out of the package into a temporary file that lives for the
+    duration of the test session, so the returned path is durable and independent of
+    how the package is installed.
 
     Returns
     -------
     :
-        Path to the packaged ignore datasets file.
-
-    Raises
-    ------
-    ValueError
-        If the file is missing from the installed package.
+        Path to a copy of the packaged grey list.
     """
-    resource = importlib.resources.files("climate_ref") / DEFAULT_IGNORE_DATASETS_FILENAME
-    local_ignore_file = Path(str(resource))
-    if not local_ignore_file.is_file():  # pragma: no cover - indicates a packaging error
-        raise ValueError(f"Could not find ignore file at {local_ignore_file}")
-    return local_ignore_file
+    destination = Path(tempfile.mkdtemp(prefix="climate_ref_grey_list_")) / (DEFAULT_IGNORE_DATASETS_FILENAME)
+    destination.write_text(BUNDLED_IGNORE_DATASETS.read_text(), encoding="utf-8")
+    return destination
 
 
 def _use_local_ignore_datasets_file(cfg: Config) -> None:
     """
-    Point the config at the packaged default_ignore_datasets.yaml and disable fetching.
+    Pin the config to the packaged grey list and disable fetching.
 
     This keeps tests deterministic and offline:
     they exercise the shipped default file rather than whatever copy happens to be cached on the host.
-
-    The file is resolved from the installed package rather than the source tree,
-    so the fixtures also work for provider packages that depend on a released ``climate-ref`` wheel.
+    Pinning it as an explicit override also stops a stale host cache from being picked up.
     """
     cfg.ignore_datasets_file = packaged_ignore_datasets_file()
     cfg.ignore_datasets_url = ""

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -26,8 +26,10 @@ Provided fixtures
 
 from __future__ import annotations
 
+import atexit
 import os
 import re
+import shutil
 import tempfile
 from collections.abc import Callable, Iterator
 from functools import lru_cache
@@ -251,7 +253,9 @@ def packaged_ignore_datasets_file() -> Path:
     :
         Path to a copy of the packaged grey list.
     """
-    destination = Path(tempfile.mkdtemp(prefix="climate_ref_grey_list_")) / (DEFAULT_IGNORE_DATASETS_FILENAME)
+    directory = tempfile.mkdtemp(prefix="climate_ref_grey_list_")
+    atexit.register(shutil.rmtree, directory, True)
+    destination = Path(directory) / DEFAULT_IGNORE_DATASETS_FILENAME
     destination.write_text(BUNDLED_IGNORE_DATASETS.read_text(), encoding="utf-8")
     return destination
 

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -241,16 +241,16 @@ def data_catalog(
 @lru_cache(maxsize=1)
 def packaged_ignore_datasets_file() -> Path:
     """
-    Materialise the grey list shipped inside the ``climate_ref`` package as a real file.
+    Expose the grey list shipped inside the ``climate_ref`` package as a real file.
 
-    The content is copied out of the package into a temporary file that lives for the
-    duration of the test session, so the returned path is durable and independent of
-    how the package is installed.
+    The path lives for the duration of the test session.
+    For an ordinary install this is the packaged file itself rather than a copy,
+    so treat it as read only.
 
     Returns
     -------
     :
-        Path to a copy of the packaged grey list.
+        Path to the packaged grey list.
     """
     stack = ExitStack()
     atexit.register(stack.close)

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -29,9 +29,9 @@ from __future__ import annotations
 import atexit
 import os
 import re
-import shutil
 import tempfile
 from collections.abc import Callable, Iterator
+from contextlib import ExitStack
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
@@ -46,7 +46,6 @@ from typer.testing import CliRunner
 from climate_ref import cli
 from climate_ref.config import (
     BUNDLED_IGNORE_DATASETS,
-    DEFAULT_IGNORE_DATASETS_FILENAME,
     Config,
     DiagnosticProviderConfig,
 )
@@ -253,11 +252,9 @@ def packaged_ignore_datasets_file() -> Path:
     :
         Path to a copy of the packaged grey list.
     """
-    directory = tempfile.mkdtemp(prefix="climate_ref_grey_list_")
-    atexit.register(shutil.rmtree, directory, True)
-    destination = Path(directory) / DEFAULT_IGNORE_DATASETS_FILENAME
-    destination.write_text(BUNDLED_IGNORE_DATASETS.read_text(), encoding="utf-8")
-    return destination
+    stack = ExitStack()
+    atexit.register(stack.close)
+    return stack.enter_context(BUNDLED_IGNORE_DATASETS.as_path())
 
 
 def _use_local_ignore_datasets_file(cfg: Config) -> None:

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -421,7 +421,7 @@ class Database:
 
         database_url = validate_database_url(database_url)
 
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
         db = Database(database_url, connect_args=connect_args or None)
 
         if run_migrations:

--- a/packages/climate-ref/src/climate_ref/executor/result_handling.py
+++ b/packages/climate-ref/src/climate_ref/executor/result_handling.py
@@ -467,7 +467,7 @@ def handle_execution_result(
         return
 
     # Ingest outputs and metrics into the database via the shared ingestion path
-    cv = CV.load_from_file(config.paths.dimensions_cv)
+    cv = CV.load(config.paths.dimensions_cv_resource)
     try:
         with database.session.begin_nested():
             ingest_execution_result(

--- a/packages/climate-ref/src/climate_ref/migrations/env.py
+++ b/packages/climate-ref/src/climate_ref/migrations/env.py
@@ -59,8 +59,7 @@ def _add_dimension_columns(connection: Connection, table: str, Cls: type[Dimensi
     # Extract the current columns in the DB
     existing_columns = [c["name"] for c in inspector.get_columns(table)]
 
-    cv_file = ref_config.paths.dimensions_cv
-    cv = CV.load_from_file(cv_file)
+    cv = CV.load(ref_config.paths.dimensions_cv_resource)
 
     for dimension in cv.dimensions:
         if dimension.name not in existing_columns:

--- a/packages/climate-ref/tests/unit/cli/test_config.py
+++ b/packages/climate-ref/tests/unit/cli/test_config.py
@@ -311,7 +311,7 @@ class TestConfigValidate:
         config_file = tmp_path / CONFIG_FILENAME
         config_file.write_text('log_level = "INFO"\n')
         request_get = Mock()
-        monkeypatch.setattr("climate_ref.config.platformdirs.user_cache_path", lambda _: tmp_path / "cache")
+        monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path / "cache"))
         monkeypatch.setattr("climate_ref.config.requests.get", request_get)
 
         assert Config.collect_validation_errors(config_file) == []

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -1144,7 +1144,7 @@ class TestReingestExecution:
         _patch_build_result(mocker, mock_provider_registry, mock_result)
 
         # Original ingestion via the shared path
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
         ingest_execution_result(
             reingest_db,
             execution,

--- a/packages/climate-ref/tests/unit/executor/test_result_handling.py
+++ b/packages/climate-ref/tests/unit/executor/test_result_handling.py
@@ -515,7 +515,7 @@ class TestIngestScalarValues:
     ):
         """Should ingest scalar metric values from a real CMEC bundle."""
         mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         ingest_scalar_values(database=_ingestion_db, result=mock_result, execution=ingestion_execution, cv=cv)
         _ingestion_db.session.commit()
@@ -536,7 +536,7 @@ class TestIngestSeriesValues:
     ):
         """Should ingest series metric values from a real series file."""
         mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         ingest_series_values(database=_ingestion_db, result=mock_result, execution=ingestion_execution, cv=cv)
         _ingestion_db.session.commit()
@@ -558,7 +558,7 @@ class TestIngestKind:
     ):
         """A series defaults to kind ``model`` and that role is persisted."""
         mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         ingest_series_values(database=_ingestion_db, result=mock_result, execution=ingestion_execution, cv=cv)
         _ingestion_db.session.commit()
@@ -588,7 +588,7 @@ class TestIngestKind:
         mocker.patch.object(TSeries, "load_from_json", return_value=[bad])
 
         mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         with pytest.raises(ResultValidationError, match="Invalid metric-value kind"):
             ingest_series_values(
@@ -613,7 +613,7 @@ class TestIngestKind:
         mocker.patch.object(CMECMetric, "iter_results", return_value=[bad])
 
         mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         with pytest.raises(ResultValidationError, match="Invalid metric-value kind"):
             ingest_scalar_values(
@@ -655,7 +655,7 @@ class TestIngestKind:
         TSeries.dump_to_json(scratch_dir_with_data / "series.json", [ref_a1, ref_a2, ref_b, model])
 
         mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         ingest_series_values(database=_ingestion_db, result=mock_result, execution=ingestion_execution, cv=cv)
         _ingestion_db.session.commit()
@@ -684,7 +684,7 @@ class TestIngestExecutionResult:
     ):
         """Should ingest scalars, series, and register outputs in one call."""
         mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         ingest_execution_result(
             _ingestion_db,
@@ -716,7 +716,7 @@ class TestIngestExecutionResult:
         mock_result = mock_result_factory(
             scratch_dir_with_data, output_bundle_filename=None, series_filename=None
         )
-        cv = CV.load_from_file(config.paths.dimensions_cv)
+        cv = CV.load(config.paths.dimensions_cv_resource)
 
         ingest_execution_result(
             _ingestion_db,

--- a/packages/climate-ref/tests/unit/executor/test_stress_results_layer.py
+++ b/packages/climate-ref/tests/unit/executor/test_stress_results_layer.py
@@ -124,7 +124,7 @@ def _write_and_ingest(
     scratch_dir.mkdir(parents=True, exist_ok=True)
     TSeries.dump_to_json(scratch_dir / "series.json", series)
 
-    cv = CV.load_from_file(config.paths.dimensions_cv)
+    cv = CV.load(config.paths.dimensions_cv_resource)
     result = _Result(scratch_dir)
 
     with count_statements(database) as counter:

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -329,6 +329,24 @@ def test_transform_error():
     assert transform_error(err, "test") == ["invalid value @ test", "required field missing @ test"]
 
 
+@pytest.mark.parametrize("value", ["", "   ", None])
+def test_optional_path_treats_blank_as_unset(value):
+    assert climate_ref.config._optional_path(value) is None
+
+
+def test_refresh_ignore_datasets_file_skips_a_directory(mocker, monkeypatch, tmp_path, caplog):
+    """A cache path that is a directory is reported rather than written over."""
+    get_mock = mocker.patch.object(climate_ref.config.requests, "get")
+    config = _refresh_config(monkeypatch, tmp_path)
+    _ignore_datasets_cache_file().mkdir(parents=True)
+
+    with caplog.at_level(logging.WARNING):
+        refresh_ignore_datasets_file(config)
+
+    get_mock.assert_not_called()
+    assert "is a directory, not a file" in caplog.text
+
+
 def test_ignore_datasets_cache_file(monkeypatch, tmp_path):
     """The cache location is a pure path computation with no filesystem or network access."""
     monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -4,7 +4,6 @@ import sys
 from datetime import timedelta
 from pathlib import Path
 
-import platformdirs
 import pytest
 import requests
 from attr import evolve
@@ -16,12 +15,12 @@ from climate_ref.config import (
     DEFAULT_LOG_FORMAT,
     Config,
     PathConfig,
-    _get_default_ignore_datasets_file,
+    _ignore_datasets_cache_file,
     refresh_ignore_datasets_file,
     transform_error,
 )
-from climate_ref_core.dataset_registry import resolve_cache_dir
-from climate_ref_core.exceptions import IgnoreDatasetsRefreshError, InvalidExecutorException
+from climate_ref_core.data import ResourceOrigin, resolve_cache_dir
+from climate_ref_core.exceptions import InvalidExecutorException
 from climate_ref_core.executor import Executor
 
 
@@ -61,14 +60,18 @@ class TestConfig:
         assert not (tmp_path / "climate_ref" / "ref.toml").exists()
 
         cache_dir = tmp_path / "cache" / "climate_ref"
-        mocker.patch.object(climate_ref.config.platformdirs, "user_cache_path", return_value=cache_dir)
+        monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(cache_dir))
         get_mock = mocker.patch.object(climate_ref.config.requests, "get")
 
         loaded = Config.default()
 
         get_mock.assert_not_called()
         assert not cache_dir.exists()
-        assert loaded.ignore_datasets_file == cache_dir / "default_ignore_datasets.yaml"
+        # Nothing is configured, so the copy shipped in the package is used.
+        assert loaded.ignore_datasets_file is None
+        assert loaded.ignore_datasets_resource.origin == ResourceOrigin.package
+        assert loaded.paths.dimensions_cv is None
+        assert loaded.paths.dimensions_cv_resource.origin == ResourceOrigin.package
         assert loaded.paths.scratch == tmp_path / "climate_ref" / "scratch"
 
     def test_load(self, config, tmp_path):
@@ -147,7 +150,6 @@ filename = "sqlite://climate_ref.db"
         monkeypatch.setenv("REF_CONFIGURATION", "test")
         # Clear any externally set env vars that would affect the test
         monkeypatch.delenv("REF_SOFTWARE_ROOT", raising=False)
-        mocker.patch("climate_ref.config.importlib.resources.files", return_value=Path("pycmec"))
         mocker.patch(
             "climate_ref.config.importlib.metadata.entry_points",
             return_value=importlib.metadata.EntryPoints(
@@ -169,9 +171,6 @@ filename = "sqlite://climate_ref.db"
         without_defaults = cfg.dump(defaults=False)
 
         assert without_defaults == {
-            "ignore_datasets_file": str(
-                platformdirs.user_cache_path("climate_ref") / "default_ignore_datasets.yaml"
-            ),
             "ignore_datasets_url": DEFAULT_IGNORE_DATASETS_URL,
             "log_level": "INFO",
             "log_format": DEFAULT_LOG_FORMAT,
@@ -182,9 +181,6 @@ filename = "sqlite://climate_ref.db"
             ],
         }
         assert with_defaults == {
-            "ignore_datasets_file": str(
-                platformdirs.user_cache_path("climate_ref") / "default_ignore_datasets.yaml"
-            ),
             "ignore_datasets_url": DEFAULT_IGNORE_DATASETS_URL,
             "log_level": "INFO",
             "log_format": DEFAULT_LOG_FORMAT,
@@ -208,7 +204,6 @@ filename = "sqlite://climate_ref.db"
                 "results": f"{default_path}/results",
                 "scratch": f"{default_path}/scratch",
                 "software": f"{default_path}/software",
-                "dimensions_cv": str(Path("pycmec") / "cv_cmip7_aft.yaml"),
             },
             "db": {
                 "database_url": "sqlite:///test/db/climate_ref.db",
@@ -312,34 +307,32 @@ def test_transform_error():
     assert transform_error(err, "test") == ["invalid value @ test", "required field missing @ test"]
 
 
-def test_get_default_ignore_datasets_file(mocker, tmp_path):
-    """The factory is a pure path computation with no filesystem or network access."""
-    mocker.patch.object(climate_ref.config.platformdirs, "user_cache_path", return_value=tmp_path)
-    get_mock = mocker.patch.object(climate_ref.config.requests, "get")
+def test_ignore_datasets_cache_file(monkeypatch, tmp_path):
+    """The cache location is a pure path computation with no filesystem or network access."""
+    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))
 
-    path = _get_default_ignore_datasets_file()
+    path = _ignore_datasets_cache_file()
 
-    assert path == tmp_path / "default_ignore_datasets.yaml"
+    assert path == tmp_path / "grey_list" / "default_ignore_datasets.yaml"
     assert not path.exists()
-    get_mock.assert_not_called()
 
 
-def _refresh_config(tmp_path, url=DEFAULT_IGNORE_DATASETS_URL, filename="default_ignore_datasets.yaml"):
+def _refresh_config(monkeypatch, tmp_path, url=DEFAULT_IGNORE_DATASETS_URL):
+    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))
     config = Config()
-    config.ignore_datasets_file = tmp_path / filename
     config.ignore_datasets_url = url
     return config
 
 
 @pytest.mark.parametrize("status", ["fresh", "stale", "missing"])
-def test_refresh_ignore_datasets_file(mocker, tmp_path, status):
+def test_refresh_ignore_datasets_file(mocker, monkeypatch, tmp_path, status):
     mocker.patch.object(
         climate_ref.config.requests,
         "get",
         return_value=mocker.MagicMock(status_code=200, content=b"downloaded"),
     )
-    config = _refresh_config(tmp_path / "nested")
-    target = config.ignore_datasets_file
+    config = _refresh_config(monkeypatch, tmp_path / "nested")
+    target = _ignore_datasets_cache_file()
     if status != "missing":
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("existing", encoding="utf-8")
@@ -353,54 +346,93 @@ def test_refresh_ignore_datasets_file(mocker, tmp_path, status):
         assert target.read_text(encoding="utf-8") == "existing"
     else:
         assert target.read_text(encoding="utf-8") == "downloaded"
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.cache
 
 
-def test_refresh_ignore_datasets_file_disabled_by_empty_url(mocker, tmp_path):
-    """An empty URL disables fetching entirely, even when the file is missing."""
+def test_refresh_ignore_datasets_file_disabled_by_empty_url(mocker, monkeypatch, tmp_path):
+    """An empty URL skips the fetch entirely, and the packaged copy is used instead."""
     get_mock = mocker.patch.object(climate_ref.config.requests, "get")
-    config = _refresh_config(tmp_path, url="")
+    config = _refresh_config(monkeypatch, tmp_path, url="")
 
     refresh_ignore_datasets_file(config)
 
     get_mock.assert_not_called()
-    assert not config.ignore_datasets_file.exists()
+    assert not _ignore_datasets_cache_file().exists()
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.package
 
 
-def test_refresh_ignore_datasets_file_fail_no_cache(mocker, tmp_path):
-    """A download failure with no cached copy must raise rather than create an empty placeholder."""
-    result = mocker.MagicMock(status_code=404, content=b"{}")
-    result.raise_for_status.side_effect = requests.RequestException
-    mocker.patch.object(climate_ref.config.requests, "get", return_value=result)
-    config = _refresh_config(tmp_path)
+def test_refresh_ignore_datasets_file_skipped_when_file_configured(mocker, monkeypatch, tmp_path):
+    """An explicit file is the operator's to manage, so no fetch is attempted."""
+    get_mock = mocker.patch.object(climate_ref.config.requests, "get")
+    config = _refresh_config(monkeypatch, tmp_path)
+    pinned = tmp_path / "pinned.yaml"
+    pinned.write_text("{}", encoding="utf-8")
+    config.ignore_datasets_file = pinned
 
-    with pytest.raises(IgnoreDatasetsRefreshError, match="no cached copy"):
+    refresh_ignore_datasets_file(config)
+
+    get_mock.assert_not_called()
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.override
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param("http", id="http-error"),
+        pytest.param("network", id="network-error"),
+    ],
+)
+def test_refresh_ignore_datasets_file_fail_no_cache(mocker, monkeypatch, tmp_path, caplog, failure):
+    """A failed download falls back to the packaged copy rather than failing the solve."""
+    if failure == "http":
+        result = mocker.MagicMock(status_code=404, content=b"{}")
+        result.raise_for_status.side_effect = requests.RequestException
+        mocker.patch.object(climate_ref.config.requests, "get", return_value=result)
+    else:
+        mocker.patch.object(
+            climate_ref.config.requests,
+            "get",
+            side_effect=requests.exceptions.ConnectionError("Network unreachable"),
+        )
+    config = _refresh_config(monkeypatch, tmp_path)
+
+    with caplog.at_level(logging.WARNING):
         refresh_ignore_datasets_file(config)
 
-    assert not config.ignore_datasets_file.exists()
+    assert not _ignore_datasets_cache_file().exists()
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.package
+    assert any("Could not refresh the grey list" in r.message for r in caplog.records)
 
 
-def test_refresh_ignore_datasets_file_network_error_no_cache(mocker, tmp_path):
-    """Network errors with no cached copy must raise (fail-safe)."""
+def test_refresh_ignore_datasets_file_unwritable_cache(mocker, monkeypatch, tmp_path, caplog):
+    """An unwritable cache directory is not fatal, since the packaged copy is always readable."""
     mocker.patch.object(
         climate_ref.config.requests,
         "get",
-        side_effect=requests.exceptions.ConnectionError("Network unreachable"),
+        return_value=mocker.MagicMock(status_code=200, content=b"downloaded"),
     )
-    config = _refresh_config(tmp_path)
+    config = _refresh_config(monkeypatch, tmp_path / "readonly" / "cache")
+    (tmp_path / "readonly").mkdir()
+    (tmp_path / "readonly").chmod(0o500)
 
-    with pytest.raises(IgnoreDatasetsRefreshError):
-        refresh_ignore_datasets_file(config)
+    try:
+        with caplog.at_level(logging.WARNING):
+            refresh_ignore_datasets_file(config)
+    finally:
+        (tmp_path / "readonly").chmod(0o700)
 
-    assert not config.ignore_datasets_file.exists()
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.package
+    assert any("Could not refresh the grey list" in r.message for r in caplog.records)
 
 
-def test_refresh_ignore_datasets_file_fail_uses_stale_cache(mocker, tmp_path, caplog):
+def test_refresh_ignore_datasets_file_fail_uses_stale_cache(mocker, monkeypatch, tmp_path, caplog):
     """A download failure must preserve and reuse an existing cached copy without touching it."""
     result = mocker.MagicMock(status_code=500, content=b"{}")
     result.raise_for_status.side_effect = requests.RequestException
     mocker.patch.object(climate_ref.config.requests, "get", return_value=result)
-    config = _refresh_config(tmp_path)
-    target = config.ignore_datasets_file
+    config = _refresh_config(monkeypatch, tmp_path)
+    target = _ignore_datasets_cache_file()
+    target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("cached", encoding="utf-8")
     original_mtime = target.stat().st_mtime
     mocker.patch.object(climate_ref.config, "DEFAULT_IGNORE_DATASETS_MAX_AGE", timedelta(seconds=-1))
@@ -410,4 +442,5 @@ def test_refresh_ignore_datasets_file_fail_uses_stale_cache(mocker, tmp_path, ca
 
     assert target.read_text(encoding="utf-8") == "cached"
     assert target.stat().st_mtime == original_mtime
-    assert any("using cached copy" in r.message for r in caplog.records)
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.cache
+    assert any("Could not refresh the grey list" in r.message for r in caplog.records)

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -462,9 +462,7 @@ def test_refresh_ignore_datasets_file_is_group_readable(mocker, monkeypatch, tmp
     refresh_ignore_datasets_file(config)
 
     target = _ignore_datasets_cache_file()
-    umask = os.umask(0)
-    os.umask(umask)
-    assert stat.S_IMODE(target.stat().st_mode) == 0o666 & ~umask
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
 
 
 def test_stale_cache_does_not_shadow_the_packaged_copy(monkeypatch, tmp_path):

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -2,6 +2,7 @@ import datetime
 import importlib.metadata
 import logging
 import os
+import stat
 import sys
 from datetime import timedelta
 from pathlib import Path
@@ -340,7 +341,9 @@ def test_refresh_ignore_datasets_file(mocker, monkeypatch, tmp_path, status):
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("existing", encoding="utf-8")
     if status == "stale":
-        mocker.patch.object(climate_ref.config, "DEFAULT_IGNORE_DATASETS_MAX_AGE", timedelta(seconds=-1))
+        mocker.patch.object(
+            climate_ref.config, "DEFAULT_IGNORE_DATASETS_REFRESH_INTERVAL", timedelta(seconds=-1)
+        )
 
     refresh_ignore_datasets_file(config)
 
@@ -447,6 +450,23 @@ def test_refresh_ignore_datasets_file_writes_atomically(mocker, monkeypatch, tmp
     assert config.ignore_datasets_resource.origin == ResourceOrigin.package
 
 
+def test_refresh_ignore_datasets_file_is_group_readable(mocker, monkeypatch, tmp_path):
+    """The cache is shared between users, so it must not inherit the 0600 mkstemp mode."""
+    mocker.patch.object(
+        climate_ref.config.requests,
+        "get",
+        return_value=mocker.MagicMock(status_code=200, content=b"downloaded"),
+    )
+    config = _refresh_config(monkeypatch, tmp_path)
+
+    refresh_ignore_datasets_file(config)
+
+    target = _ignore_datasets_cache_file()
+    umask = os.umask(0)
+    os.umask(umask)
+    assert stat.S_IMODE(target.stat().st_mode) == 0o666 & ~umask
+
+
 def test_stale_cache_does_not_shadow_the_packaged_copy(monkeypatch, tmp_path):
     """A cache left by an older release must not shadow the newer packaged copy forever."""
     monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))
@@ -498,7 +518,7 @@ def test_refresh_ignore_datasets_file_fail_uses_stale_cache(mocker, monkeypatch,
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("cached", encoding="utf-8")
     original_mtime = target.stat().st_mtime
-    mocker.patch.object(climate_ref.config, "DEFAULT_IGNORE_DATASETS_MAX_AGE", timedelta(seconds=-1))
+    mocker.patch.object(climate_ref.config, "DEFAULT_IGNORE_DATASETS_REFRESH_INTERVAL", timedelta(seconds=-1))
 
     with caplog.at_level(logging.WARNING):
         refresh_ignore_datasets_file(config)

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -1,5 +1,7 @@
+import datetime
 import importlib.metadata
 import logging
+import os
 import sys
 from datetime import timedelta
 from pathlib import Path
@@ -16,6 +18,7 @@ from climate_ref.config import (
     Config,
     PathConfig,
     _ignore_datasets_cache_file,
+    _legacy_ignore_datasets_file,
     refresh_ignore_datasets_file,
     transform_error,
 )
@@ -423,6 +426,66 @@ def test_refresh_ignore_datasets_file_unwritable_cache(mocker, monkeypatch, tmp_
 
     assert config.ignore_datasets_resource.origin == ResourceOrigin.package
     assert any("Could not refresh the grey list" in r.message for r in caplog.records)
+
+
+def test_refresh_ignore_datasets_file_writes_atomically(mocker, monkeypatch, tmp_path):
+    """A failed write must not leave a truncated file behind with a fresh modification time."""
+    mocker.patch.object(
+        climate_ref.config.requests,
+        "get",
+        return_value=mocker.MagicMock(status_code=200, content=b"downloaded"),
+    )
+    mocker.patch.object(climate_ref.config.Path, "replace", side_effect=OSError("disk full"))
+    config = _refresh_config(monkeypatch, tmp_path)
+
+    refresh_ignore_datasets_file(config)
+
+    target = _ignore_datasets_cache_file()
+    assert not target.exists()
+    # The temporary file is cleaned up rather than left in the cache directory.
+    assert list(target.parent.iterdir()) == []
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.package
+
+
+def test_stale_cache_does_not_shadow_the_packaged_copy(monkeypatch, tmp_path):
+    """A cache left by an older release must not shadow the newer packaged copy forever."""
+    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))
+    config = Config()
+    target = _ignore_datasets_cache_file()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("ancient", encoding="utf-8")
+
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.cache
+
+    ancient = (
+        datetime.datetime.now() - climate_ref.config.DEFAULT_IGNORE_DATASETS_MAX_STALE - timedelta(days=1)
+    ).timestamp()
+    os.utime(target, (ancient, ancient))
+
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.package
+
+
+def test_inherited_legacy_ignore_datasets_default_is_not_an_override(monkeypatch, tmp_path, mocker):
+    """Releases up to 0.16 baked the cache path into ref.toml, which must not pin the grey list."""
+    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path))
+    get_mock = mocker.patch.object(
+        climate_ref.config.requests,
+        "get",
+        return_value=mocker.MagicMock(status_code=200, content=b"downloaded"),
+    )
+    legacy = _legacy_ignore_datasets_file()
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("stale", encoding="utf-8")
+
+    config = Config()
+    config.ignore_datasets_file = legacy
+
+    # The inherited value is ignored, so refreshing still happens.
+    refresh_ignore_datasets_file(config)
+
+    get_mock.assert_called_once()
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.cache
+    assert config.ignore_datasets_resource.read_text() == "downloaded"
 
 
 def test_refresh_ignore_datasets_file_fail_uses_stale_cache(mocker, monkeypatch, tmp_path, caplog):

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -495,15 +495,22 @@ def test_inherited_legacy_ignore_datasets_default_is_not_an_override(monkeypatch
     legacy.parent.mkdir(parents=True, exist_ok=True)
     legacy.write_text("stale", encoding="utf-8")
 
-    config = Config()
-    config.ignore_datasets_file = legacy
+    config_file = tmp_path / "ref.toml"
+    config_file.write_text(f'ignore_datasets_file = "{legacy}"\n', encoding="utf-8")
 
-    # The inherited value is ignored, so refreshing still happens.
+    config = Config.load(config_file)
+
+    # Cleared at load, so it is not reported, not saved, and does not disable refreshing.
+    assert config.ignore_datasets_file is None
+
     refresh_ignore_datasets_file(config)
 
     get_mock.assert_called_once()
     assert config.ignore_datasets_resource.origin == ResourceOrigin.cache
     assert config.ignore_datasets_resource.read_text() == "downloaded"
+
+    config.save(config_file)
+    assert "ignore_datasets_file" not in config_file.read_text()
 
 
 def test_refresh_ignore_datasets_file_fail_uses_stale_cache(mocker, monkeypatch, tmp_path, caplog):

--- a/packages/climate-ref/tests/unit/test_conftest_plugin.py
+++ b/packages/climate-ref/tests/unit/test_conftest_plugin.py
@@ -2,22 +2,32 @@
 
 from pathlib import Path
 
-from climate_ref.config import DEFAULT_IGNORE_DATASETS_FILENAME, Config
+import pytest
+
+from climate_ref.config import BUNDLED_IGNORE_DATASETS, DEFAULT_IGNORE_DATASETS_FILENAME, Config
 from climate_ref.conftest_plugin import _use_local_ignore_datasets_file, packaged_ignore_datasets_file
+from climate_ref_core.data import ResourceOrigin
 
 # The canonical copy, served over `DEFAULT_IGNORE_DATASETS_URL` from the default branch.
+# Only present in a source checkout, so tests using it skip for an installed wheel.
 REPO_ROOT_IGNORE_FILE = Path(__file__).parents[4] / DEFAULT_IGNORE_DATASETS_FILENAME
 
 
 def test_packaged_ignore_datasets_file_is_resolvable():
-    # Resolved from the installed package, so this also holds for a wheel install.
+    # Materialised from the installed package, so this also holds for a wheel install.
     assert packaged_ignore_datasets_file().is_file()
 
 
 def test_packaged_ignore_datasets_file_matches_repo_root():
     # The root copy is what `DEFAULT_IGNORE_DATASETS_URL` serves, so the two must not drift apart.
-    assert REPO_ROOT_IGNORE_FILE.is_file()
-    assert packaged_ignore_datasets_file().read_bytes() == REPO_ROOT_IGNORE_FILE.read_bytes()
+    # `scripts/sync_grey_list.py` keeps them identical, and runs as a pre-commit hook.
+    if not REPO_ROOT_IGNORE_FILE.is_file():
+        pytest.skip("not running from a source checkout")
+
+    assert BUNDLED_IGNORE_DATASETS.read_text() == REPO_ROOT_IGNORE_FILE.read_text(encoding="utf-8"), (
+        "The packaged grey list has drifted from the canonical copy. "
+        "Run `python scripts/sync_grey_list.py` to update it."
+    )
 
 
 def test_use_local_ignore_datasets_file_disables_fetching():
@@ -26,5 +36,7 @@ def test_use_local_ignore_datasets_file_disables_fetching():
     _use_local_ignore_datasets_file(cfg)
 
     assert cfg.ignore_datasets_file == packaged_ignore_datasets_file()
+    # Pinned as an override, so a stale cache on the host cannot leak into a test.
+    assert cfg.ignore_datasets_resource.origin == ResourceOrigin.override
     # An empty URL short-circuits `refresh_ignore_datasets_file`, keeping tests offline.
     assert cfg.ignore_datasets_url == ""

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -184,15 +184,15 @@ def test_database_invalid_url(config, monkeypatch):
 
 
 def test_database_cvs(config, mocker):
-    cv = CV.load_from_file(config.paths.dimensions_cv)
+    cv = CV.load(config.paths.dimensions_cv_resource)
 
     mock_register_cv = mocker.patch.object(MetricValue, "register_cv_dimensions")
-    mock_cv = mocker.patch.object(CV, "load_from_file", return_value=cv)
+    mock_cv = mocker.patch.object(CV, "load", return_value=cv)
 
     with Database.from_config(config, run_migrations=True) as db:
         # CV is loaded once during a migration and once with each call to _add_dimension_columns
         assert mock_cv.call_count == 3
-        mock_cv.assert_called_with(config.paths.dimensions_cv)
+        mock_cv.assert_called_with(config.paths.dimensions_cv_resource)
         mock_register_cv.assert_called_once_with(mock_cv.return_value)
 
         # Verify that the dimensions have automatically been created

--- a/packages/climate-ref/tests/unit/test_offline.py
+++ b/packages/climate-ref/tests/unit/test_offline.py
@@ -9,6 +9,7 @@ and they point the cache at an unwritable directory so nothing can quietly be wr
 import socket
 
 import pytest
+import requests
 
 from climate_ref.config import Config, refresh_ignore_datasets_file
 from climate_ref_core.data import ResourceOrigin
@@ -29,23 +30,31 @@ def no_network(monkeypatch):
     library is caught, including one added by a future change.
     """
 
+    attempts: list[object] = []
+
     def blocked(*args, **kwargs):
-        raise NetworkAccessError(f"network access attempted: {args[:1]}")
+        attempts.append(args[-1] if args else None)
+        raise NetworkAccessError("network access attempted")
 
     monkeypatch.setattr(socket.socket, "connect", blocked)
     monkeypatch.setattr(socket.socket, "connect_ex", blocked)
     monkeypatch.setattr(socket, "create_connection", blocked)
+    return attempts
 
 
 @pytest.fixture
 def read_only_cache(monkeypatch, tmp_path):
-    """Point the dataset cache at a directory that cannot be created."""
-    root = tmp_path / "readonly"
-    root.mkdir()
-    root.chmod(0o500)
-    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(root / "cache"))
-    yield root / "cache"
-    root.chmod(0o700)
+    """
+    Point the dataset cache somewhere it cannot be created.
+
+    A regular file is used rather than a directory with the write bit cleared,
+    because permissions do not stop a privileged user and do not mean the same
+    thing on Windows. Creating a directory beneath a file always fails.
+    """
+    root = tmp_path / "not-a-directory"
+    root.touch()
+    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(root))
+    return root
 
 
 @pytest.fixture
@@ -60,19 +69,22 @@ def test_the_fixture_really_blocks_the_network(no_network):
     # test below pass for the wrong reason.
     with pytest.raises(NetworkAccessError):
         socket.create_connection(("example.invalid", 80))
+    assert no_network
 
 
 def test_configuration_loads(offline_config, read_only_cache):
     assert offline_config.ignore_datasets_file is None
     assert offline_config.paths.dimensions_cv is None
-    assert not read_only_cache.exists()
+    assert read_only_cache.is_file()
 
 
-def test_controlled_vocabulary_resolves_from_the_package(offline_config):
+def test_controlled_vocabulary_resolves_from_the_package(offline_config, no_network):
     resource = offline_config.paths.dimensions_cv_resource
 
     assert resource.origin == ResourceOrigin.package
     assert CV.load(resource).dimensions
+    # The controlled vocabulary has no remote copy, so nothing should even try.
+    assert no_network == []
 
 
 def test_grey_list_resolves_from_the_package(offline_config):
@@ -87,7 +99,26 @@ def test_grey_list_resolves_from_the_package(offline_config):
 def test_refreshing_the_grey_list_writes_nothing(offline_config, read_only_cache):
     refresh_ignore_datasets_file(offline_config)
 
-    assert not read_only_cache.exists()
+    assert read_only_cache.is_file()
+
+
+def test_grey_list_resolves_from_the_package_with_a_writable_cache(monkeypatch, tmp_path, no_network):
+    """
+    The air-gapped case with an ordinary filesystem.
+
+    `refresh_ignore_datasets_file` creates the cache directory before it fetches,
+    so the read-only case above never reaches the network.
+    This one does, and the download is what fails.
+    """
+    monkeypatch.setenv("REF_CONFIGURATION", str(tmp_path / "climate_ref"))
+    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(tmp_path / "cache"))
+    config = Config.default()
+
+    refresh_ignore_datasets_file(config)
+
+    assert no_network, "the download should have been attempted and blocked"
+    assert config.ignore_datasets_resource.origin == ResourceOrigin.package
+    assert config.ignore_datasets_resource.read_text()
 
 
 def test_provider_configure_applies_the_grey_list(offline_config, provider):
@@ -116,7 +147,7 @@ def test_a_conda_provider_does_not_need_the_network_to_configure(offline_config)
 
 @pytest.mark.xfail(
     reason="climate_ref_pmp downloads micromamba during configure, which is on the solve path",
-    raises=Exception,
+    raises=requests.exceptions.ConnectionError,
     strict=True,
 )
 def test_offline_known_gaps(offline_config):

--- a/packages/climate-ref/tests/unit/test_offline.py
+++ b/packages/climate-ref/tests/unit/test_offline.py
@@ -1,0 +1,132 @@
+"""
+Tests that the REF resolves its bundled data with no network and no writable filesystem.
+
+The other tests in this area mock `requests.get`, which only proves that one call site
+behaves. These block outbound sockets outright, so a request from any library fails,
+and they point the cache at an unwritable directory so nothing can quietly be written.
+"""
+
+import socket
+
+import pytest
+
+from climate_ref.config import Config, refresh_ignore_datasets_file
+from climate_ref_core.data import ResourceOrigin
+from climate_ref_core.providers import CondaDiagnosticProvider
+from climate_ref_core.pycmec.controlled_vocabulary import CV
+
+
+class NetworkAccessError(OSError):
+    """Raised when code under test tries to open a socket."""
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """
+    Block every outbound socket for the duration of a test.
+
+    Patching at the socket layer rather than at `requests` means a call from any
+    library is caught, including one added by a future change.
+    """
+
+    def blocked(*args, **kwargs):
+        raise NetworkAccessError(f"network access attempted: {args[:1]}")
+
+    monkeypatch.setattr(socket.socket, "connect", blocked)
+    monkeypatch.setattr(socket.socket, "connect_ex", blocked)
+    monkeypatch.setattr(socket, "create_connection", blocked)
+
+
+@pytest.fixture
+def read_only_cache(monkeypatch, tmp_path):
+    """Point the dataset cache at a directory that cannot be created."""
+    root = tmp_path / "readonly"
+    root.mkdir()
+    root.chmod(0o500)
+    monkeypatch.setenv("REF_DATASET_CACHE_DIR", str(root / "cache"))
+    yield root / "cache"
+    root.chmod(0o700)
+
+
+@pytest.fixture
+def offline_config(monkeypatch, tmp_path, no_network, read_only_cache):
+    """A default configuration on a host with no network and an unwritable cache."""
+    monkeypatch.setenv("REF_CONFIGURATION", str(tmp_path / "climate_ref"))
+    return Config.default()
+
+
+def test_the_fixture_really_blocks_the_network(no_network):
+    # Guards the guard. A fixture that silently stopped working would make every
+    # test below pass for the wrong reason.
+    with pytest.raises(NetworkAccessError):
+        socket.create_connection(("example.invalid", 80))
+
+
+def test_configuration_loads(offline_config, read_only_cache):
+    assert offline_config.ignore_datasets_file is None
+    assert offline_config.paths.dimensions_cv is None
+    assert not read_only_cache.exists()
+
+
+def test_controlled_vocabulary_resolves_from_the_package(offline_config):
+    resource = offline_config.paths.dimensions_cv_resource
+
+    assert resource.origin == ResourceOrigin.package
+    assert CV.load(resource).dimensions
+
+
+def test_grey_list_resolves_from_the_package(offline_config):
+    # Refreshing is attempted and fails on both counts, which must not be fatal.
+    refresh_ignore_datasets_file(offline_config)
+
+    resource = offline_config.ignore_datasets_resource
+    assert resource.origin == ResourceOrigin.package
+    assert resource.read_text()
+
+
+def test_refreshing_the_grey_list_writes_nothing(offline_config, read_only_cache):
+    refresh_ignore_datasets_file(offline_config)
+
+    assert not read_only_cache.exists()
+
+
+def test_provider_configure_applies_the_grey_list(offline_config, provider):
+    # `configure` is on the solve path, so it must not need the network either.
+    provider.configure(offline_config)
+
+    assert offline_config.ignore_datasets_resource.origin == ResourceOrigin.package
+
+
+def test_repeated_resolution_stays_offline(offline_config):
+    # Resolution happens on every access, so a later access must not reach out either.
+    for _ in range(3):
+        assert offline_config.ignore_datasets_resource.origin == ResourceOrigin.package
+        assert offline_config.paths.dimensions_cv_resource.origin == ResourceOrigin.package
+
+
+def test_a_conda_provider_does_not_need_the_network_to_configure(offline_config):
+    # A plain conda provider only records where its prefix will be.
+    # `climate_ref_pmp` additionally resolves its conda executable here, which does
+    # need the network. See test_offline_known_gaps below.
+    conda_provider = CondaDiagnosticProvider("offline-test", "v0")
+    conda_provider.configure(offline_config)
+
+    assert conda_provider.prefix == offline_config.paths.software / "conda"
+
+
+@pytest.mark.xfail(
+    reason="climate_ref_pmp downloads micromamba during configure, which is on the solve path",
+    raises=Exception,
+    strict=True,
+)
+def test_offline_known_gaps(offline_config):
+    """
+    Records that building the provider registry still needs the network.
+
+    `PMPDiagnosticProvider.configure` calls `get_conda_exe`, which downloads micromamba
+    when it is missing or more than a week old.
+    Remove this test once that call is deferred to environment setup.
+    """
+    pmp = pytest.importorskip("climate_ref_pmp")
+
+    pmp.PMPDiagnosticProvider("PMP", "v0").configure(offline_config)

--- a/packages/climate-ref/tests/unit/test_offline.py
+++ b/packages/climate-ref/tests/unit/test_offline.py
@@ -9,7 +9,6 @@ and they point the cache at an unwritable directory so nothing can quietly be wr
 import socket
 
 import pytest
-import requests
 
 from climate_ref.config import Config, refresh_ignore_datasets_file
 from climate_ref_core.data import ResourceOrigin
@@ -145,19 +144,17 @@ def test_a_conda_provider_does_not_need_the_network_to_configure(offline_config)
     assert conda_provider.prefix == offline_config.paths.software / "conda"
 
 
-@pytest.mark.xfail(
-    reason="climate_ref_pmp downloads micromamba during configure, which is on the solve path",
-    raises=requests.exceptions.ConnectionError,
-    strict=True,
-)
-def test_offline_known_gaps(offline_config):
+def test_pmp_configure_does_not_download_micromamba(offline_config, no_network):
     """
-    Records that building the provider registry still needs the network.
+    `configure` runs whenever the provider registry is built, so it is on the solve path.
 
-    `PMPDiagnosticProvider.configure` calls `get_conda_exe`, which downloads micromamba
-    when it is missing or more than a week old.
-    Remove this test once that call is deferred to environment setup.
+    It used to resolve the conda executable eagerly, which downloaded micromamba when it
+    was missing or more than a week old, and so failed on a host with no network.
     """
     pmp = pytest.importorskip("climate_ref_pmp")
 
-    pmp.PMPDiagnosticProvider("PMP", "v0").configure(offline_config)
+    provider = pmp.PMPDiagnosticProvider("PMP", "v0")
+    provider.configure(offline_config)
+
+    assert no_network == []
+    assert provider.env_vars["PCMDI_CONDA_EXE"] == str(offline_config.paths.software / "conda/micromamba")

--- a/scripts/sync_grey_list.py
+++ b/scripts/sync_grey_list.py
@@ -1,0 +1,49 @@
+"""
+Copy the canonical grey list into the ``climate_ref`` package.
+
+``default_ignore_datasets.yaml`` at the repository root is the canonical copy.
+It is served over HTTPS from the default branch, so already-released clients fetch it
+from that path and it cannot move.
+The same file also ships inside the ``climate_ref`` wheel, so an installation with no
+network access and no writable cache still has a grey list to work from.
+
+Two copies means they can drift, so this script keeps them identical.
+It runs as a pre-commit hook and rewrites the packaged copy rather than merely
+reporting a difference.
+"""
+
+import filecmp
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FILENAME = "default_ignore_datasets.yaml"
+CANONICAL = REPO_ROOT / FILENAME
+PACKAGED = REPO_ROOT / "packages" / "climate-ref" / "src" / "climate_ref" / FILENAME
+
+
+def main() -> int:
+    """
+    Copy the canonical grey list over the packaged copy if they differ.
+
+    Returns
+    -------
+    :
+        0 if the copies already matched, 1 if the packaged copy was rewritten.
+    """
+    if not CANONICAL.is_file():
+        print(f"Canonical grey list not found at {CANONICAL}", file=sys.stderr)
+        return 1
+
+    if PACKAGED.is_file() and filecmp.cmp(CANONICAL, PACKAGED, shallow=False):
+        return 0
+
+    PACKAGED.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(CANONICAL, PACKAGED)
+    print(f"Updated {PACKAGED.relative_to(REPO_ROOT)} from {FILENAME}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Reworks how the controlled vocabulary and the grey list are distributed so they resolve the same way, and so both work on read-only filesystems and in deployments with no internet access.

We were distributing these two files by several different mechanisms at once, and the one that put them inside the package did not hold up. Different Python versions and install layouts resolve package data differently, and the resolved location was leaking into places that assumed a writable, stable path.

## What was wrong

The CV was located with `Path(str(importlib.resources.files(...)))`. That is only correct when the package happens to be unpacked on disk. Worse, the resolved path was a config default, so `Config.save()` wrote a venv- and Python-version-specific absolute path into the user's TOML. That file is then shared between the CLI, celery workers and containers. The docs made this explicit, telling people to write `dimensions_cv = "${REF_INSTALLATION_DIR}/packages/climate-ref-core/src/..."`, a path that only exists in a source checkout.

The grey list existed in three places at once: the repository root, an identical copy inside the `climate_ref` package used only by the test fixtures, and an HTTP-refreshed copy in the user cache. The runtime never fell back to the packaged copy, so a solve with no network and no warm cache raised `IgnoreDatasetsRefreshError` even though the file was sitting right there in the wheel. Offline deployment required an operator to hand-copy a file and set two environment variables.

The pooch registry manifests repeated the same unsound `str(files(...))` pattern, and there were two unrelated cache roots: the grey list used `platformdirs.user_cache_path` while the registries used `resolve_cache_dir`, which honours `REF_DATASET_CACHE_DIR`. Setting that variable did not move the grey list.

## What this does

Adds `climate_ref_core.data` with `PackagedResource`, `FileResource` and `LayeredResource`. A logical file resolves across three layers: an operator override, a local cache, and the copy shipped in the package. The packaged copy is the floor, so resolution never requires the network or a writable filesystem. Resolution happens on every access, so a cache populated after the object is built is picked up without rebuilding it.

- `paths.dimensions_cv` and `ignore_datasets_file` become `Path | None`. Unset means the packaged copy, and no site-packages path is ever serialised into the saved configuration.
- A failed grey list refresh is no longer fatal. An unreachable network, an HTTP error and an unwritable cache directory all fall back to the cached or packaged copy with a warning.
- The cached grey list is written atomically, so an interrupted download cannot leave a truncated file that shadows the packaged copy until the cache window expires.
- A cached grey list that has not been refreshed for 30 days is ignored in favour of the packaged copy, so a cache left by an older release cannot shadow it indefinitely on a host that can never reach the network.
- The grey list cache moved under `REF_DATASET_CACHE_DIR`, so there is now one cache root rather than two. The copy in the old location is left in place and is no longer read.
- Package data is read through `importlib.resources` rather than `Path(str(...))`. This covers the CV, the grey list, the registry manifests, and ILAMB's import-time scan of `configure/`, which also no longer risks opening a `__pycache__` entry and now registers diagnostics in a deterministic order.
- Registry cache migration no longer fails the import of `climate_ref` when the cache root is read only.
- Adds a packaging test covering every data file the REF reads out of a package, plus a pre-commit hook that keeps the packaged grey list identical to the canonical copy at the repository root. Previously a unit test only detected drift between the two copies rather than fixing it.
- Adds `python -m climate_ref_core.pycmec.controlled_vocabulary`, which writes the bundled CV to stdout as the starting point for a custom one. The custom diagnostics guide now points at this instead of a site-packages path.
- Removes `IgnoreDatasetsRefreshError`, which nothing raises any more.
- Fixes the config docs generator, which assumed every field annotation has a `__name__` and so broke on `Path | None`. The Read the Docs build was failing on this and the GitHub Actions checks did not cover it.
- Deletes the `$REF_INSTALL_DIRECTORY` string-substitution hack in `docs/gen_config_stubs.py`, which existed only to hide the leaked path from the rendered docs.

`pmp_driver.py` keeps its `str(files(...))` call. It hands a path to an external subprocess, so it needs a durable real path that a context-managed temporary cannot give it.

## Deployment impact

Nothing needs to change in Docker or helm. A read-only rootfs now works out of the box and offline needs no environment variables at all. On a host with no route to the internet, setting `REF_IGNORE_DATASETS_URL=` is still worth doing to skip the request timeout on every solve, but it no longer changes the outcome.

## Notes for upgraders

Releases up to 0.16 wrote the grey list cache path into every saved `ref.toml` as a default. Left alone, this change would have reinterpreted that inherited value as a deliberate override, pinning those installations to a stale cache and silently disabling refreshing. That value is now recognised and ignored. If you deliberately set `ignore_datasets_file` to exactly the old cache path, move your copy elsewhere and point at that instead.

Anyone whose saved `ref.toml` contains the baked `dimensions_cv` path keeps that as an explicit override, and it will point at a stale venv after a Python upgrade or a container rebuild. The error now names the fix ("remove the setting to use the copy shipped with the REF") rather than failing obscurely, but it does not self-heal.

## Validation

- `mypy` clean across 157 source files.
- 2766 tests pass, `pre-commit run --all-files` green, Read the Docs build green.
- The offline claim is checked end to end: with outbound sockets blocked and the cache root at mode 500, both files resolve to the packaged copy and nothing is written.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled controlled vocabulary and grey-list now resolve automatically for offline/air-gapped runs, with optional operator overrides and local caching.
  * Added a command to export the bundled controlled vocabulary.
* **Bug Fixes**
  * Grey-list refresh is best-effort: failures no longer block solves and now fall back to cached or bundled data.
  * Prevented micromamba downloads during provider registry construction (improves offline reliability).
* **Documentation**
  * Updated configuration and custom diagnostic guides for the revised grey-list/vocabulary behaviour.
* **Tests/Chores**
  * Added offline/data-resolution coverage and a pre-commit grey-list sync hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->