### PR TITLE
Parallelise and chunk solve-time finalisation

### DIFF
--- a/changelog/837.improvement.md
+++ b/changelog/837.improvement.md
@@ -1,0 +1,10 @@
+Reworks the finalisation of datasets that were ingested with a `drs` parser.
+
+- Adds an `n_jobs` configuration value that controls how many worker processes parse dataset files.
+  Solve-time finalisation used to be permanently serial because `n_jobs` was only plumbed through `ref datasets ingest`.
+- Finalisation now runs in chunks of whole datasets, committing each chunk before parsing the next.
+  Progress is logged as it goes, and a cancelled solve keeps the work it has already done.
+- `ref datasets ingest` reports how many datasets are still missing metadata that can only be read from the files themselves.
+  This makes the cost that the `drs` parser defers to the first solve visible up front.
+- Fixes per-file metadata (`start_time`, `end_time`) being broadcast across every file of a dataset during finalisation.
+  A catalog loaded from the database repeats its dataset id once per file, and the per-row update did not account for that.

--- a/docs/background/datasets.md
+++ b/docs/background/datasets.md
@@ -124,6 +124,15 @@ export REF_CMIP6_PARSER=drs
 export REF_CMIP7_PARSER=drs
 ```
 
+Both parsers open files in parallel using `n_jobs` worker processes:
+
+```toml
+n_jobs = 16  # 1 (the default) parses serially, -1 uses all available CPUs
+```
+
+This applies to `ref datasets ingest` (where `--n-jobs` overrides it)
+and to the finalisation that `ref solve` performs.
+
 ## Two-Phase Ingestion (Lazy Finalisation)
 
 When using the DRS parser, the REF uses a two-phase workflow
@@ -146,6 +155,18 @@ so subsequent solves do not need to re-read the same files.
 This means that for an archive with hundreds of thousands of files,
 only the subset that is actually needed by a diagnostic is ever opened --
 not the entire archive.
+
+That subset can still be large, and opening a file is slow,
+so the deferred cost shows up as a long pause at the start of the first solve.
+Two things help:
+
+- Set `n_jobs` in your configuration to parse the files in parallel.
+  The work is bound by filesystem latency rather than by CPU, so values well above the core count are reasonable.
+- Watch the log. Finalisation runs in chunks of whole datasets and commits each chunk before parsing the next,
+  so progress is reported as it goes and a cancelled solve keeps what it has already parsed.
+
+`ref datasets ingest` reports how many datasets are left unfinalised
+so the size of the deferred work is known before the first solve.
 
 ### Re-ingestion Behaviour
 

--- a/docs/background/datasets.md
+++ b/docs/background/datasets.md
@@ -165,7 +165,7 @@ Two things help:
 - Watch the log. Finalisation runs in chunks of whole datasets and commits each chunk before parsing the next,
   so progress is reported as it goes and a cancelled solve keeps what it has already parsed.
 
-`ref datasets ingest` reports how many datasets are left unfinalised
+`ref datasets ingest` reports how many datasets are left unfinalised,
 so the size of the deferred work is known before the first solve.
 
 ### Re-ingestion Behaviour

--- a/docs/background/datasets.md
+++ b/docs/background/datasets.md
@@ -124,7 +124,7 @@ export REF_CMIP6_PARSER=drs
 export REF_CMIP7_PARSER=drs
 ```
 
-Both parsers open files in parallel using `n_jobs` worker processes:
+File parsing is spread across `n_jobs` worker processes:
 
 ```toml
 n_jobs = 16  # 1 (the default) parses serially, -1 uses all available CPUs

--- a/packages/climate-ref/src/climate_ref/cli/datasets.py
+++ b/packages/climate-ref/src/climate_ref/cli/datasets.py
@@ -253,7 +253,10 @@ def ingest(  # noqa
     source_type: Annotated[SourceDatasetType, typer.Option(help="Type of source dataset")],
     solve: Annotated[bool, typer.Option(help="Solve for new diagnostic executions after ingestion")] = False,
     dry_run: Annotated[bool, typer.Option(help="Do not ingest datasets into the database")] = False,
-    n_jobs: Annotated[int | None, typer.Option(help="Number of jobs to run in parallel")] = None,
+    n_jobs: Annotated[
+        int | None,
+        typer.Option(help="Number of jobs to run in parallel. Defaults to the `n_jobs` configuration value"),
+    ] = None,
     skip_invalid: Annotated[
         bool, typer.Option(help="Ignore (but log) any datasets that don't pass validation")
     ] = True,
@@ -276,19 +279,14 @@ def ingest(  # noqa
 
     A table of the datasets will be printed to the console at the end of the operation.
     """
-    from climate_ref.datasets import IngestionStats, ingest_datasets
+    from climate_ref.datasets import IngestionStats, ingest_datasets, log_deferred_finalisation
 
     config = ctx.obj.config
     db = ctx.obj.database
     console = ctx.obj.console
 
-    kwargs = {}
-
-    if n_jobs is not None:
-        kwargs["n_jobs"] = n_jobs
-
     # Create a data catalog from the specified file or directory
-    adapter = get_dataset_adapter(source_type.value, **kwargs)
+    adapter = get_dataset_adapter(source_type.value, n_jobs=n_jobs if n_jobs is not None else config.n_jobs)
 
     failed_dirs: list[Path] = []
 
@@ -395,6 +393,9 @@ def ingest(  # noqa
             # Use shared ingestion logic with pre-validated catalog
             stats = ingest_datasets(adapter, None, db, data_catalog=data_catalog, skip_invalid=skip_invalid)
             stats.log_summary()
+
+    if not dry_run:
+        log_deferred_finalisation(db, source_type)
 
     if solve:
         from climate_ref.solver import solve_required_executions

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -764,6 +764,11 @@ class Config:
         # This is needed to apply the environment variable overrides on initialization
         _environ_post_init(self)
 
+        # Checked after the overrides so an invalid value from the environment is caught too.
+        # `0` and negatives below `-1` would otherwise fall back to serial parsing without a word.
+        if self.n_jobs != -1 and self.n_jobs < 1:
+            raise ValueError(f"n_jobs must be -1 (all CPUs) or a positive integer, got {self.n_jobs}")
+
 
 def _make_converter(omit_default: bool, forbid_extra_keys: bool) -> Converter:
     conv = Converter(omit_if_default=omit_default, forbid_extra_keys=forbid_extra_keys)

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -535,8 +535,9 @@ class Config:
     """
     Number of worker processes used to parse dataset files
 
-    `1` parses serially, `-1` uses all available CPUs and any other positive value
-    is used as-is.
+    `1` parses serially,
+    `-1` uses all available CPUs,
+    and any other positive value is used as-is.
 
     Parsing opens netCDF files, so it is bound by (highly parallel) filesystem latency rather than by CPU.
     This applies both to `ref datasets ingest` (where `--n-jobs` overrides it)

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -531,6 +531,19 @@ class Config:
     - `complete`: Use the complete parser, which parses the dataset based on all available metadata.
     """
 
+    n_jobs: int = env_field("N_JOBS", default=1, converter=int)
+    """
+    Number of worker processes used to parse dataset files
+
+    `1` parses serially, `-1` uses all available CPUs and any other positive value
+    is used as-is.
+
+    Parsing opens netCDF files, so it is bound by (highly parallel) filesystem latency rather than by CPU.
+    This applies both to `ref datasets ingest` (where `--n-jobs` overrides it)
+    and to the finalisation of datasets that the solver performs
+    when they were ingested with the `drs` parser.
+    """
+
     ignore_datasets_file: Path = env_field(  # noqa: RUF009
         "IGNORE_DATASETS_FILE",
         factory=_get_default_ignore_datasets_file,

--- a/packages/climate-ref/src/climate_ref/data_catalog.py
+++ b/packages/climate-ref/src/climate_ref/data_catalog.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import pandas as pd
 from attrs import define
-from loguru import logger
 
 from climate_ref.database import Database
 from climate_ref.datasets.base import DatasetAdapter
@@ -106,9 +105,6 @@ class DataCatalog:
         if not has_unfinalised:
             return subset
 
-        logger.info(
-            f"Finalising {(subset['finalised'] == False).sum()} unfinalised datasets"  # noqa: E712
-        )
         result = self.adapter.finalise_datasets(self.database, subset)
 
         # Invalidate the cached DataFrame so the next to_frame() call

--- a/packages/climate-ref/src/climate_ref/datasets/__init__.py
+++ b/packages/climate-ref/src/climate_ref/datasets/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 import pandas as pd
 from attrs import define
 from loguru import logger
+from sqlalchemy import func
 
 from climate_ref.database import Database, ModelState
 from climate_ref.datasets.base import DatasetAdapter
@@ -16,6 +17,7 @@ from climate_ref.datasets.cmip7 import CMIP7DatasetAdapter
 from climate_ref.datasets.esmvaltool_reference import ESMValToolReferenceDatasetAdapter
 from climate_ref.datasets.obs4mips import Obs4MIPsDatasetAdapter, Obs4REFDatasetAdapter
 from climate_ref.datasets.pmp_climatology import PMPClimatologyDatasetAdapter
+from climate_ref.models.dataset import Dataset, DatasetFile
 from climate_ref_core.datasets import SourceDatasetType
 
 # Pre-computed slug column lookup by source type.
@@ -228,6 +230,40 @@ def ingest_datasets(  # noqa: PLR0913
     return _ingest_catalog(adapter, db, data_catalog)
 
 
+def log_deferred_finalisation(db: Database, source_type: SourceDatasetType) -> None:
+    """
+    Report the metadata extraction that has been deferred to the next solve.
+
+    The `drs` parsers read metadata from the filename and directory structure only,
+    so the remaining metadata is extracted the first time the solver needs it.
+    That work is invisible at ingest time,
+    which makes the `drs` parser look cheaper than it is.
+
+    Parameters
+    ----------
+    db
+        Database instance to count the unfinalised datasets in
+    source_type
+        Source type that was just ingested
+    """
+    with db.session.begin():
+        counts = (
+            db.session.query(func.count(func.distinct(Dataset.id)), func.count(DatasetFile.id))
+            .join(DatasetFile, DatasetFile.dataset_id == Dataset.id, isouter=True)
+            .filter(Dataset.dataset_type == source_type, Dataset.finalised.is_(False))
+            .one()
+        )
+    n_datasets, n_files = counts
+
+    if not n_datasets:
+        return
+
+    logger.warning(
+        f"{n_datasets} {source_type.value} datasets ({n_files} files) are missing metadata that "
+        "can only be read from the files themselves when potentially needed by a solve. "
+    )
+
+
 def get_dataset_adapter(source_type: str, **kwargs: Any) -> DatasetAdapter:
     """
     Get the appropriate adapter for the specified source type
@@ -271,4 +307,5 @@ __all__ = [
     "get_dataset_adapter",
     "get_slug_column",
     "ingest_datasets",
+    "log_deferred_finalisation",
 ]

--- a/packages/climate-ref/src/climate_ref/datasets/__init__.py
+++ b/packages/climate-ref/src/climate_ref/datasets/__init__.py
@@ -260,7 +260,7 @@ def log_deferred_finalisation(db: Database, source_type: SourceDatasetType) -> N
 
     logger.warning(
         f"{n_datasets} {source_type.value} datasets ({n_files} files) are missing metadata that "
-        "can only be read from the files themselves when potentially needed by a solve. "
+        "can only be read from the files themselves when potentially needed by a solve."
     )
 
 

--- a/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
+++ b/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
@@ -177,7 +177,7 @@ def build_catalog(
         Maximum directory depth to search
     n_jobs
         Number of parallel workers for parsing.
-        ``1`` = sequential, ``-1`` = all CPUs, ``>1`` = that many threads.
+        ``1`` = sequential, ``-1`` = all CPUs, ``>1`` = that many worker processes.
 
     Returns
     -------

--- a/packages/climate-ref/src/climate_ref/datasets/mixins.py
+++ b/packages/climate-ref/src/climate_ref/datasets/mixins.py
@@ -195,7 +195,11 @@ class FinaliseableDatasetAdapterMixin:
         :
             The chunk with metadata extracted from the files that parsed successfully
         """
+        # Captured before the parse marks rows finalised, so the commit can still tell
+        # which rows this chunk was responsible for.
         pending = chunk.loc[chunk["finalised"] == False, "path"]  # noqa: E712
+        pending_index = pending.index
+
         valid = [(label, str(path)) for label, path in pending.items() if not pd.isna(path)]
         if not valid:
             return chunk
@@ -227,7 +231,7 @@ class FinaliseableDatasetAdapterMixin:
             # A chunk holds whole datasets, so per-dataset fixes see all of their files.
             chunk = self._post_finalise_fixes(chunk)
 
-        self._persist_finalised_metadata(db, chunk, chunk.index)
+        self._persist_finalised_metadata(db, chunk, pending_index)
 
         return chunk
 

--- a/packages/climate-ref/src/climate_ref/datasets/mixins.py
+++ b/packages/climate-ref/src/climate_ref/datasets/mixins.py
@@ -47,7 +47,9 @@ def _chunk_by_dataset(datasets: pd.DataFrame, slug_column: str, chunk_size: int)
     """
     labels: list[Any] = []
 
-    for _, group in datasets.groupby(slug_column, sort=False):
+    # dropna=False so a row with a missing slug still lands in a chunk.
+    # The caller reassembles the catalog from the chunks and would otherwise lose it.
+    for _, group in datasets.groupby(slug_column, sort=False, dropna=False):
         labels.extend(group.index.tolist())
         if len(labels) >= chunk_size:
             yield pd.Index(labels)

--- a/packages/climate-ref/src/climate_ref/datasets/mixins.py
+++ b/packages/climate-ref/src/climate_ref/datasets/mixins.py
@@ -3,6 +3,8 @@ Mixins for dataset adapters that support lazy finalization.
 """
 
 from abc import abstractmethod
+from collections.abc import Iterator
+from typing import Any
 
 import pandas as pd
 from loguru import logger
@@ -11,6 +13,48 @@ from climate_ref.database import Database
 from climate_ref.datasets.base import DatasetParsingFunction
 from climate_ref.datasets.catalog_builder import parse_files
 from climate_ref.datasets.utils import _is_na, parse_cftime_dates
+
+DEFAULT_FINALISE_CHUNK_SIZE = 500
+"""
+Number of files that are parsed and committed per finalisation chunk.
+
+Each chunk is committed before the next one is parsed,
+so cancelling a long finalisation keeps the work that has already been done.
+"""
+
+
+def _chunk_by_dataset(datasets: pd.DataFrame, slug_column: str, chunk_size: int) -> Iterator[pd.Index]:
+    """
+    Split a catalog into chunks of index labels holding roughly ``chunk_size`` files each.
+
+    A dataset is never split across two chunks,
+    so each chunk can be parsed and committed as a unit.
+
+    Parameters
+    ----------
+    datasets
+        Catalog to split. The index must be unique.
+    slug_column
+        Column holding the dataset identifier.
+    chunk_size
+        Soft target for the number of files per chunk.
+        A chunk exceeds this when a single dataset has more files.
+
+    Yields
+    ------
+    :
+        Index labels for each chunk.
+    """
+    labels: list[Any] = []
+
+    for _, group in datasets.groupby(slug_column, sort=False):
+        labels.extend(group.index.tolist())
+        if len(labels) >= chunk_size:
+            yield pd.Index(labels)
+            labels = []
+
+    if labels:
+        yield pd.Index(labels)
 
 
 class FinaliseableDatasetAdapterMixin:
@@ -54,12 +98,21 @@ class FinaliseableDatasetAdapterMixin:
         """
         return datasets
 
-    def finalise_datasets(self, db: Database, datasets: pd.DataFrame) -> pd.DataFrame:
+    def finalise_datasets(
+        self,
+        db: Database,
+        datasets: pd.DataFrame,
+        chunk_size: int = DEFAULT_FINALISE_CHUNK_SIZE,
+    ) -> pd.DataFrame:
         """
         Finalise unfinalised datasets by opening files to extract full metadata.
 
-        Files are parsed in parallel using ``self.n_jobs`` threads,
+        Files are parsed in parallel using ``self.n_jobs`` worker processes,
         mirroring the parallelism used during ingest.
+
+        Work is done in chunks of whole datasets.
+        Each chunk is committed before the next one is parsed,
+        so progress is visible and a cancelled run keeps what it has already parsed.
 
         Parameters
         ----------
@@ -67,53 +120,107 @@ class FinaliseableDatasetAdapterMixin:
             Database instance for persisting updated metadata
         datasets
             DataFrame containing datasets to finalise (should have finalised=False)
+        chunk_size
+            Soft target for the number of files parsed and committed per chunk
 
         Returns
         -------
         :
             Updated DataFrame with full metadata extracted from files
         """
-        unfinalised = datasets[datasets["finalised"] == False]  # noqa: E712
+        # The catalog is indexed by dataset id, which repeats once per file.
+        # Work against a unique index so per-row updates address a single file
+        # and chunks can be reassembled without ambiguity.
+        original_index = datasets.index
+        working = datasets.set_axis(pd.RangeIndex(len(datasets)))
 
-        # Collect (index, path) pairs for rows that have a valid path
-        valid = [(idx, str(row["path"])) for idx, row in unfinalised.iterrows() if not pd.isna(row["path"])]
-        if not valid:
+        unfinalised = working[working["finalised"] == False]  # noqa: E712
+        total_files = int(unfinalised["path"].notna().sum())
+        if not total_files:
             return datasets
 
-        indices, paths = zip(*valid)
-
+        slug_column = self.slug_column  # type: ignore[attr-defined]
+        parsing_func = self.get_complete_parser()
         n_jobs = self.n_jobs if hasattr(self, "n_jobs") else 1
 
-        parsed_results = parse_files(list(paths), self.get_complete_parser(), n_jobs=n_jobs)
+        logger.info(
+            f"Finalising {unfinalised[slug_column].nunique()} datasets ({total_files} files) "
+            f"using {n_jobs} worker(s)"
+        )
 
-        updated_indices = []
-        for idx, path, parsed in zip(indices, paths, parsed_results):
+        untouched = working.drop(index=unfinalised.index)
+        chunks = [untouched] if len(untouched) else []
+
+        parsed_files = 0
+        for labels in _chunk_by_dataset(unfinalised, slug_column, chunk_size):
+            chunk = self._finalise_chunk(db, working.loc[labels].copy(), parsing_func, n_jobs)
+            chunks.append(chunk)
+
+            parsed_files += int(chunk["path"].notna().sum())
+            logger.info(f"Parsed {parsed_files}/{total_files} files")
+
+        return pd.concat(chunks).sort_index().set_axis(original_index)
+
+    def _finalise_chunk(
+        self,
+        db: Database,
+        chunk: pd.DataFrame,
+        parsing_func: DatasetParsingFunction,
+        n_jobs: int,
+    ) -> pd.DataFrame:
+        """
+        Parse, fix and persist a single chunk of unfinalised rows.
+
+        Parameters
+        ----------
+        db
+            Database instance for persisting updated metadata
+        chunk
+            Unfinalised rows for a whole number of datasets, with a unique index
+        parsing_func
+            Parser that opens each file to extract full metadata
+        n_jobs
+            Number of parallel workers to parse the chunk with
+
+        Returns
+        -------
+        :
+            The chunk with metadata extracted from the files that parsed successfully
+        """
+        valid = [(label, str(path)) for label, path in chunk["path"].items() if not pd.isna(path)]
+        if not valid:
+            return chunk
+
+        labels, paths = zip(*valid)
+        parsed_results = parse_files(list(paths), parsing_func, n_jobs=n_jobs)
+
+        updated_labels = []
+        for label, path, parsed in zip(labels, paths, parsed_results):
             if "INVALID_ASSET" in parsed:
                 logger.warning(f"Failed to finalise {path}: {parsed.get('TRACEBACK', '')}")
                 continue
 
             for key, value in parsed.items():
-                if key in datasets.columns and value is not None:
-                    datasets.at[idx, key] = value
+                if key in chunk.columns and value is not None:
+                    chunk.at[label, key] = value
 
-            datasets.at[idx, "finalised"] = True
-            updated_indices.append(idx)
+            chunk.at[label, "finalised"] = True
+            updated_labels.append(label)
 
-        if updated_indices:
+        if updated_labels:
             # Convert start_time/end_time strings from the complete parser to cftime objects
-            mask = datasets.index.isin(updated_indices)
-            cal = datasets.loc[mask, "calendar"] if "calendar" in datasets.columns else "standard"
-            datasets.loc[mask, "start_time"] = parse_cftime_dates(
-                datasets.loc[mask, "start_time"], cal
-            ).values
-            datasets.loc[mask, "end_time"] = parse_cftime_dates(datasets.loc[mask, "end_time"], cal).values
+            mask = chunk.index.isin(updated_labels)
+            cal = chunk.loc[mask, "calendar"] if "calendar" in chunk.columns else "standard"
+            chunk.loc[mask, "start_time"] = parse_cftime_dates(chunk.loc[mask, "start_time"], cal).values
+            chunk.loc[mask, "end_time"] = parse_cftime_dates(chunk.loc[mask, "end_time"], cal).values
 
-            # Apply adapter-specific fixes
-            datasets = self._post_finalise_fixes(datasets)
+            # Apply adapter-specific fixes.
+            # A chunk holds whole datasets, so per-dataset fixes see all of their files.
+            chunk = self._post_finalise_fixes(chunk)
 
-        self._persist_finalised_metadata(db, datasets, unfinalised.index)
+        self._persist_finalised_metadata(db, chunk, chunk.index)
 
-        return datasets
+        return chunk
 
     def _persist_finalised_metadata(
         self, db: Database, datasets: pd.DataFrame, unfinalised_index: pd.Index

--- a/packages/climate-ref/src/climate_ref/datasets/mixins.py
+++ b/packages/climate-ref/src/climate_ref/datasets/mixins.py
@@ -148,15 +148,20 @@ class FinaliseableDatasetAdapterMixin:
             f"using {n_jobs} worker(s)"
         )
 
-        untouched = working.drop(index=unfinalised.index)
-        chunks = [untouched] if len(untouched) else []
+        # Chunk over every file of an affected dataset, not just its unfinalised ones,
+        # so per-dataset fixes and the per-dataset commit see the whole dataset.
+        affected = working[working[slug_column].isin(unfinalised[slug_column].unique())]
+        untouched = working.drop(index=affected.index)
+        chunks: list[pd.DataFrame] = [untouched] if len(untouched) else []
 
         parsed_files = 0
-        for labels in _chunk_by_dataset(unfinalised, slug_column, chunk_size):
-            chunk = self._finalise_chunk(db, working.loc[labels].copy(), parsing_func, n_jobs)
-            chunks.append(chunk)
+        for labels in _chunk_by_dataset(affected, slug_column, chunk_size):
+            chunk = working.loc[labels].copy()
+            attempted = int(chunk.loc[chunk["finalised"] == False, "path"].notna().sum())  # noqa: E712
 
-            parsed_files += int(chunk["path"].notna().sum())
+            chunks.append(self._finalise_chunk(db, chunk, parsing_func, n_jobs))
+
+            parsed_files += attempted
             logger.info(f"Parsed {parsed_files}/{total_files} files")
 
         return pd.concat(chunks).sort_index().set_axis(original_index)
@@ -176,7 +181,8 @@ class FinaliseableDatasetAdapterMixin:
         db
             Database instance for persisting updated metadata
         chunk
-            Unfinalised rows for a whole number of datasets, with a unique index
+            Every row of a whole number of datasets, with a unique index.
+            Rows that are already finalised are left alone.
         parsing_func
             Parser that opens each file to extract full metadata
         n_jobs
@@ -187,7 +193,8 @@ class FinaliseableDatasetAdapterMixin:
         :
             The chunk with metadata extracted from the files that parsed successfully
         """
-        valid = [(label, str(path)) for label, path in chunk["path"].items() if not pd.isna(path)]
+        pending = chunk.loc[chunk["finalised"] == False, "path"]  # noqa: E712
+        valid = [(label, str(path)) for label, path in pending.items() if not pd.isna(path)]
         if not valid:
             return chunk
 

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -501,15 +501,23 @@ class ExecutionSolver:
         return ExecutionSolver(
             provider_registry=ProviderRegistry.build_from_config(config, db),
             data_catalog={
-                SourceDatasetType.CMIP6: DataCatalog(database=db, adapter=CMIP6DatasetAdapter(config=config)),
-                SourceDatasetType.CMIP7: DataCatalog(database=db, adapter=CMIP7DatasetAdapter()),
-                SourceDatasetType.obs4MIPs: DataCatalog(database=db, adapter=Obs4MIPsDatasetAdapter()),
-                SourceDatasetType.PMPClimatology: DataCatalog(
-                    database=db, adapter=PMPClimatologyDatasetAdapter()
+                SourceDatasetType.CMIP6: DataCatalog(
+                    database=db, adapter=CMIP6DatasetAdapter(n_jobs=config.n_jobs, config=config)
                 ),
-                SourceDatasetType.obs4REF: DataCatalog(database=db, adapter=Obs4REFDatasetAdapter()),
+                SourceDatasetType.CMIP7: DataCatalog(
+                    database=db, adapter=CMIP7DatasetAdapter(n_jobs=config.n_jobs, config=config)
+                ),
+                SourceDatasetType.obs4MIPs: DataCatalog(
+                    database=db, adapter=Obs4MIPsDatasetAdapter(n_jobs=config.n_jobs)
+                ),
+                SourceDatasetType.PMPClimatology: DataCatalog(
+                    database=db, adapter=PMPClimatologyDatasetAdapter(n_jobs=config.n_jobs)
+                ),
+                SourceDatasetType.obs4REF: DataCatalog(
+                    database=db, adapter=Obs4REFDatasetAdapter(n_jobs=config.n_jobs)
+                ),
                 SourceDatasetType.ESMValToolReference: DataCatalog(
-                    database=db, adapter=ESMValToolReferenceDatasetAdapter()
+                    database=db, adapter=ESMValToolReferenceDatasetAdapter(n_jobs=config.n_jobs)
                 ),
             },
         )

--- a/packages/climate-ref/tests/unit/cli/test_datasets.py
+++ b/packages/climate-ref/tests/unit/cli/test_datasets.py
@@ -377,6 +377,23 @@ class TestIngest:
         assert db.session.query(CMIP6Dataset).count() == expected_dataset_count
         assert db.session.query(DatasetFile).count() == expected_dataset_count
 
+    def test_ingest_drs_reports_deferred_finalisation(self, sample_data_dir, db, invoke_cli, monkeypatch):
+        """The DRS parser defers work to the first solve, so ingest has to say so."""
+        monkeypatch.setenv("REF_CMIP6_PARSER", "drs")
+
+        result = invoke_cli(
+            ["datasets", "ingest", str(sample_data_dir / self.data_dir), "--source-type", "cmip6"]
+        )
+
+        assert "6 cmip6 datasets (6 files) are missing metadata" in result.stderr
+
+    def test_ingest_complete_does_not_report_deferred_finalisation(self, sample_data_dir, db, invoke_cli):
+        result = invoke_cli(
+            ["datasets", "ingest", str(sample_data_dir / self.data_dir), "--source-type", "cmip6"]
+        )
+
+        assert "missing metadata" not in result.stderr
+
     def test_ingest_multiple(self, sample_data_dir, db, invoke_cli):
         invoke_cli(
             [

--- a/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
+++ b/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
@@ -239,6 +239,24 @@ class TestChunkedFinalisation:
         mock_parse.assert_called_once_with("/b.nc")
         assert result["finalised"].all()
 
+    def test_chunk_holds_every_file_of_a_partly_finalised_dataset(self, config, adapter_config, db, mocker):
+        """Per-dataset fixes need the whole dataset, not just its unfinalised files."""
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/a1.nc", "/a2.nc"])
+        df.loc[0, "finalised"] = True
+
+        persist = mocker.patch.object(adapter, "_persist_finalised_metadata")
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value=adapter_config.successful_parsed_result,
+        ) as mock_parse:
+            result = adapter.finalise_datasets(db, df, chunk_size=10)
+
+        # Only the unfinalised file is opened, but the commit sees both rows.
+        mock_parse.assert_called_once_with("/a2.nc")
+        assert len(persist.call_args_list[0].args[1]) == 2
+        assert result["finalised"].all()
+
     def test_file_metadata_is_not_broadcast_across_duplicate_labels(self, config, adapter_config, db):
         """A catalog loaded from the database repeats its dataset id once per file."""
         adapter = adapter_config.adapter_cls(config=config)

--- a/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
+++ b/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
@@ -257,6 +257,29 @@ class TestChunkedFinalisation:
         assert len(persist.call_args_list[0].args[1]) == 2
         assert result["finalised"].all()
 
+    def test_failed_parse_does_not_finalise_via_an_already_finalised_sibling(
+        self, config, adapter_config, db, mocker
+    ):
+        """A dataset must not be committed as finalised on the strength of rows it did not parse."""
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/a1.nc", "/a2.nc"])
+        df.loc[0, "finalised"] = True
+
+        persist = mocker.spy(adapter, "_persist_finalised_metadata")
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value={"INVALID_ASSET": "/a2.nc", "TRACEBACK": "corrupt file"},
+        ):
+            result = adapter.finalise_datasets(db, df, chunk_size=10)
+
+        # Only the row this chunk actually parsed counts towards the commit,
+        # so the already-finalised sibling cannot stand in for it.
+        committed = persist.call_args_list[0].args[1]
+        pending_index = persist.call_args_list[0].args[2]
+        assert list(pending_index) == [1]
+        assert not committed.loc[pending_index, "finalised"].any()
+        assert not result["finalised"].iloc[1]
+
     def test_file_metadata_is_not_broadcast_across_duplicate_labels(self, config, adapter_config, db):
         """A catalog loaded from the database repeats its dataset id once per file."""
         adapter = adapter_config.adapter_cls(config=config)

--- a/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
+++ b/packages/climate-ref/tests/unit/datasets/test_cmip_adapters.py
@@ -170,6 +170,93 @@ class TestFinalisationEdgeCases:
         assert result[check_field].iloc[0] == check_value
 
 
+class TestChunkedFinalisation:
+    """Finalisation happens in chunks of whole datasets, committed as it goes."""
+
+    def test_each_chunk_is_persisted_separately(self, config, adapter_config, db, mocker):
+        """A chunk is committed before the next one is parsed."""
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/a.nc", "/b.nc", "/c.nc"])
+        df["instance_id"] = ["ds1", "ds2", "ds3"]
+
+        persist = mocker.patch.object(adapter, "_persist_finalised_metadata")
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value=adapter_config.successful_parsed_result,
+        ):
+            result = adapter.finalise_datasets(db, df, chunk_size=1)
+
+        assert persist.call_count == 3
+        assert result["finalised"].all()
+
+    def test_datasets_are_not_split_across_chunks(self, config, adapter_config, db, mocker):
+        """All files of a dataset are parsed and committed together."""
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/a1.nc", "/a2.nc", "/b1.nc", "/b2.nc"])
+        df["instance_id"] = ["ds1", "ds1", "ds2", "ds2"]
+
+        persist = mocker.patch.object(adapter, "_persist_finalised_metadata")
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value=adapter_config.successful_parsed_result,
+        ):
+            adapter.finalise_datasets(db, df, chunk_size=1)
+
+        assert persist.call_count == 2
+        assert [len(call.args[1]) for call in persist.call_args_list] == [2, 2]
+
+    def test_row_order_and_index_are_preserved(self, config, adapter_config, db, mocker):
+        """The returned catalog keeps the index and row order it was given."""
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/a.nc", "/b.nc", "/c.nc"])
+        df["instance_id"] = ["ds2", "ds1", "ds2"]
+        df.index = pd.Index([11, 12, 13])
+
+        mocker.patch.object(adapter, "_persist_finalised_metadata")
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value=adapter_config.successful_parsed_result,
+        ):
+            result = adapter.finalise_datasets(db, df, chunk_size=1)
+
+        assert list(result.index) == [11, 12, 13]
+        assert list(result["path"]) == ["/a.nc", "/b.nc", "/c.nc"]
+
+    def test_already_finalised_rows_are_kept(self, config, adapter_config, db, mocker):
+        """Rows that were already finalised survive the chunked rebuild."""
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/a.nc", "/b.nc"])
+        df["instance_id"] = ["ds1", "ds2"]
+        df.loc[0, "finalised"] = True
+
+        mocker.patch.object(adapter, "_persist_finalised_metadata")
+        with patch(
+            adapter_config.complete_parser_patch_path,
+            return_value=adapter_config.successful_parsed_result,
+        ) as mock_parse:
+            result = adapter.finalise_datasets(db, df, chunk_size=10)
+
+        mock_parse.assert_called_once_with("/b.nc")
+        assert result["finalised"].all()
+
+    def test_file_metadata_is_not_broadcast_across_duplicate_labels(self, config, adapter_config, db):
+        """A catalog loaded from the database repeats its dataset id once per file."""
+        adapter = adapter_config.adapter_cls(config=config)
+        df = _make_unfinalised_df(adapter_config, ["/a1.nc", "/a2.nc"])
+        df.index = pd.Index([7, 7])
+
+        def side_effect(path, **_):
+            parsed = dict(adapter_config.successful_parsed_result)
+            parsed["start_time"] = "2000-01-01" if path.endswith("a1.nc") else "2001-01-01"
+            return parsed
+
+        with patch(adapter_config.complete_parser_patch_path, side_effect=side_effect):
+            result = adapter.finalise_datasets(db, df)
+
+        assert list(result.index) == [7, 7]
+        assert result["start_time"].iloc[0] != result["start_time"].iloc[1]
+
+
 class TestPersistFinalisedMetadata:
     """_persist_finalised_metadata edge cases, parameterised over adapter types."""
 

--- a/packages/climate-ref/tests/unit/datasets/test_mixins.py
+++ b/packages/climate-ref/tests/unit/datasets/test_mixins.py
@@ -1,0 +1,40 @@
+"""Unit tests for the finalisation helpers that are not adapter specific."""
+
+import pandas as pd
+
+from climate_ref.datasets.mixins import _chunk_by_dataset
+
+
+def _frame(slugs: list[str | None]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {"instance_id": slugs, "path": [f"/{i}.nc" for i in range(len(slugs))]},
+        index=pd.RangeIndex(len(slugs)),
+    )
+
+
+class TestChunkByDataset:
+    def test_keeps_a_dataset_in_one_chunk(self):
+        """A chunk may exceed the target rather than split a dataset."""
+        chunks = list(_chunk_by_dataset(_frame(["a", "a", "a", "b"]), "instance_id", 1))
+
+        assert [len(c) for c in chunks] == [3, 1]
+
+    def test_fills_chunks_to_the_target(self):
+        chunks = list(_chunk_by_dataset(_frame(["a", "b", "c", "d"]), "instance_id", 2))
+
+        assert [len(c) for c in chunks] == [2, 2]
+
+    def test_covers_every_row(self):
+        """The caller rebuilds the catalog from the chunks, so none may be dropped."""
+        frame = _frame(["a", "b", "a"])
+
+        labels = [label for chunk in _chunk_by_dataset(frame, "instance_id", 2) for label in chunk]
+
+        assert sorted(labels) == list(frame.index)
+
+    def test_covers_rows_with_a_missing_slug(self):
+        frame = _frame(["a", None, "b"])
+
+        labels = [label for chunk in _chunk_by_dataset(frame, "instance_id", 1) for label in chunk]
+
+        assert sorted(labels) == list(frame.index)

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -177,6 +177,7 @@ filename = "sqlite://climate_ref.db"
             "log_format": DEFAULT_LOG_FORMAT,
             "cmip6_parser": "complete",
             "cmip7_parser": "complete",
+            "n_jobs": 1,
             "diagnostic_providers": [
                 {"provider": "climate_ref_example:provider"},
             ],
@@ -190,6 +191,7 @@ filename = "sqlite://climate_ref.db"
             "log_format": DEFAULT_LOG_FORMAT,
             "cmip6_parser": "complete",
             "cmip7_parser": "complete",
+            "n_jobs": 1,
             "diagnostic_providers": [
                 {
                     "provider": "climate_ref_example:provider",

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -132,6 +132,22 @@ filename = "sqlite://climate_ref.db"
         assert f"invalid type ({expected_msg}) @ $.paths.scratch" in caplog.records[1].message
         assert caplog.records[1].levelname == "ERROR"
 
+    @pytest.mark.parametrize("n_jobs", [0, -2])
+    def test_invalid_n_jobs_rejected(self, n_jobs):
+        """An unusable n_jobs must fail loudly rather than silently parse serially."""
+        with pytest.raises(ValueError, match="n_jobs must be -1"):
+            Config(n_jobs=n_jobs)
+
+    @pytest.mark.parametrize("n_jobs", [-1, 1, 32])
+    def test_valid_n_jobs_accepted(self, n_jobs):
+        assert Config(n_jobs=n_jobs).n_jobs == n_jobs
+
+    def test_invalid_n_jobs_from_environment_rejected(self, monkeypatch):
+        monkeypatch.setenv("REF_N_JOBS", "0")
+
+        with pytest.raises(ValueError, match="n_jobs must be -1"):
+            Config()
+
     def test_save(self, tmp_path):
         config = Config(paths=PathConfig(scratch=Path("scratch")))
 

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -94,6 +94,16 @@ class TestMetricSolver:
         assert SourceDatasetType.ESMValToolReference in solver.data_catalog
         assert isinstance(solver.data_catalog[SourceDatasetType.ESMValToolReference], DataCatalog)
 
+    def test_build_from_db_uses_configured_n_jobs(self, config, db_seeded):
+        """Solve-time finalisation must be parallelisable via the configuration."""
+        config.n_jobs = 4
+
+        solver = ExecutionSolver.build_from_db(config, db_seeded)
+
+        for catalog in solver.data_catalog.values():
+            assert catalog.adapter.n_jobs == 4
+
+
     def test_build_from_db_refreshes_ignore_datasets(self, config, db_seeded, mocker):
         refresh_mock = mocker.patch("climate_ref.solver.refresh_ignore_datasets_file")
 

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -103,7 +103,6 @@ class TestMetricSolver:
         for catalog in solver.data_catalog.values():
             assert catalog.adapter.n_jobs == 4
 
-
     def test_build_from_db_refreshes_ignore_datasets(self, config, db_seeded, mocker):
         refresh_mock = mocker.patch("climate_ref.solver.refresh_ignore_datasets_file")
 


### PR DESCRIPTION
Reworks the finalisation of datasets that were ingested with a `drs` parser. Closes #837.

- Adds an `n_jobs` configuration value that controls how many worker processes parse dataset files. The solver now passes it to every adapter it builds, so solve-time finalisation is no longer permanently serial. `ref datasets ingest --n-jobs` falls back to it. The default stays at `1`, so nothing changes until it is set.
- Finalises in chunks of whole datasets, committing each chunk before parsing the next. Progress is logged as it goes and a cancelled solve keeps the work it has already done. A chunk carries every file of the datasets it covers, so an adapter's per-dataset fixes still see the whole group, and only the unfinalised files are opened.
- Reports the number of unfinalised datasets at the end of `ref datasets ingest`, so the cost the `drs` parser defers to the first solve is visible up front.
- Fixes per-file metadata being collapsed during finalisation. A catalog loaded from the database repeats its dataset id once per file, and the per-row update did not account for that.


## Known limits

A dataset with one corrupt file is still marked finalised once any sibling file parses, so that file is never retried. This is pre-existing behaviour, unchanged here.

Interrupting with a signal delivered only to the parent process (`kill -INT <pid>` rather than Ctrl-C) hangs in `ProcessPoolExecutor.shutdown` waiting on workers that never received it. This is pre-existing in `parse_files` and applies equally to ingest, but raising `n_jobs` above 1 makes solve newly susceptible. Ctrl-C in a terminal signals the whole process group and exits cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable parallel file parsing through `n_jobs`, used during ingestion and solve-time finalisation.
  * Finalisation now processes datasets in committed chunks, preserving completed work if a solve is cancelled.
  * Dataset ingestion reports files and datasets requiring deferred metadata extraction.

* **Bug Fixes**
  * Corrected per-file metadata assignment during finalisation to prevent values being applied to unrelated files.

* **Documentation**
  * Added guidance on configuring parallel parsing, monitoring chunked finalisation, and understanding deferred ingestion work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->