### PR TITLE
refactor(test-cases): extract the shared verb driver

### DIFF
--- a/changelog/856.improvement.md
+++ b/changelog/856.improvement.md
@@ -1,0 +1,6 @@
+Extracted the duplicated per-verb driver loop in the `ref test-cases` CLI
+into a shared `VerbDriver` helper,
+covering selector validation, case enumeration, skip policy and the summary epilogue.
+The promote-or-preserve manifest block shared by `run` and `build`
+was also collapsed into a single helper.
+No CLI surface or manifest format change.

--- a/changelog/856.improvement.md
+++ b/changelog/856.improvement.md
@@ -1,3 +1,3 @@
-Extracted the duplicated per-verb driver loop in the `ref test-cases` CLI
+Extracts the duplicated per-verb driver loop in the `ref test-cases` CLI
 into a shared `VerbDriver` helper,
 covering selector validation, case enumeration, skip policy and the summary epilogue.

--- a/changelog/856.improvement.md
+++ b/changelog/856.improvement.md
@@ -1,6 +1,3 @@
 Extracted the duplicated per-verb driver loop in the `ref test-cases` CLI
 into a shared `VerbDriver` helper,
 covering selector validation, case enumeration, skip policy and the summary epilogue.
-The promote-or-preserve manifest block shared by `run` and `build`
-was also collapsed into a single helper.
-No CLI surface or manifest format change.

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
@@ -252,6 +252,9 @@ class VerbDriver:
         An unlocatable test-data directory or a missing ``manifest.json`` is a hard failure
         when the case was named explicitly, and a warn-and-skip when sweeping.
         A missing catalog is always a hard failure.
+
+        Skips and failures are recorded as the caller iterates,
+        so the loop must run to exhaustion for the summary to see them all.
         """
         from climate_ref_core.testing import TestCasePaths
 

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
@@ -1,21 +1,24 @@
 """
 Helpers shared across several ``ref test-cases`` commands.
 
-``_iter_test_cases`` enumerates ``(diagnostic, test_case)`` pairs from the
-provider registry (used by ``sync`` / ``replay`` / ``mint`` / ``build`` /
-``ci-gate``) and ``_write_test_case_manifest`` authors the committed
-``manifest.json`` (used by ``run`` / ``mint`` / ``build``).
+``VerbDriver`` owns the per-case loop machinery every verb repeats
+(registry construction, selector validation, case enumeration, skip policy,
+tally and summary). ``_iter_test_cases`` enumerates ``(diagnostic, test_case)``
+pairs from the provider registry and ``_write_test_case_manifest`` authors the
+committed ``manifest.json`` (used by ``run`` / ``mint`` / ``build``).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import typer
 from loguru import logger
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from rich.console import Console
 
     from climate_ref.provider_registry import ProviderRegistry
     from climate_ref_core.diagnostics import Diagnostic
@@ -173,3 +176,122 @@ def _iter_test_cases(
                 if test_case and tc.name != test_case:
                     continue
                 yield diag, tc
+
+
+class VerbCase(NamedTuple):
+    """A test case ready for a verb's loop body, with its paths resolved."""
+
+    diag: Diagnostic
+    tc: TestCase
+    paths: TestCasePaths
+    case_id: str
+
+
+class VerbSummary(NamedTuple):
+    """The Rich epilogue wording for a per-case verb."""
+
+    mixed: str
+    """Yellow tally line when any case failed, e.g. ``"Replay: {successes} passed, {failures} failed"``."""
+
+    failed_header: str
+    """Red header above the failed case list, e.g. ``"Failed replays:"``."""
+
+    success: str
+    """Green line when every case succeeded, e.g. ``"All {successes} replay(s) matched ..."``."""
+
+
+class VerbDriver:
+    """
+    Shared per-case driver for the ``ref test-cases`` verbs.
+
+    Owns the loop machinery every verb repeats:
+    provider-registry construction, selector validation, case enumeration,
+    the missing-manifest and missing-catalog skip policy,
+    the success and failure tally, and the Rich summary epilogue.
+    The loop body stays with the verb and reports via :meth:`ok` and :meth:`fail`.
+    """
+
+    def __init__(
+        self,
+        ctx: typer.Context,
+        *,
+        provider: str | None,
+        diagnostic: str | None,
+        test_case: str | None,
+    ) -> None:
+        from climate_ref.provider_registry import ProviderRegistry
+
+        self.console: Console = ctx.obj.console
+        self.provider = provider
+        # When a specific case is named, a missing manifest is a hard failure.
+        self.named = bool(diagnostic or test_case)
+        self.registry = ProviderRegistry.build_from_config(ctx.obj.config, ctx.obj.database)
+        _validate_provider_in_registry(self.registry, provider)
+        _validate_requested_filters(
+            self.registry, provider=provider, diagnostic=diagnostic, test_case=test_case
+        )
+        self.cases = list(
+            _iter_test_cases(self.registry, provider=provider, diagnostic=diagnostic, test_case=test_case)
+        )
+        self.successes = 0
+        self.failures: list[str] = []
+
+    def exit_if_empty(self, message: str | None = None) -> None:
+        """Exit 0 with a warning when the selectors matched no test cases."""
+        if self.cases:
+            return
+        logger.warning(message or f"No test cases found for provider {self.provider!r}")
+        raise typer.Exit(code=0)
+
+    def ready_cases(
+        self, *, require_manifest: bool = False, require_catalog: bool = False
+    ) -> Iterator[VerbCase]:
+        """
+        Yield the matched cases with paths resolved, applying the shared skip policy.
+
+        A case whose test-data directory cannot be located is warned about and skipped.
+        A missing ``manifest.json`` is a hard failure when the case was named explicitly,
+        and a warn-and-skip when sweeping.
+        A missing catalog is always a hard failure.
+        """
+        from climate_ref_core.testing import TestCasePaths
+
+        for diag, tc in self.cases:
+            case_id = f"{diag.provider.slug}/{diag.slug}/{tc.name}"
+            paths = TestCasePaths.from_diagnostic(diag, tc.name)
+            if paths is None:
+                logger.warning(f"Could not determine test case directory for {case_id}")
+                continue
+            if require_manifest and not paths.manifest.exists():
+                message = f"No manifest.json for {case_id}; run `ref test-cases mint` first"
+                if self.named:
+                    self.fail(case_id, message)
+                else:
+                    logger.warning(message)
+                continue
+            if require_catalog and not paths.catalog.exists():
+                self.fail(case_id, f"No catalog file for {case_id}; run `ref test-cases fetch` first")
+                continue
+            yield VerbCase(diag, tc, paths, case_id)
+
+    def ok(self) -> None:
+        """Record a successful case."""
+        self.successes += 1
+
+    def fail(self, case_id: str, message: str | None = None) -> None:
+        """Record a failed case, logging ``message`` as an error when given."""
+        if message:
+            logger.error(message)
+        self.failures.append(case_id)
+
+    def finish(self, summary: VerbSummary) -> None:
+        """Print the verb's summary epilogue and exit non-zero when any case failed."""
+        self.console.print()
+        if self.failures:
+            mixed = summary.mixed.format(successes=self.successes, failures=len(self.failures))
+            self.console.print(f"[yellow]{mixed}[/yellow]")
+            self.console.print(f"[red]{summary.failed_header}[/red]")
+            for case in self.failures:
+                self.console.print(f"  - {case}")
+            raise typer.Exit(code=1)
+        self.console.print(f"[green]{summary.success.format(successes=self.successes)}[/green]")

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
@@ -223,7 +223,7 @@ class VerbDriver:
 
         self.console: Console = ctx.obj.console
         self.provider = provider
-        # When a specific case is named, a missing manifest is a hard failure.
+        # When a specific case is named, an unusable test case is a hard failure.
         self.named = bool(diagnostic or test_case)
         self.registry = ProviderRegistry.build_from_config(ctx.obj.config, ctx.obj.database)
         _validate_provider_in_registry(self.registry, provider)

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
@@ -259,11 +259,11 @@ class VerbDriver:
                 continue
             if require_manifest and not paths.manifest.exists():
                 self._skip_or_fail(
-                    case_id, f"No manifest.json for {case_id}; run `ref test-cases mint` first"
+                    case_id, f"No manifest.json for {case_id}. Run `ref test-cases mint` first"
                 )
                 continue
             if require_catalog and not paths.catalog.exists():
-                self.fail(case_id, f"No catalog file for {case_id}; run `ref test-cases fetch` first")
+                self.fail(case_id, f"No catalog file for {case_id}. Run `ref test-cases fetch` first")
                 continue
             yield VerbCase(diag, tc, paths, case_id)
 

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
@@ -2,10 +2,7 @@
 Helpers shared across several ``ref test-cases`` commands.
 
 ``VerbDriver`` owns the per-case loop machinery every verb repeats
-(registry construction, selector validation, case enumeration, skip policy,
-tally and summary). ``_iter_test_cases`` enumerates ``(diagnostic, test_case)``
-pairs from the provider registry and ``_write_test_case_manifest`` authors the
-committed ``manifest.json`` (used by ``run`` / ``mint`` / ``build``).
+(registry construction, selector validation, case enumeration, skip policy, tally and summary).
 """
 
 from __future__ import annotations
@@ -188,7 +185,7 @@ class VerbCase(NamedTuple):
 
 
 class VerbSummary(NamedTuple):
-    """The Rich epilogue wording for a per-case verb."""
+    """Summary for a per-case verb."""
 
     mixed: str
     """Yellow tally line when any case failed, e.g. ``"Replay: {successes} passed, {failures} failed"``."""
@@ -204,10 +201,6 @@ class VerbDriver:
     """
     Shared per-case driver for the ``ref test-cases`` verbs.
 
-    Owns the loop machinery every verb repeats:
-    provider-registry construction, selector validation, case enumeration,
-    the missing-manifest and missing-catalog skip policy,
-    the success and failure tally, and the Rich summary epilogue.
     The loop body stays with the verb and reports via :meth:`ok` and :meth:`fail`.
     """
 
@@ -296,8 +289,9 @@ class VerbDriver:
             logger.warning(message)
 
     def finish(self, summary: VerbSummary) -> None:
-        """Print the verb's summary epilogue and exit non-zero when any case failed."""
+        """Print the verb's summary and exit non-zero when any case failed."""
         self.console.print()
+
         if self.failures:
             mixed = summary.mixed.format(successes=self.successes, failures=len(self.failures))
             self.console.print(f"[yellow]{mixed}[/yellow]")

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_common.py
@@ -249,9 +249,8 @@ class VerbDriver:
         """
         Yield the matched cases with paths resolved, applying the shared skip policy.
 
-        A case whose test-data directory cannot be located is warned about and skipped.
-        A missing ``manifest.json`` is a hard failure when the case was named explicitly,
-        and a warn-and-skip when sweeping.
+        An unlocatable test-data directory or a missing ``manifest.json`` is a hard failure
+        when the case was named explicitly, and a warn-and-skip when sweeping.
         A missing catalog is always a hard failure.
         """
         from climate_ref_core.testing import TestCasePaths
@@ -260,14 +259,12 @@ class VerbDriver:
             case_id = f"{diag.provider.slug}/{diag.slug}/{tc.name}"
             paths = TestCasePaths.from_diagnostic(diag, tc.name)
             if paths is None:
-                logger.warning(f"Could not determine test case directory for {case_id}")
+                self._skip_or_fail(case_id, f"Could not determine test case directory for {case_id}")
                 continue
             if require_manifest and not paths.manifest.exists():
-                message = f"No manifest.json for {case_id}; run `ref test-cases mint` first"
-                if self.named:
-                    self.fail(case_id, message)
-                else:
-                    logger.warning(message)
+                self._skip_or_fail(
+                    case_id, f"No manifest.json for {case_id}; run `ref test-cases mint` first"
+                )
                 continue
             if require_catalog and not paths.catalog.exists():
                 self.fail(case_id, f"No catalog file for {case_id}; run `ref test-cases fetch` first")
@@ -278,11 +275,22 @@ class VerbDriver:
         """Record a successful case."""
         self.successes += 1
 
-    def fail(self, case_id: str, message: str | None = None) -> None:
-        """Record a failed case, logging ``message`` as an error when given."""
+    def fail(self, label: str, message: str | None = None) -> None:
+        """
+        Record a failure, logging ``message`` as an error when given.
+
+        ``label`` is the entry listed under the summary's failed header, usually the case id.
+        """
         if message:
             logger.error(message)
-        self.failures.append(case_id)
+        self.failures.append(label)
+
+    def _skip_or_fail(self, case_id: str, message: str) -> None:
+        """Fail a case that was named explicitly, and warn-and-skip it when sweeping."""
+        if self.named:
+            self.fail(case_id, message)
+        else:
+            logger.warning(message)
 
     def finish(self, summary: VerbSummary) -> None:
         """Print the verb's summary epilogue and exit non-zero when any case failed."""

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
@@ -294,9 +294,12 @@ def promote_and_author_manifest(  # noqa: PLR0913
     from climate_ref.cli.test_cases._common import _write_test_case_manifest
     from climate_ref_core.regression.manifest import Manifest
 
+    # Load before promoting: an unreadable manifest must fail before the tracked
+    # baseline is overwritten, or the promoted bundle is left recorded by stale digests.
+    previous = Manifest.load(paths.manifest) if paths.manifest.exists() else None
+
     promote_to_baseline(slot, paths)
     native = snapshot_native(slot, source=source, placeholders=placeholders)
-    previous = Manifest.load(paths.manifest) if paths.manifest.exists() else None
 
     if previous is not None:
         _write_test_case_manifest(

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
@@ -290,8 +290,6 @@ def promote_and_author_manifest(  # noqa: PLR0913
     and native block, or seeds an empty set for a never-minted case.
     When the freshly snapshotted native differs from the minted one,
     ``stale_message`` is logged as a warning so the author knows to re-mint.
-    Shared by ``run`` and ``build``, which only promote when ``--force-regen``
-    is given or no baseline exists yet.
     """
     from climate_ref.cli.test_cases._common import _write_test_case_manifest
     from climate_ref_core.regression.manifest import Manifest

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
@@ -273,6 +273,54 @@ def promote_to_baseline(slot: Path, paths: TestCasePaths) -> None:
             shutil.copy(source, paths.regression / filename)
 
 
+def promote_and_author_manifest(  # noqa: PLR0913
+    *,
+    paths: TestCasePaths,
+    diag: Diagnostic,
+    slot: Path,
+    source: SourceOutputs,
+    placeholders: PlaceholderMap,
+    committed: dict[str, str],
+    stale_message: str,
+) -> None:
+    """
+    Promote a slot's rebuilt bundle to the tracked baseline and author the manifest.
+
+    The native block is mint-owned, so this preserves the previous manifest's version
+    and native block, or seeds an empty set for a never-minted case.
+    When the freshly snapshotted native differs from the minted one,
+    ``stale_message`` is logged as a warning so the author knows to re-mint.
+    Shared by ``run`` and ``build``, which only promote when ``--force-regen``
+    is given or no baseline exists yet.
+    """
+    from climate_ref.cli.test_cases._common import _write_test_case_manifest
+    from climate_ref_core.regression.manifest import Manifest
+
+    promote_to_baseline(slot, paths)
+    native = snapshot_native(slot, source=source, placeholders=placeholders)
+    previous = Manifest.load(paths.manifest) if paths.manifest.exists() else None
+
+    if previous is not None:
+        _write_test_case_manifest(
+            paths,
+            test_case_version=previous.test_case_version,
+            diagnostic_version=previous.diagnostic_version,
+            committed=committed,
+            native=previous.native,
+            schema=previous.schema,
+        )
+        if native_is_stale(native, previous.native):
+            logger.warning(stale_message)
+    else:
+        _write_test_case_manifest(
+            paths,
+            test_case_version=1,
+            diagnostic_version=diag.version,
+            committed=committed,
+            native={},
+        )
+
+
 def stage_upload(
     *,
     slot: Path,

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
@@ -286,16 +286,16 @@ def promote_and_author_manifest(  # noqa: PLR0913
     """
     Promote a slot's rebuilt bundle to the tracked baseline and author the manifest.
 
-    The native block is mint-owned, so this preserves the previous manifest's version
-    and native block, or seeds an empty set for a never-minted case.
+    The native block is mint-owned, so this preserves the previous manifest's version and native block,
+    or seeds an empty set for a never-minted case.
     When the freshly snapshotted native differs from the minted one,
     ``stale_message`` is logged as a warning so the author knows to re-mint.
     """
     from climate_ref.cli.test_cases._common import _write_test_case_manifest
     from climate_ref_core.regression.manifest import Manifest
 
-    # Load before promoting: an unreadable manifest must fail before the tracked
-    # baseline is overwritten, or the promoted bundle is left recorded by stale digests.
+    # Load before promoting: an unreadable manifest must fail before the tracked baseline is overwritten,
+    # or the promoted bundle is left recorded by stale digests.
     previous = Manifest.load(paths.manifest) if paths.manifest.exists() else None
 
     promote_to_baseline(slot, paths)

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/baselines.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/baselines.py
@@ -102,7 +102,7 @@ def replay_test_case(
         if not manifest.native:
             driver.fail(
                 case_id,
-                f"{case_id}: manifest has no native baselines — not yet minted. "
+                f"{case_id}: manifest has no native baselines, not yet minted. "
                 "Run `ref test-cases mint` first.",
             )
             continue
@@ -235,12 +235,12 @@ def mint_native(  # noqa: PLR0912, PLR0913, PLR0915
         raise typer.Exit(code=1) from exc
 
     if dry_run:
-        # The store preflight has already passed at this point; report scope and stop before
-        # running any diagnostics or uploading anything.
-        console.print(f"[cyan]Dry run — would mint {len(driver.cases)} test case(s):[/cyan]")
+        # The store preflight has already passed at this point.
+        # Report scope and stop before running any diagnostics or uploading anything.
+        console.print(f"[cyan]Dry run: would mint {len(driver.cases)} test case(s):[/cyan]")
         for diag, tc in driver.cases:
             console.print(f"  - {provider}/{diag.slug}/{tc.name}")
-        console.print("[cyan]Store preflight passed; nothing was run or uploaded.[/cyan]")
+        console.print("[cyan]Store preflight passed. Nothing was run or uploaded.[/cyan]")
         return
 
     for diag, tc, paths, case_id in driver.ready_cases(require_catalog=True):
@@ -382,7 +382,7 @@ def build_test_case(  # noqa: PLR0913
     for diag, tc, paths, case_id in driver.ready_cases(require_catalog=True):
         slot = paths.output_slot(label)
         if not slot.exists() or not slot_native_relpaths(slot):
-            driver.fail(case_id, f"{case_id}: no native in output slot {label!r}; run/replay/mint it first")
+            driver.fail(case_id, f"{case_id}: no native in output slot {label!r}. Run/replay/mint it first")
             continue
 
         placeholders = baseline_placeholders(paths, config)
@@ -405,8 +405,8 @@ def build_test_case(  # noqa: PLR0913
                 placeholders=placeholders,
                 committed=committed,
                 stale_message=(
-                    f"{case_id}: committed bundle rebuilt but the native baseline differs; "
-                    "re-mint with `ref test-cases mint`"
+                    f"{case_id}: committed bundle rebuilt but the native baseline differs. "
+                    "Re-mint with `ref test-cases mint`"
                 ),
             )
             logger.info(f"Promoted rebuilt bundle to regression baseline: {paths.regression}")

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/baselines.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/baselines.py
@@ -18,16 +18,15 @@ from loguru import logger
 
 from climate_ref.cli.test_cases._app import app
 from climate_ref.cli.test_cases._common import (
-    _iter_test_cases,
-    _validate_provider_in_registry,
-    _validate_requested_filters,
+    VerbDriver,
+    VerbSummary,
     _write_test_case_manifest,
 )
 from climate_ref.cli.test_cases._stages import (
     StageError,
     baseline_placeholders,
-    native_is_stale,
     prepare_slot,
+    promote_and_author_manifest,
     promote_to_baseline,
     slot_native_relpaths,
     snapshot_native,
@@ -45,7 +44,7 @@ if TYPE_CHECKING:
 
 
 @app.command(name="replay")
-def replay_test_case(  # noqa: PLR0912, PLR0915
+def replay_test_case(
     ctx: typer.Context,
     provider: Annotated[
         str,
@@ -78,50 +77,16 @@ def replay_test_case(  # noqa: PLR0912, PLR0915
         ref test-cases replay --provider example
         ref test-cases replay --provider example --diagnostic global-mean-timeseries
     """
-    from climate_ref.provider_registry import ProviderRegistry
     from climate_ref_core.regression import Manifest, verify_committed_integrity
     from climate_ref_core.regression.store import build_native_store
-    from climate_ref_core.testing import TestCasePaths
 
     config: Config = ctx.obj.config
-    db = ctx.obj.database
-    console: Console = ctx.obj.console
 
-    registry = ProviderRegistry.build_from_config(config, db)
-    _validate_provider_in_registry(registry, provider)
-    _validate_requested_filters(registry, provider=provider, diagnostic=diagnostic, test_case=test_case)
+    driver = VerbDriver(ctx, provider=provider, diagnostic=diagnostic, test_case=test_case)
     store = build_native_store(config.native_store, writable=False)
+    driver.exit_if_empty()
 
-    cases = list(_iter_test_cases(registry, provider=provider, diagnostic=diagnostic, test_case=test_case))
-    if not cases:
-        logger.warning(f"No test cases found for provider {provider!r}")
-        raise typer.Exit(code=0)
-
-    # When a specific case is named, a missing manifest/catalog is a hard failure.
-    named = bool(diagnostic or test_case)
-
-    successes = 0
-    failures: list[str] = []
-
-    for diag, tc in cases:
-        paths = TestCasePaths.from_diagnostic(diag, tc.name)
-        case_id = f"{provider}/{diag.slug}/{tc.name}"
-        if paths is None:
-            logger.warning(f"Could not determine test case directory for {case_id}")
-            continue
-        if not paths.manifest.exists():
-            message = f"No manifest.json for {case_id}; run `ref test-cases mint` first"
-            if named:
-                logger.error(message)
-                failures.append(case_id)
-            else:
-                logger.warning(message)
-            continue
-        if not paths.catalog.exists():
-            logger.error(f"No catalog file for {case_id}; run `ref test-cases fetch` first")
-            failures.append(case_id)
-            continue
-
+    for diag, tc, paths, case_id in driver.ready_cases(require_manifest=True, require_catalog=True):
         manifest = Manifest.load(paths.manifest)
 
         # The byte-exact digest check is advisory that the committed baseline is not bitwise identical.
@@ -135,11 +100,11 @@ def replay_test_case(  # noqa: PLR0912, PLR0915
                 logger.warning(f"  - {mismatch}")
 
         if not manifest.native:
-            logger.error(
+            driver.fail(
+                case_id,
                 f"{case_id}: manifest has no native baselines — not yet minted. "
-                "Run `ref test-cases mint` first."
+                "Run `ref test-cases mint` first.",
             )
-            failures.append(case_id)
             continue
 
         slot = prepare_slot(paths, label)
@@ -155,8 +120,7 @@ def replay_test_case(  # noqa: PLR0912, PLR0915
                 placeholders=placeholders,
             )
         except Exception as exc:
-            logger.error(f"{case_id}: failed to materialise/rebuild native: {exc}")
-            failures.append(case_id)
+            driver.fail(case_id, f"{case_id}: failed to materialise/rebuild native: {exc}")
             continue
 
         stage_build(slot=slot, source=source, placeholders=placeholders)
@@ -164,11 +128,10 @@ def replay_test_case(  # noqa: PLR0912, PLR0915
             slot=slot, paths=paths, slug=diag.slug, expected=manifest.committed
         )
         if cmp_failures:
-            logger.error(f"{case_id}: replay drift detected:\n" + "\n".join(cmp_failures))
-            failures.append(case_id)
+            driver.fail(case_id, f"{case_id}: replay drift detected:\n" + "\n".join(cmp_failures))
             continue
 
-        successes += 1
+        driver.ok()
         if mismatches:
             # The byte-level warning above was reconciled by the tolerant comparison.
             logger.info(
@@ -183,14 +146,13 @@ def replay_test_case(  # noqa: PLR0912, PLR0915
                 f"{len(compared)} bundle file(s) compared)"
             )
 
-    console.print()
-    if failures:
-        console.print(f"[yellow]Replay: {successes} passed, {len(failures)} failed[/yellow]")
-        console.print("[red]Failed replays:[/red]")
-        for case in failures:
-            console.print(f"  - {case}")
-        raise typer.Exit(code=1)
-    console.print(f"[green]All {successes} replay(s) matched the committed bundle[/green]")
+    driver.finish(
+        VerbSummary(
+            mixed="Replay: {successes} passed, {failures} failed",
+            failed_header="Failed replays:",
+            success="All {successes} replay(s) matched the committed bundle",
+        )
+    )
 
 
 @app.command(name="mint")
@@ -242,22 +204,15 @@ def mint_native(  # noqa: PLR0912, PLR0913, PLR0915
         ref test-cases mint --provider example --bump-version
         ref test-cases mint --provider example --dry-run
     """
-    from climate_ref.provider_registry import ProviderRegistry
     from climate_ref_core.regression.manifest import Manifest
     from climate_ref_core.regression.store import NativeStoreUnavailableError, build_native_store
-    from climate_ref_core.testing import TestCasePaths, load_datasets_from_yaml
+    from climate_ref_core.testing import load_datasets_from_yaml
 
     config: Config = ctx.obj.config
-    db = ctx.obj.database
     console: Console = ctx.obj.console
 
-    registry = ProviderRegistry.build_from_config(config, db)
-    _validate_provider_in_registry(registry, provider)
-    _validate_requested_filters(registry, provider=provider, diagnostic=diagnostic, test_case=test_case)
-    cases = list(_iter_test_cases(registry, provider=provider, diagnostic=diagnostic, test_case=test_case))
-    if not cases:
-        logger.warning(f"No test cases found for provider {provider!r}")
-        raise typer.Exit(code=0)
+    driver = VerbDriver(ctx, provider=provider, diagnostic=diagnostic, test_case=test_case)
+    driver.exit_if_empty()
 
     try:
         store = build_native_store(config.native_store, writable=True)
@@ -282,33 +237,19 @@ def mint_native(  # noqa: PLR0912, PLR0913, PLR0915
     if dry_run:
         # The store preflight has already passed at this point; report scope and stop before
         # running any diagnostics or uploading anything.
-        console.print(f"[cyan]Dry run — would mint {len(cases)} test case(s):[/cyan]")
-        for diag, tc in cases:
+        console.print(f"[cyan]Dry run — would mint {len(driver.cases)} test case(s):[/cyan]")
+        for diag, tc in driver.cases:
             console.print(f"  - {provider}/{diag.slug}/{tc.name}")
         console.print("[cyan]Store preflight passed; nothing was run or uploaded.[/cyan]")
         return
 
-    minted = 0
-    failures: list[str] = []
-
-    for diag, tc in cases:
-        case_id = f"{provider}/{diag.slug}/{tc.name}"
-        paths = TestCasePaths.from_diagnostic(diag, tc.name)
-        if paths is None:
-            logger.warning(f"Could not determine test case directory for {case_id}")
-            continue
-        if not paths.catalog.exists():
-            logger.error(f"No catalog file for {case_id}; run `ref test-cases fetch` first")
-            failures.append(case_id)
-            continue
-
+    for diag, tc, paths, case_id in driver.ready_cases(require_catalog=True):
         paths.create()
         previous = Manifest.load(paths.manifest) if paths.manifest.exists() else None
         # Validate the --from-replay precondition before wiping the slot, so a never-minted
         # case does not destroy a pre-existing output/<label>/ on its way to failing.
         if from_replay and (previous is None or not previous.native):
-            logger.error(f"{case_id}: --from-replay needs an existing minted manifest")
-            failures.append(case_id)
+            driver.fail(case_id, f"{case_id}: --from-replay needs an existing minted manifest")
             continue
 
         slot = prepare_slot(paths, label)
@@ -340,12 +281,10 @@ def mint_native(  # noqa: PLR0912, PLR0913, PLR0915
                     clean=True,
                 )
         except StageError as exc:
-            logger.error(f"{case_id}: {exc}")
-            failures.append(case_id)
+            driver.fail(case_id, f"{case_id}: {exc}")
             continue
         except Exception as exc:
-            logger.error(f"{case_id}: source stage failed during mint: {exc}")
-            failures.append(case_id)
+            driver.fail(case_id, f"{case_id}: source stage failed during mint: {exc}")
             continue
 
         committed = stage_build(slot=slot, source=source, placeholders=placeholders)
@@ -364,7 +303,7 @@ def mint_native(  # noqa: PLR0912, PLR0913, PLR0915
         if errors:
             for error in errors:
                 logger.error(f"{case_id}: {error}")
-            failures.append(case_id)
+            driver.fail(case_id)
             continue
 
         # Promote the rebuilt bundle and author the committed manifest: the native block
@@ -382,25 +321,24 @@ def mint_native(  # noqa: PLR0912, PLR0913, PLR0915
             native=native,
         )
 
-        minted += 1
+        driver.ok()
         logger.info(
             f"Minted native baseline: {case_id} "
             f"({len(native)} native file(s), {len(committed)} committed file(s), "
             f"test_case_version={version})"
         )
 
-    console.print()
-    if failures:
-        console.print(f"[yellow]Mint: {minted} minted, {len(failures)} failed[/yellow]")
-        console.print("[red]Failed mints:[/red]")
-        for case in failures:
-            console.print(f"  - {case}")
-        raise typer.Exit(code=1)
-    console.print(f"[green]Minted {minted} native baseline(s)[/green]")
+    driver.finish(
+        VerbSummary(
+            mixed="Mint: {successes} minted, {failures} failed",
+            failed_header="Failed mints:",
+            success="Minted {successes} native baseline(s)",
+        )
+    )
 
 
 @app.command(name="build")
-def build_test_case(  # noqa: PLR0912, PLR0913, PLR0915
+def build_test_case(  # noqa: PLR0913
     ctx: typer.Context,
     provider: Annotated[
         str,
@@ -436,39 +374,15 @@ def build_test_case(  # noqa: PLR0912, PLR0913, PLR0915
         ref test-cases build --provider example
         ref test-cases build --provider example --label before --force-regen
     """
-    from climate_ref.provider_registry import ProviderRegistry
-    from climate_ref_core.regression.manifest import Manifest
-    from climate_ref_core.testing import TestCasePaths
-
     config: Config = ctx.obj.config
-    db = ctx.obj.database
-    console: Console = ctx.obj.console
 
-    registry = ProviderRegistry.build_from_config(config, db)
-    _validate_provider_in_registry(registry, provider)
-    _validate_requested_filters(registry, provider=provider, diagnostic=diagnostic, test_case=test_case)
-    cases = list(_iter_test_cases(registry, provider=provider, diagnostic=diagnostic, test_case=test_case))
-    if not cases:
-        logger.warning(f"No test cases found for provider {provider!r}")
-        raise typer.Exit(code=0)
+    driver = VerbDriver(ctx, provider=provider, diagnostic=diagnostic, test_case=test_case)
+    driver.exit_if_empty()
 
-    built = 0
-    failures: list[str] = []
-
-    for diag, tc in cases:
-        case_id = f"{provider}/{diag.slug}/{tc.name}"
-        paths = TestCasePaths.from_diagnostic(diag, tc.name)
-        if paths is None:
-            logger.warning(f"Could not determine test case directory for {case_id}")
-            continue
+    for diag, tc, paths, case_id in driver.ready_cases(require_catalog=True):
         slot = paths.output_slot(label)
         if not slot.exists() or not slot_native_relpaths(slot):
-            logger.error(f"{case_id}: no native in output slot {label!r}; run/replay/mint it first")
-            failures.append(case_id)
-            continue
-        if not paths.catalog.exists():
-            logger.error(f"No catalog file for {case_id}; run `ref test-cases fetch` first")
-            failures.append(case_id)
+            driver.fail(case_id, f"{case_id}: no native in output slot {label!r}; run/replay/mint it first")
             continue
 
         placeholders = baseline_placeholders(paths, config)
@@ -477,38 +391,24 @@ def build_test_case(  # noqa: PLR0912, PLR0913, PLR0915
                 diag=diag, tc=tc, paths=paths, slot=slot, placeholders=placeholders
             )
         except Exception as exc:
-            logger.error(f"{case_id}: failed to rebuild bundle from slot: {exc}")
-            failures.append(case_id)
+            driver.fail(case_id, f"{case_id}: failed to rebuild bundle from slot: {exc}")
             continue
 
         committed = stage_build(slot=slot, source=source, placeholders=placeholders)
-        previous = Manifest.load(paths.manifest) if paths.manifest.exists() else None
 
         if force_regen or not paths.regression.exists():
-            promote_to_baseline(slot, paths)
-            native = snapshot_native(slot, source=source, placeholders=placeholders)
-            if previous is not None:
-                _write_test_case_manifest(
-                    paths,
-                    test_case_version=previous.test_case_version,
-                    diagnostic_version=previous.diagnostic_version,
-                    committed=committed,
-                    native=previous.native,
-                    schema=previous.schema,
-                )
-                if native_is_stale(native, previous.native):
-                    logger.warning(
-                        f"{case_id}: committed bundle rebuilt but the native baseline differs; "
-                        "re-mint with `ref test-cases mint`"
-                    )
-            else:
-                _write_test_case_manifest(
-                    paths,
-                    test_case_version=1,
-                    diagnostic_version=diag.version,
-                    committed=committed,
-                    native={},
-                )
+            promote_and_author_manifest(
+                paths=paths,
+                diag=diag,
+                slot=slot,
+                source=source,
+                placeholders=placeholders,
+                committed=committed,
+                stale_message=(
+                    f"{case_id}: committed bundle rebuilt but the native baseline differs; "
+                    "re-mint with `ref test-cases mint`"
+                ),
+            )
             logger.info(f"Promoted rebuilt bundle to regression baseline: {paths.regression}")
         else:
             logger.info(
@@ -516,13 +416,12 @@ def build_test_case(  # noqa: PLR0912, PLR0913, PLR0915
                 "(committed baseline unchanged; use --force-regen to promote it)"
             )
 
-        built += 1
+        driver.ok()
 
-    console.print()
-    if failures:
-        console.print(f"[yellow]Build: {built} built, {len(failures)} failed[/yellow]")
-        console.print("[red]Failed builds:[/red]")
-        for case in failures:
-            console.print(f"  - {case}")
-        raise typer.Exit(code=1)
-    console.print(f"[green]Built {built} committed bundle(s) from output slots[/green]")
+    driver.finish(
+        VerbSummary(
+            mixed="Build: {successes} built, {failures} failed",
+            failed_header="Failed builds:",
+            success="Built {successes} committed bundle(s) from output slots",
+        )
+    )

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/ci_gate.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/ci_gate.py
@@ -17,12 +17,7 @@ from rich.table import Table
 
 from climate_ref.cli._git_utils import get_repo_for_path
 from climate_ref.cli.test_cases._app import app
-from climate_ref.cli.test_cases._common import (
-    _iter_test_cases,
-    _validate_provider_in_registry,
-    _validate_requested_filters,
-)
-from climate_ref.config import Config
+from climate_ref.cli.test_cases._common import VerbDriver
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -158,13 +153,10 @@ def ci_gate(  # noqa: PLR0912, PLR0913, PLR0915
 
     from git import GitCommandError
 
-    from climate_ref.provider_registry import ProviderRegistry
     from climate_ref_core.regression.gate import Action, decide_coupling, paths_under
     from climate_ref_core.regression.manifest import Manifest, compute_committed_digests
     from climate_ref_core.testing import TestCasePaths, get_catalog_hash
 
-    config: Config = ctx.obj.config
-    db = ctx.obj.database
     console: Console = ctx.obj.console
 
     repo = get_repo_for_path(Path.cwd())
@@ -197,10 +189,8 @@ def ci_gate(  # noqa: PLR0912, PLR0913, PLR0915
     repo_root_resolved = repo_root.resolve()
     source_root_cache: dict[str, str | None] = {}
 
-    registry = ProviderRegistry.build_from_config(config, db)
-    _validate_provider_in_registry(registry, provider)
-    _validate_requested_filters(registry, provider=provider, diagnostic=diagnostic, test_case=test_case)
-    cases = list(_iter_test_cases(registry, provider=provider, diagnostic=diagnostic, test_case=test_case))
+    driver = VerbDriver(ctx, provider=provider, diagnostic=diagnostic, test_case=test_case)
+    cases = driver.cases
 
     decisions: list[dict[str, str]] = []
     has_failure = False

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/run.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/run.py
@@ -19,18 +19,12 @@ from climate_ref.cli._git_utils import collect_regression_file_info, get_repo_fo
 from climate_ref.cli._utils import format_size
 from climate_ref.cli.test_cases._app import app
 from climate_ref.cli.test_cases._catalog import _fetch_and_build_catalog
-from climate_ref.cli.test_cases._common import (
-    _validate_provider_in_registry,
-    _validate_requested_filters,
-    _write_test_case_manifest,
-)
+from climate_ref.cli.test_cases._common import VerbDriver, VerbSummary
 from climate_ref.cli.test_cases._stages import (
     StageError,
     baseline_placeholders,
-    native_is_stale,
     prepare_slot,
-    promote_to_baseline,
-    snapshot_native,
+    promote_and_author_manifest,
     stage_build,
     stage_execute,
 )
@@ -137,7 +131,6 @@ def _run_single_test_case(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915
 
     Returns True if successful, False otherwise.
     """
-    from climate_ref_core.regression.manifest import Manifest
     from climate_ref_core.testing import TestCasePaths, load_datasets_from_yaml
 
     provider_slug = diag.provider.slug
@@ -211,33 +204,20 @@ def _run_single_test_case(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915
     # one (or seeds an empty set) and never authors native here.
     placeholders = baseline_placeholders(paths, config)
     committed = stage_build(slot=slot, source=source, placeholders=placeholders)
-    previous = Manifest.load(paths.manifest) if paths.manifest.exists() else None
 
     if force_regen or not paths.regression.exists():
-        promote_to_baseline(slot, paths)
-        native = snapshot_native(slot, source=source, placeholders=placeholders)
-        if previous is not None:
-            _write_test_case_manifest(
-                paths,
-                test_case_version=previous.test_case_version,
-                diagnostic_version=previous.diagnostic_version,
-                committed=committed,
-                native=previous.native,
-                schema=previous.schema,
-            )
-            if native_is_stale(native, previous.native):
-                logger.warning(
-                    f"{case_id}: committed bundle regenerated but the native baseline differs; "
-                    "re-mint with `ref test-cases mint` (or `mint --from-replay`)"
-                )
-        else:
-            _write_test_case_manifest(
-                paths,
-                test_case_version=1,
-                diagnostic_version=diag.version,
-                committed=committed,
-                native={},
-            )
+        promote_and_author_manifest(
+            paths=paths,
+            diag=diag,
+            slot=slot,
+            source=source,
+            placeholders=placeholders,
+            committed=committed,
+            stale_message=(
+                f"{case_id}: committed bundle regenerated but the native baseline differs; "
+                "re-mint with `ref test-cases mint` (or `mint --from-replay`)"
+            ),
+        )
         logger.info(f"Updated regression baseline: {paths.regression}")
         _print_regression_summary(console, paths.regression, size_threshold)
     else:
@@ -322,49 +302,31 @@ def run_test_case(  # noqa: PLR0912, PLR0913, PLR0915
         ref test-cases run --provider pmp --only-missing # Skip test cases with regression data
         ref test-cases run --provider pmp --if-changed   # Only run if catalog changed
     """
-    from climate_ref.provider_registry import ProviderRegistry
     from climate_ref_core.testing import (
         TestCasePaths,
         catalog_changed_since_regression,
     )
 
     config: Config = ctx.obj.config
-    db = ctx.obj.database
     console: Console = ctx.obj.console
 
-    # Build provider registry
-    registry = ProviderRegistry.build_from_config(config, db)
-
-    # Find the provider
-    _validate_provider_in_registry(registry, provider)
-    _validate_requested_filters(registry, provider=provider, diagnostic=diagnostic, test_case=test_case)
-    provider_instance = next(p for p in registry.providers if p.slug == provider)
+    driver = VerbDriver(ctx, provider=provider, diagnostic=diagnostic, test_case=test_case)
 
     # Collect test cases to run
     test_cases_to_run: list[tuple[Diagnostic, TestCase]] = []
     skipped_cases: list[tuple[Diagnostic, TestCase]] = []
 
-    for diag in provider_instance.diagnostics():
-        if diagnostic and diag.slug != diagnostic:
+    for diag, tc in driver.cases:
+        paths = TestCasePaths.from_diagnostic(diag, tc.name)
+        # Skip if regression exists when using --only-missing
+        if only_missing and paths and paths.regression.exists():
+            skipped_cases.append((diag, tc))
             continue
-        if diag.test_data_spec is None:
+        # Skip if catalog hasn't changed when using --if-changed
+        if if_changed and paths and not catalog_changed_since_regression(paths):
+            skipped_cases.append((diag, tc))
             continue
-
-        for tc in diag.test_data_spec.test_cases:
-            if test_case and tc.name != test_case:
-                continue
-            # Skip if regression exists when using --only-missing
-            paths = TestCasePaths.from_diagnostic(diag, tc.name)
-            if only_missing:
-                if paths and paths.regression.exists():
-                    skipped_cases.append((diag, tc))
-                    continue
-            # Skip if catalog hasn't changed when using --if-changed
-            if if_changed:
-                if paths and not catalog_changed_since_regression(paths):
-                    skipped_cases.append((diag, tc))
-                    continue
-            test_cases_to_run.append((diag, tc))
+        test_cases_to_run.append((diag, tc))
 
     if not test_cases_to_run:
         if only_missing and skipped_cases:
@@ -408,11 +370,6 @@ def run_test_case(  # noqa: PLR0912, PLR0913, PLR0915
         console.print(table)
         return
 
-    # Run each test case
-    successes = 0
-    failures = 0
-    failed_cases: list[str] = []
-
     if output_directory is not None:
         logger.info(
             f"Using {output_directory} as the execution scratch directory; rebuilt native/bundle files "
@@ -434,18 +391,14 @@ def run_test_case(  # noqa: PLR0912, PLR0913, PLR0915
             label=label,
         )
         if success:
-            successes += 1
+            driver.ok()
         else:
-            failures += 1
-            failed_cases.append(case_id)
+            driver.fail(case_id)
 
-    # Print summary
-    console.print()
-    if failures == 0:
-        console.print(f"[green]All {successes} test case(s) passed[/green]")
-    else:
-        console.print(f"[yellow]Results: {successes} passed, {failures} failed[/yellow]")
-        console.print("[red]Failed test cases:[/red]")
-        for case in failed_cases:
-            console.print(f"  - {case}")
-        raise typer.Exit(code=1)
+    driver.finish(
+        VerbSummary(
+            mixed="Results: {successes} passed, {failures} failed",
+            failed_header="Failed test cases:",
+            success="All {successes} test case(s) passed",
+        )
+    )

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/run.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/run.py
@@ -214,8 +214,8 @@ def _run_single_test_case(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915
             placeholders=placeholders,
             committed=committed,
             stale_message=(
-                f"{case_id}: committed bundle regenerated but the native baseline differs; "
-                "re-mint with `ref test-cases mint` (or `mint --from-replay`)"
+                f"{case_id}: committed bundle regenerated but the native baseline differs. "
+                "Re-mint with `ref test-cases mint` (or `mint --from-replay`)"
             ),
         )
         logger.info(f"Updated regression baseline: {paths.regression}")

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/store.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/store.py
@@ -74,7 +74,10 @@ def sync_native(
                 try:
                     store.fetch(entry.sha256, Path(tmp) / "blob")
                 except Exception as exc:
-                    driver.fail(f"{case_id}: cannot serve native blob {entry.sha256} ({relpath}): {exc}")
+                    driver.fail(
+                        f"{case_id}: {relpath}",
+                        f"{case_id}: cannot serve native blob {entry.sha256} ({relpath}): {exc}",
+                    )
                     continue
             fetched += 1
 

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/store.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/store.py
@@ -11,14 +11,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import typer
-from loguru import logger
 
 from climate_ref.cli.test_cases._app import app
-from climate_ref.cli.test_cases._common import (
-    _iter_test_cases,
-    _validate_provider_in_registry,
-    _validate_requested_filters,
-)
+from climate_ref.cli.test_cases._common import VerbDriver
 from climate_ref.config import Config
 
 if TYPE_CHECKING:
@@ -56,40 +51,20 @@ def sync_native(
     """
     import tempfile
 
-    from climate_ref.provider_registry import ProviderRegistry
     from climate_ref_core.regression.manifest import Manifest
     from climate_ref_core.regression.store import build_native_store
-    from climate_ref_core.testing import TestCasePaths
 
     config: Config = ctx.obj.config
-    db = ctx.obj.database
     console: Console = ctx.obj.console
 
-    registry = ProviderRegistry.build_from_config(config, db)
-    _validate_provider_in_registry(registry, provider)
-    _validate_requested_filters(registry, provider=provider, diagnostic=diagnostic, test_case=test_case)
+    driver = VerbDriver(ctx, provider=provider, diagnostic=diagnostic, test_case=test_case)
     store = build_native_store(config.native_store, writable=False)
-
-    # When a specific case is named, a missing manifest is a hard failure.
-    named = bool(diagnostic or test_case)
-    cases = list(_iter_test_cases(registry, provider=provider, diagnostic=diagnostic, test_case=test_case))
-
-    if not cases:
-        logger.warning("No test cases found for the selected filters")
-        raise typer.Exit(code=0)
+    driver.exit_if_empty("No test cases found for the selected filters")
 
     fetched = 0
     skipped = 0
-    failures: list[str] = []
 
-    for diag, tc in cases:
-        case_id = f"{diag.provider.slug}/{diag.slug}/{tc.name}"
-        paths = TestCasePaths.from_diagnostic(diag, tc.name)
-        if paths is None or not paths.manifest.exists():
-            if named:
-                logger.error(f"No manifest.json for {case_id}; run `ref test-cases mint` first")
-                failures.append(case_id)
-            continue
+    for _diag, _tc, paths, case_id in driver.ready_cases(require_manifest=True):
         manifest = Manifest.load(paths.manifest)
         for relpath, entry in manifest.native.items():
             if store.has(entry.sha256):
@@ -99,13 +74,13 @@ def sync_native(
                 try:
                     store.fetch(entry.sha256, Path(tmp) / "blob")
                 except Exception as exc:
-                    failures.append(f"{case_id}: cannot serve native blob {entry.sha256} ({relpath}): {exc}")
+                    driver.fail(f"{case_id}: cannot serve native blob {entry.sha256} ({relpath}): {exc}")
                     continue
             fetched += 1
 
     console.print(f"[green]Synced native blobs:[/green] {fetched} fetched, {skipped} already cached")
-    if failures:
+    if driver.failures:
         console.print("[red]Failed to fetch referenced native blobs:[/red]")
-        for failure in failures:
+        for failure in driver.failures:
             console.print(f"  - {failure}")
         raise typer.Exit(code=1)

--- a/packages/climate-ref/tests/unit/cli/test_test_cases.py
+++ b/packages/climate-ref/tests/unit/cli/test_test_cases.py
@@ -1620,6 +1620,92 @@ class TestSyncCommand:
         assert "Test case 'missing' was not found" in result.stderr
 
 
+class TestVerbDriverSkipPolicy:
+    """The shared driver's skip policy: hard fail when a case is named, warn and skip when sweeping."""
+
+    @staticmethod
+    def _patch_registry(mocker, registry):
+        mocker.patch(
+            "climate_ref.provider_registry.ProviderRegistry.build_from_config",
+            return_value=registry,
+        )
+
+    def _setup_sync(self, mocker, tmp_path, *, paths):
+        """Wire `sync` against a given TestCasePaths (or None) and an empty local store."""
+        from climate_ref_core.regression.store import LocalFilesystemStore
+
+        registry, _diag, _tc = _make_case_mocks()
+        self._patch_registry(mocker, registry)
+        mocker.patch("climate_ref_core.testing.TestCasePaths.from_diagnostic", return_value=paths)
+        mocker.patch(
+            "climate_ref_core.regression.store.build_native_store",
+            return_value=LocalFilesystemStore(root=tmp_path / "store"),
+        )
+        return registry
+
+    def test_named_case_without_test_data_dir_fails(self, invoke_cli, mocker, tmp_path):
+        """A named case whose test-data directory cannot be located is a hard failure."""
+        self._setup_sync(mocker, tmp_path, paths=None)
+
+        result = invoke_cli(
+            ["test-cases", "sync", "--provider", "example", "--diagnostic", "test-diag"],
+            expected_exit_code=1,
+        )
+        assert "Could not determine test case directory" in result.stderr
+
+    def test_sweeping_case_without_test_data_dir_warns(self, invoke_cli, mocker, tmp_path):
+        """Sweeping past a case with no test-data directory warns and still exits 0."""
+        self._setup_sync(mocker, tmp_path, paths=None)
+
+        result = invoke_cli(["test-cases", "sync", "--provider", "example"])
+        assert result.exit_code == 0
+        assert "Could not determine test case directory" in result.stderr
+
+    def test_sweeping_case_without_manifest_warns(self, invoke_cli, mocker, tmp_path):
+        """Sweeping past a case with no manifest warns and still exits 0."""
+        from climate_ref_core.testing import TestCasePaths
+
+        case_dir = tmp_path / "td" / "test-diag" / "default"
+        case_dir.mkdir(parents=True)
+        self._setup_sync(mocker, tmp_path, paths=TestCasePaths(root=case_dir, provider_slug="example"))
+
+        result = invoke_cli(["test-cases", "sync", "--provider", "example"])
+        assert result.exit_code == 0
+        assert "No manifest.json" in result.stderr
+
+    def test_named_case_without_manifest_fails(self, invoke_cli, mocker, tmp_path):
+        """A named case with no manifest is a hard failure."""
+        from climate_ref_core.testing import TestCasePaths
+
+        case_dir = tmp_path / "td" / "test-diag" / "default"
+        case_dir.mkdir(parents=True)
+        self._setup_sync(mocker, tmp_path, paths=TestCasePaths(root=case_dir, provider_slug="example"))
+
+        result = invoke_cli(
+            ["test-cases", "sync", "--provider", "example", "--diagnostic", "test-diag"],
+            expected_exit_code=1,
+        )
+        assert "No manifest.json" in result.stderr
+
+    def test_no_matching_cases_exits_zero(self, invoke_cli, mocker, tmp_path):
+        """Selectors that match nothing are a successful no-op, not an error."""
+        from unittest.mock import MagicMock
+
+        from climate_ref_core.regression.store import LocalFilesystemStore
+
+        provider = MagicMock(slug="example")
+        provider.diagnostics.return_value = []
+        self._patch_registry(mocker, MagicMock(providers=[provider]))
+        mocker.patch(
+            "climate_ref_core.regression.store.build_native_store",
+            return_value=LocalFilesystemStore(root=tmp_path / "store"),
+        )
+
+        result = invoke_cli(["test-cases", "sync"])
+        assert result.exit_code == 0
+        assert "No test cases found for the selected filters" in result.stderr
+
+
 class TestStageCompare:
     """`stage_compare` drives replay verification from the manifest's committed set."""
 
@@ -2406,6 +2492,40 @@ class TestBuildCommand:
         assert result.exit_code == 0
         assert runner.run.call_count == 1  # build did not re-run the diagnostic
         assert (paths.output_slot("latest") / "regression" / "diagnostic.json").exists()
+
+    def test_unreadable_manifest_leaves_the_baseline_intact(self, invoke_cli, mocker, tmp_path):
+        """A manifest that cannot be read fails before the tracked baseline is overwritten."""
+        paths, _scratch, _regression, _runner = _setup_real_run(mocker, tmp_path)
+
+        # Seed a slot and a promoted baseline with one run.
+        assert (
+            invoke_cli(
+                ["test-cases", "run", "--provider", "example", "--diagnostic", "test-diag", "--force-regen"]
+            ).exit_code
+            == 0
+        )
+        # Diverge the tracked baseline from the slot's bundle, so a promotion would overwrite it.
+        for committed_file in sorted(paths.regression.iterdir()):
+            committed_file.write_text('{"sentinel": true}')
+        before = {p.name: p.read_bytes() for p in sorted(paths.regression.iterdir())}
+        assert before
+
+        paths.manifest.write_text("{ not valid json")
+        invoke_cli(
+            [
+                "test-cases",
+                "build",
+                "--provider",
+                "example",
+                "--diagnostic",
+                "test-diag",
+                "--force-regen",
+            ],
+            expected_exit_code=1,
+        )
+
+        after = {p.name: p.read_bytes() for p in sorted(paths.regression.iterdir())}
+        assert after == before
 
 
 def test_output_slot_pattern_is_gitignored(tmp_path):


### PR DESCRIPTION
## Description

Extracts the duplicated per-verb driver loop in the `ref test-cases` CLI into a shared `VerbDriver` helper, and collapses the promote-or-preserve manifest block shared by `run` and `build` into one function. Pure refactor apart from the edges listed below, following on from #854. No CLI surface change and no manifest format change.

- Adds `VerbDriver` to `_common.py`. It owns provider-registry construction, selector validation, case enumeration, the missing-manifest and missing-catalog skip policy, the success and failure tally, and the Rich summary epilogue.
- Each verb's loop body stays with the verb and reports via `driver.ok()` / `driver.fail()`. The per-verb summary wording is passed as a `VerbSummary`.
- Adds `promote_and_author_manifest` to `_stages.py` for the block `run` and `build` shared verbatim. It promotes the slot's rebuilt bundle, preserves the previous manifest's version and native block (or seeds an empty set), and warns when the native baseline is stale.
- `replay` / `mint` / `build` / `run` now use the driver end to end. `sync` uses it for setup, enumeration and failure recording but keeps its own fetched/skipped tally, because its summary is fetch shaped. `ci-gate` only borrows the setup and case enumeration, because its loop is decision shaped rather than run shaped.
- Drops the `PLR0912` / `PLR0915` waivers from `replay` and `build`.

Four edges changed while unifying the skip policy and the manifest handling. The skip-policy edges are covered by `TestVerbDriverSkipPolicy`, and the manifest edge by an unreadable-manifest `build` test. All are reachable only through an already-broken selection or an already-unreadable manifest.

- The "hard fail when named, warn and skip when sweeping" policy now covers an unlocatable test-data directory as well as a missing manifest. Previously only `sync` failed on the former, and only when named. So `replay` / `mint` / `build` now exit 1 rather than 0 when an explicitly named case has no resolvable test-data directory.
- `sync` now warns (instead of staying silent) when sweeping past a case with no manifest or no resolvable test-data directory.
- `build` now reports a missing catalog before a missing output slot when both are absent. Either way it is a hard failure with exit 1.
- `run` and `build` now read the previous manifest only when promoting, immediately before the promote. A run that skips promotion no longer reads it at all, and an unreadable manifest fails with exit 1 before the existing baseline can be altered.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added (existing tests cover the change, no behaviour changed)
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Streamlined `ref test-cases` workflows with more consistent filtering, validation, execution reporting and completion summaries.
  * Improved manifest creation and updates, preserving existing metadata and providing clearer warnings when native outputs change.
  * Added clearer handling for explicitly selected versus broad test-case searches.
  * Prevented forced regeneration from altering an existing baseline when its manifest cannot be read.
  * Maintained the existing command interface and manifest format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
