### PR TITLE
Route Celery executions via a queue routing table

### DIFF
--- a/changelog/860.feature.md
+++ b/changelog/860.feature.md
@@ -1,0 +1,5 @@
+Added size-based queue routing for the Celery executor.
+A TOML routing table named by the `REF_CELERY_ROUTES` environment variable maps diagnostics to size classes,
+so each execution is submitted to a queue such as `esmvaltool-large`
+and differently sized worker pools can consume them independently.
+Without the variable set, behaviour is unchanged.

--- a/changelog/860.feature.md
+++ b/changelog/860.feature.md
@@ -1,5 +1,4 @@
-Added size-based queue routing for the Celery executor.
-A TOML routing table named by the `REF_CELERY_ROUTES` environment variable maps diagnostics to size classes,
-so each execution is submitted to a queue such as `esmvaltool-large`
-and differently sized worker pools can consume them independently.
+Added queue routing for the Celery executor.
+A TOML routing table named by the `REF_CELERY_ROUTES` environment variable maps diagnostics to queue names,
+so each execution is submitted to a queue such as `esmvaltool-large` and differently sized worker pools can consume them independently.
 Without the variable set, behaviour is unchanged.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,39 @@ Edit structured values such as `diagnostic_providers` and `executor.config` dire
 Environment variables are used to control some aspects of the framework
 outside of the configuration file.
 
+### `REF_CELERY_ROUTES`
+
+Path to a TOML routing table for the Celery executor.
+The table maps diagnostics to size classes,
+so that an execution lands on a size-specific queue such as `esmvaltool-large`
+instead of the bare provider queue.
+Differently sized worker pools can then consume the queues independently.
+
+```toml
+default = "medium"
+
+[esmvaltool]
+default = "medium"
+rules = [
+  { match = "portrait-*", size = "large" },
+  { match = "sea-ice-basic", size = "small" },
+]
+
+[ilamb]
+default = "small"
+```
+
+Rules are matched against the diagnostic slug in order, first match wins.
+Patterns support exact strings and glob wildcards.
+A provider `default` applies when no rule matches,
+and the top-level `default` applies when the provider has no entry.
+With no default and no match, the bare provider queue is used.
+
+If this is not set, every execution uses the bare provider queue.
+A malformed file fails the solve at startup rather than silently misrouting jobs.
+Workers consuming a size-specific queue must be started with that queue name explicitly,
+for example `ref-celery start-worker --provider climate_ref_esmvaltool -- --queues=esmvaltool-large`.
+
 ### `REF_DATASET_CACHE_DIR`
 
 Path where any datasets that are fetched via the `ref datasets fetch-data` command are stored.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,30 +95,31 @@ outside of the configuration file.
 ### `REF_CELERY_ROUTES`
 
 Path to a TOML routing table for the Celery executor.
-The table maps diagnostics to size classes,
-so that an execution lands on a size-specific queue such as `esmvaltool-large`
-instead of the bare provider queue.
+The table maps diagnostics to queue names,
+so that an execution lands on a queue such as `esmvaltool-large` instead of the bare provider queue.
 Differently sized worker pools can then consume the queues independently.
 
 ```toml
-default = "medium"
+default = "{provider}"
 
 [esmvaltool]
-default = "medium"
+default = "esmvaltool-medium"
 rules = [
-  { match = "portrait-*", size = "large" },
-  { match = "sea-ice-basic", size = "small" },
+  { match = "portrait-*", queue = "esmvaltool-large" },
+  { match = "sea-ice-basic", queue = "esmvaltool-small" },
 ]
 
 [ilamb]
-default = "small"
+default = "ilamb-small"
 ```
 
 Rules are matched against the diagnostic slug in order, first match wins.
 Patterns support exact strings and glob wildcards.
+Queue names are templates in which `{provider}` expands to the provider slug.
 A provider `default` applies when no rule matches,
 and the top-level `default` applies when the provider has no entry.
-With no default and no match, the bare provider queue is used.
+With no default and no match, the bare provider queue is used,
+equivalent to a default of `"{provider}"`.
 
 If this is not set, every execution uses the bare provider queue.
 A malformed file fails the solve at startup rather than silently misrouting jobs.

--- a/packages/climate-ref-celery/pyproject.toml
+++ b/packages/climate-ref-celery/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
     "climate-ref",
     "climate-ref-core",
+    "attrs>=23.2.0",
     "celery[redis]>=5.4.0",
     "typer>=0.12.0",
     "environs>=11",

--- a/packages/climate-ref-celery/src/climate_ref_celery/executor.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/executor.py
@@ -2,7 +2,9 @@
 Executor for running diagnostics asynchronously using Celery
 """
 
+import os
 import time
+from collections import Counter
 from typing import Any
 
 import celery.exceptions
@@ -13,9 +15,32 @@ from tqdm import tqdm
 from climate_ref.config import Config
 from climate_ref.models import Execution
 from climate_ref_celery.app import app
+from climate_ref_celery.routing import ROUTES_ENV_VAR, load_routing_table
 from climate_ref_celery.tasks import generate_task_name
 from climate_ref_core.diagnostics import ExecutionDefinition, ExecutionResult
+from climate_ref_core.exceptions import InvalidProviderException
 from climate_ref_core.executor import Executor
+from climate_ref_core.providers import import_provider
+
+
+def _configured_provider_slugs(config: Config) -> list[str] | None:
+    """
+    Resolve the provider slugs configured for this deployment
+
+    Returns ``None`` when any provider cannot be imported,
+    which skips the stale-entry warning rather than risking a false one.
+    """
+    slugs = []
+    for provider_config in config.diagnostic_providers:
+        try:
+            slugs.append(import_provider(provider_config.provider).slug)
+        except InvalidProviderException:
+            logger.debug(
+                f"Could not import provider {provider_config.provider!r}, "
+                "skipping the routing table provider check"
+            )
+            return None
+    return slugs
 
 
 class CeleryExecutor(Executor):
@@ -45,6 +70,10 @@ class CeleryExecutor(Executor):
         self.config = config
         super().__init__(**kwargs)  # type: ignore
         self._results: list[celery.result.AsyncResult[ExecutionResult]] = []
+        self._queue_counts: Counter[str] = Counter()
+        # Resolving provider slugs imports the provider packages, so only do it when a table is set
+        known_providers = _configured_provider_slugs(config) if os.environ.get(ROUTES_ENV_VAR) else None
+        self._routing_table = load_routing_table(known_providers=known_providers)
 
     def run(
         self,
@@ -80,16 +109,28 @@ class CeleryExecutor(Executor):
         diagnostic = definition.diagnostic
 
         name = generate_task_name(diagnostic.provider, diagnostic)
+        queue = self._routing_table.queue_for(diagnostic.provider.slug, diagnostic.slug)
 
         async_result = app.send_task(
             name,
             args=[definition, self.config.log_level],
-            queue=diagnostic.provider.slug,
+            queue=queue,
             link=handle_result.s(execution_id=execution.id).set(queue="celery") if execution else None,
             link_error=handle_failure.s(execution_id=execution.id).set(queue="celery") if execution else None,
         )
-        logger.debug(f"Celery task {async_result.id} submitted")
+        logger.debug(f"Celery task {async_result.id} for {diagnostic.slug} submitted to queue {queue}")
+        self._queue_counts[queue] += 1
         self._results.append(async_result)
+
+    def log_submission_summary(self) -> None:
+        """
+        Log a per-queue count of the tasks submitted so far
+
+        The solver calls this at the end of a solve,
+        so the counts appear whether or not the solve waits on ``join``.
+        """
+        for queue, count in sorted(self._queue_counts.items()):
+            logger.info(f"Submitted {count} executions to queue {queue}")
 
     def join(self, timeout: float) -> None:
         """

--- a/packages/climate-ref-celery/src/climate_ref_celery/executor.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/executor.py
@@ -124,13 +124,11 @@ class CeleryExecutor(Executor):
 
     def log_submission_summary(self) -> None:
         """
-        Log a per-queue count of the tasks submitted so far
-
-        The solver calls this at the end of a solve,
-        so the counts appear whether or not the solve waits on ``join``.
+        Log a per-queue count of the tasks submitted since the last summary
         """
         for queue, count in sorted(self._queue_counts.items()):
             logger.info(f"Submitted {count} executions to queue {queue}")
+        self._queue_counts.clear()
 
     def join(self, timeout: float) -> None:
         """

--- a/packages/climate-ref-celery/src/climate_ref_celery/routing.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/routing.py
@@ -1,9 +1,9 @@
 """
 Queue routing for Celery task submission
 
-A deployment may wish to map diagnostics to different queues depending on their size.
-The routing table maps diagnostics to queues,
-so that each execution lands on a size-specific queue such as ``esmvaltool-large``.
+A deployment may wish to place executions on different queues depending on their size.
+The routing table maps diagnostics to queue names,
+so that each execution lands on a queue such as ``esmvaltool-large``.
 Differently sized worker pools can then consume the queues independently.
 
 The table is a TOML file whose path is given by the ``REF_CELERY_ROUTES`` environment variable.
@@ -13,23 +13,25 @@ Example:
 
 .. code-block:: toml
 
-    default = "medium"
+    default = "{provider}"
 
     [esmvaltool]
-    default = "medium"
+    default = "esmvaltool-medium"
     rules = [
-      { match = "portrait-*", size = "large" },
-      { match = "sea-ice-basic", size = "small" },
+      { match = "portrait-*", queue = "esmvaltool-large" },
+      { match = "sea-ice-basic", queue = "esmvaltool-small" },
     ]
 
     [ilamb]
-    default = "small"
+    default = "ilamb-small"
 
 Rules are matched against the diagnostic slug in order, first match wins.
 Patterns use :func:`fnmatch.fnmatchcase` semantics, so exact strings and glob wildcards both work.
+Queue names are templates in which ``{provider}`` expands to the provider slug.
 A provider ``default`` applies when no rule matches.
 The top-level ``default`` applies when the provider has no entry.
-With no default and no match, the queue is the bare provider slug.
+With no default and no match, the queue is the bare provider slug,
+equivalent to a default of ``"{provider}"``.
 """
 
 import fnmatch
@@ -55,6 +57,19 @@ class RoutingTableError(ValueError):
     """
 
 
+def _require_queue_template(value: Any, path: Path, entry: str) -> str:
+    if not isinstance(value, str):
+        raise RoutingTableError(f"Routing table {path}: {entry} must be a string, got {value!r}")
+    try:
+        value.format(provider="provider")
+    except (KeyError, IndexError, ValueError) as exc:
+        raise RoutingTableError(
+            f"Routing table {path}: {entry} is not a valid queue template "
+            f"(only {{provider}} is supported): {value!r}"
+        ) from exc
+    return value
+
+
 def _require_string(value: Any, path: Path, entry: str) -> str:
     if not isinstance(value, str):
         raise RoutingTableError(f"Routing table {path}: {entry} must be a string, got {value!r}")
@@ -64,39 +79,39 @@ def _require_string(value: Any, path: Path, entry: str) -> str:
 @frozen
 class RoutingRule:
     """
-    A single pattern to size-class rule
+    A single pattern to queue rule
     """
 
     match: str
     """Pattern matched against the diagnostic slug, with ``fnmatch`` semantics"""
 
-    size: str
-    """Size class assigned when the pattern matches"""
+    queue: str
+    """Queue name template used when the pattern matches"""
 
 
 @frozen
 class ProviderRoutes:
     """
-    The ordered rules and optional default size class for one provider
+    The ordered rules and optional default queue for one provider
     """
 
     rules: tuple[RoutingRule, ...] = ()
     default: str | None = None
 
-    def size_for(self, diagnostic_slug: str) -> str | None:
+    def queue_template_for(self, diagnostic_slug: str) -> str | None:
         """
-        Resolve the size class for a diagnostic, or the provider default if no rule matches
+        Resolve the queue template for a diagnostic, or the provider default if no rule matches
         """
         for rule in self.rules:
             if fnmatch.fnmatchcase(diagnostic_slug, rule.match):
-                return rule.size
+                return rule.queue
         return self.default
 
 
 @frozen
 class RoutingTable:
     """
-    Deployment-supplied mapping of diagnostics to size classes
+    Deployment-supplied mapping of diagnostics to queue names
 
     An empty table routes everything to the bare provider queue,
     which matches the behaviour when no table is configured.
@@ -105,20 +120,6 @@ class RoutingTable:
     providers: Mapping[str, ProviderRoutes] = field(factory=dict)
     default: str | None = None
 
-    def size_for(self, provider_slug: str, diagnostic_slug: str) -> str | None:
-        """
-        Resolve the size class for an execution
-
-        Returns
-        -------
-        :
-            The size class, or ``None`` when neither a rule nor a default applies
-        """
-        provider = self.providers.get(provider_slug)
-        if provider is None:
-            return self.default
-        return provider.size_for(diagnostic_slug)
-
     def queue_for(self, provider_slug: str, diagnostic_slug: str) -> str:
         """
         Compute the queue name for an execution
@@ -126,12 +127,17 @@ class RoutingTable:
         Returns
         -------
         :
-            ``{provider_slug}-{size}`` when a size class applies, otherwise the bare provider slug
+            The matched queue template with ``{provider}`` expanded to the provider slug,
+            or the bare provider slug when neither a rule nor a default applies
         """
-        size = self.size_for(provider_slug, diagnostic_slug)
-        if size is None:
+        provider = self.providers.get(provider_slug)
+        if provider is None:
+            template = self.default
+        else:
+            template = provider.queue_template_for(diagnostic_slug)
+        if template is None:
             return provider_slug
-        return f"{provider_slug}-{size}"
+        return template.format(provider=provider_slug)
 
     @classmethod
     def from_file(cls, path: Path, known_providers: Collection[str] | None = None) -> "RoutingTable":
@@ -165,7 +171,7 @@ class RoutingTable:
 
         for key, value in raw.items():
             if key == "default":
-                default = _require_string(value, path, "top-level 'default'")
+                default = _require_queue_template(value, path, "top-level 'default'")
                 continue
             if not isinstance(value, dict):
                 raise RoutingTableError(
@@ -187,7 +193,7 @@ class RoutingTable:
 
         default: str | None = None
         if "default" in raw:
-            default = _require_string(raw["default"], path, f"[{provider}] 'default'")
+            default = _require_queue_template(raw["default"], path, f"[{provider}] 'default'")
 
         raw_rules = raw.get("rules", [])
         if not isinstance(raw_rules, list):
@@ -196,15 +202,15 @@ class RoutingTable:
         rules = []
         for index, raw_rule in enumerate(raw_rules):
             entry = f"[{provider}] rule {index}"
-            if not isinstance(raw_rule, dict) or raw_rule.keys() != {"match", "size"}:
+            if not isinstance(raw_rule, dict) or raw_rule.keys() != {"match", "queue"}:
                 raise RoutingTableError(
-                    f"Routing table {path}: {entry} must have exactly 'match' and 'size' keys, "
+                    f"Routing table {path}: {entry} must have exactly 'match' and 'queue' keys, "
                     f"got {raw_rule!r}"
                 )
             rules.append(
                 RoutingRule(
                     match=_require_string(raw_rule["match"], path, f"{entry} 'match'"),
-                    size=_require_string(raw_rule["size"], path, f"{entry} 'size'"),
+                    queue=_require_queue_template(raw_rule["queue"], path, f"{entry} 'queue'"),
                 )
             )
 

--- a/packages/climate-ref-celery/src/climate_ref_celery/routing.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/routing.py
@@ -1,0 +1,236 @@
+"""
+Queue routing for Celery task submission
+
+A deployment may wish to map diagnostics to different queues depending on their size.
+The routing table maps diagnostics to queues,
+so that each execution lands on a size-specific queue such as ``esmvaltool-large``.
+Differently sized worker pools can then consume the queues independently.
+
+The table is a TOML file whose path is given by the ``REF_CELERY_ROUTES`` environment variable.
+When the variable is unset, no table is loaded and every execution uses the bare provider queue.
+
+Example:
+
+.. code-block:: toml
+
+    default = "medium"
+
+    [esmvaltool]
+    default = "medium"
+    rules = [
+      { match = "portrait-*", size = "large" },
+      { match = "sea-ice-basic", size = "small" },
+    ]
+
+    [ilamb]
+    default = "small"
+
+Rules are matched against the diagnostic slug in order, first match wins.
+Patterns use :func:`fnmatch.fnmatchcase` semantics, so exact strings and glob wildcards both work.
+A provider ``default`` applies when no rule matches.
+The top-level ``default`` applies when the provider has no entry.
+With no default and no match, the queue is the bare provider slug.
+"""
+
+import fnmatch
+import os
+import tomllib
+from collections.abc import Collection, Mapping
+from pathlib import Path
+from typing import Any
+
+from attrs import field, frozen
+from loguru import logger
+
+ROUTES_ENV_VAR = "REF_CELERY_ROUTES"
+"""Environment variable holding the path to the routing table file"""
+
+
+class RoutingTableError(ValueError):
+    """
+    Raised when a routing table file is malformed
+
+    A malformed table fails hard rather than falling back to default routing,
+    because silent fallback would misplace large jobs onto small workers.
+    """
+
+
+def _require_string(value: Any, path: Path, entry: str) -> str:
+    if not isinstance(value, str):
+        raise RoutingTableError(f"Routing table {path}: {entry} must be a string, got {value!r}")
+    return value
+
+
+@frozen
+class RoutingRule:
+    """
+    A single pattern to size-class rule
+    """
+
+    match: str
+    """Pattern matched against the diagnostic slug, with ``fnmatch`` semantics"""
+
+    size: str
+    """Size class assigned when the pattern matches"""
+
+
+@frozen
+class ProviderRoutes:
+    """
+    The ordered rules and optional default size class for one provider
+    """
+
+    rules: tuple[RoutingRule, ...] = ()
+    default: str | None = None
+
+    def size_for(self, diagnostic_slug: str) -> str | None:
+        """
+        Resolve the size class for a diagnostic, or the provider default if no rule matches
+        """
+        for rule in self.rules:
+            if fnmatch.fnmatchcase(diagnostic_slug, rule.match):
+                return rule.size
+        return self.default
+
+
+@frozen
+class RoutingTable:
+    """
+    Deployment-supplied mapping of diagnostics to size classes
+
+    An empty table routes everything to the bare provider queue,
+    which matches the behaviour when no table is configured.
+    """
+
+    providers: Mapping[str, ProviderRoutes] = field(factory=dict)
+    default: str | None = None
+
+    def size_for(self, provider_slug: str, diagnostic_slug: str) -> str | None:
+        """
+        Resolve the size class for an execution
+
+        Returns
+        -------
+        :
+            The size class, or ``None`` when neither a rule nor a default applies
+        """
+        provider = self.providers.get(provider_slug)
+        if provider is None:
+            return self.default
+        return provider.size_for(diagnostic_slug)
+
+    def queue_for(self, provider_slug: str, diagnostic_slug: str) -> str:
+        """
+        Compute the queue name for an execution
+
+        Returns
+        -------
+        :
+            ``{provider_slug}-{size}`` when a size class applies, otherwise the bare provider slug
+        """
+        size = self.size_for(provider_slug, diagnostic_slug)
+        if size is None:
+            return provider_slug
+        return f"{provider_slug}-{size}"
+
+    @classmethod
+    def from_file(cls, path: Path, known_providers: Collection[str] | None = None) -> "RoutingTable":
+        """
+        Load and validate a routing table from a TOML file
+
+        Parameters
+        ----------
+        path
+            Path to the TOML file
+        known_providers
+            Slugs of the currently registered providers.
+            An entry for a provider not in this collection logs a warning, not an error,
+            because deployments may share one table across environments with different provider sets.
+            ``None`` skips the check.
+
+        Raises
+        ------
+        RoutingTableError
+            The file is missing, is not valid TOML, or contains a malformed entry
+        """
+        try:
+            raw = tomllib.loads(path.read_text())
+        except OSError as exc:
+            raise RoutingTableError(f"Routing table {path}: cannot read file ({exc})") from exc
+        except tomllib.TOMLDecodeError as exc:
+            raise RoutingTableError(f"Routing table {path}: invalid TOML ({exc})") from exc
+
+        default: str | None = None
+        providers: dict[str, ProviderRoutes] = {}
+
+        for key, value in raw.items():
+            if key == "default":
+                default = _require_string(value, path, "top-level 'default'")
+                continue
+            if not isinstance(value, dict):
+                raise RoutingTableError(
+                    f"Routing table {path}: '{key}' must be a provider table, got {value!r}"
+                )
+            providers[key] = cls._parse_provider(value, path, key)
+
+        if known_providers is not None:
+            for slug in providers.keys() - set(known_providers):
+                logger.warning(f"Routing table {path}: provider '{slug}' is not currently registered")
+
+        return cls(providers=providers, default=default)
+
+    @classmethod
+    def _parse_provider(cls, raw: dict[str, Any], path: Path, provider: str) -> ProviderRoutes:
+        unknown = raw.keys() - {"default", "rules"}
+        if unknown:
+            raise RoutingTableError(f"Routing table {path}: [{provider}] has unknown keys {sorted(unknown)}")
+
+        default: str | None = None
+        if "default" in raw:
+            default = _require_string(raw["default"], path, f"[{provider}] 'default'")
+
+        raw_rules = raw.get("rules", [])
+        if not isinstance(raw_rules, list):
+            raise RoutingTableError(f"Routing table {path}: [{provider}] 'rules' must be a list")
+
+        rules = []
+        for index, raw_rule in enumerate(raw_rules):
+            entry = f"[{provider}] rule {index}"
+            if not isinstance(raw_rule, dict) or raw_rule.keys() != {"match", "size"}:
+                raise RoutingTableError(
+                    f"Routing table {path}: {entry} must have exactly 'match' and 'size' keys, "
+                    f"got {raw_rule!r}"
+                )
+            rules.append(
+                RoutingRule(
+                    match=_require_string(raw_rule["match"], path, f"{entry} 'match'"),
+                    size=_require_string(raw_rule["size"], path, f"{entry} 'size'"),
+                )
+            )
+
+        patterns = [rule.match for rule in rules]
+        for pattern in sorted({p for p in patterns if patterns.count(p) > 1}):
+            logger.warning(f"Routing table {path}: [{provider}] has duplicate pattern '{pattern}'")
+
+        return ProviderRoutes(rules=tuple(rules), default=default)
+
+
+def load_routing_table(known_providers: Collection[str] | None = None) -> RoutingTable:
+    """
+    Load the routing table named by ``REF_CELERY_ROUTES``, or an empty table if unset
+
+    Parameters
+    ----------
+    known_providers
+        Slugs of the currently registered providers, used to warn about stale entries.
+        ``None`` skips the check.
+
+    Raises
+    ------
+    RoutingTableError
+        The variable is set but the file is missing or malformed
+    """
+    path = os.environ.get(ROUTES_ENV_VAR)
+    if not path:
+        return RoutingTable()
+    return RoutingTable.from_file(Path(path), known_providers=known_providers)

--- a/packages/climate-ref-celery/src/climate_ref_celery/routing.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/routing.py
@@ -39,6 +39,7 @@ import os
 import tomllib
 from collections.abc import Collection, Mapping
 from pathlib import Path
+from string import Formatter
 from typing import Any
 
 from attrs import field, frozen
@@ -60,13 +61,25 @@ class RoutingTableError(ValueError):
 def _require_queue_template(value: Any, path: Path, entry: str) -> str:
     if not isinstance(value, str):
         raise RoutingTableError(f"Routing table {path}: {entry} must be a string, got {value!r}")
-    try:
-        value.format(provider="provider")
-    except (KeyError, IndexError, ValueError) as exc:
-        raise RoutingTableError(
+
+    def invalid() -> RoutingTableError:
+        return RoutingTableError(
             f"Routing table {path}: {entry} is not a valid queue template "
             f"(only {{provider}} is supported): {value!r}"
-        ) from exc
+        )
+
+    # Allow only the bare {provider} field.
+    # Index/attribute lookups, conversions and format specs would mangle the queue name,
+    # for example {provider[0]}-large silently routes esmvaltool to e-large.
+    try:
+        fields = list(Formatter().parse(value))
+    except ValueError as exc:
+        raise invalid() from exc
+    for _, field_name, format_spec, conversion in fields:
+        if field_name is None:
+            continue
+        if field_name != "provider" or format_spec or conversion:
+            raise invalid()
     return value
 
 

--- a/packages/climate-ref-celery/src/climate_ref_celery/routing.py
+++ b/packages/climate-ref-celery/src/climate_ref_celery/routing.py
@@ -28,6 +28,7 @@ Example:
 Rules are matched against the diagnostic slug in order, first match wins.
 Patterns use :func:`fnmatch.fnmatchcase` semantics, so exact strings and glob wildcards both work.
 Queue names are templates in which ``{provider}`` expands to the provider slug.
+
 A provider ``default`` applies when no rule matches.
 The top-level ``default`` applies when the provider has no entry.
 With no default and no match, the queue is the bare provider slug,
@@ -69,8 +70,6 @@ def _require_queue_template(value: Any, path: Path, entry: str) -> str:
         )
 
     # Allow only the bare {provider} field.
-    # Index/attribute lookups, conversions and format specs would mangle the queue name,
-    # for example {provider[0]}-large silently routes esmvaltool to e-large.
     try:
         fields = list(Formatter().parse(value))
     except ValueError as exc:
@@ -127,7 +126,8 @@ class RoutingTable:
     Deployment-supplied mapping of diagnostics to queue names
 
     An empty table routes everything to the bare provider queue,
-    which matches the behaviour when no table is configured.
+    which matches the behaviour when no table is configured,
+    i.e. `default = "{provider}"`.
     """
 
     providers: Mapping[str, ProviderRoutes] = field(factory=dict)

--- a/packages/climate-ref-celery/tests/unit/test_executor.py
+++ b/packages/climate-ref-celery/tests/unit/test_executor.py
@@ -1,5 +1,6 @@
 import pytest
 from climate_ref_celery.executor import CeleryExecutor
+from climate_ref_celery.routing import ROUTES_ENV_VAR, RoutingTableError
 from climate_ref_celery.worker_tasks import handle_failure, handle_result
 
 
@@ -31,6 +32,56 @@ def test_run_metric(provider, config, mock_diagnostic, metric_definition, mocker
         )
 
     assert executor._results == [mock_app.send_task.return_value]
+
+
+def test_run_routed_queue(config, metric_definition, mocker, monkeypatch, tmp_path):
+    routes = tmp_path / "routes.toml"
+    routes.write_text('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
+    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+
+    executor = CeleryExecutor(config=config)
+    mock_app = mocker.patch("climate_ref_celery.executor.app")
+
+    executor.run(metric_definition, None)
+
+    assert mock_app.send_task.call_args.kwargs["queue"] == "mock_provider-large"
+
+
+def test_run_routed_queue_no_match(config, metric_definition, mocker, monkeypatch, tmp_path):
+    routes = tmp_path / "routes.toml"
+    routes.write_text('[mock_provider]\nrules = [{ match = "other-*", size = "large" }]\n')
+    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+
+    executor = CeleryExecutor(config=config)
+    mock_app = mocker.patch("climate_ref_celery.executor.app")
+
+    executor.run(metric_definition, None)
+
+    assert mock_app.send_task.call_args.kwargs["queue"] == "mock_provider"
+
+
+def test_malformed_routes_fails_construction(config, monkeypatch, tmp_path):
+    routes = tmp_path / "routes.toml"
+    routes.write_text("default = 3\n")
+    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+
+    with pytest.raises(RoutingTableError):
+        CeleryExecutor(config=config)
+
+
+def test_log_submission_summary(config, metric_definition, mocker, monkeypatch, tmp_path, caplog):
+    routes = tmp_path / "routes.toml"
+    routes.write_text('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
+    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+
+    executor = CeleryExecutor(config=config)
+    mocker.patch("climate_ref_celery.executor.app")
+
+    executor.run(metric_definition, None)
+    executor.run(metric_definition, None)
+    executor.log_submission_summary()
+
+    assert "Submitted 2 executions to queue mock_provider-large" in caplog.text
 
 
 def test_join_empty():

--- a/packages/climate-ref-celery/tests/unit/test_executor.py
+++ b/packages/climate-ref-celery/tests/unit/test_executor.py
@@ -34,10 +34,18 @@ def test_run_metric(provider, config, mock_diagnostic, metric_definition, mocker
     assert executor._results == [mock_app.send_task.return_value]
 
 
-def test_run_routed_queue(config, metric_definition, mocker, monkeypatch, tmp_path):
-    routes = tmp_path / "routes.toml"
-    routes.write_text('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
-    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+@pytest.fixture
+def set_routes(monkeypatch, tmp_path):
+    def write(content):
+        path = tmp_path / "routes.toml"
+        path.write_text(content)
+        monkeypatch.setenv(ROUTES_ENV_VAR, str(path))
+
+    return write
+
+
+def test_run_routed_queue(config, metric_definition, mocker, set_routes):
+    set_routes('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
 
     executor = CeleryExecutor(config=config)
     mock_app = mocker.patch("climate_ref_celery.executor.app")
@@ -47,10 +55,8 @@ def test_run_routed_queue(config, metric_definition, mocker, monkeypatch, tmp_pa
     assert mock_app.send_task.call_args.kwargs["queue"] == "mock_provider-large"
 
 
-def test_run_routed_queue_no_match(config, metric_definition, mocker, monkeypatch, tmp_path):
-    routes = tmp_path / "routes.toml"
-    routes.write_text('[mock_provider]\nrules = [{ match = "other-*", size = "large" }]\n')
-    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+def test_run_routed_queue_no_match(config, metric_definition, mocker, set_routes):
+    set_routes('[mock_provider]\nrules = [{ match = "other-*", size = "large" }]\n')
 
     executor = CeleryExecutor(config=config)
     mock_app = mocker.patch("climate_ref_celery.executor.app")
@@ -60,19 +66,15 @@ def test_run_routed_queue_no_match(config, metric_definition, mocker, monkeypatc
     assert mock_app.send_task.call_args.kwargs["queue"] == "mock_provider"
 
 
-def test_malformed_routes_fails_construction(config, monkeypatch, tmp_path):
-    routes = tmp_path / "routes.toml"
-    routes.write_text("default = 3\n")
-    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+def test_malformed_routes_fails_construction(config, set_routes):
+    set_routes("default = 3\n")
 
     with pytest.raises(RoutingTableError):
         CeleryExecutor(config=config)
 
 
-def test_log_submission_summary(config, metric_definition, mocker, monkeypatch, tmp_path, caplog):
-    routes = tmp_path / "routes.toml"
-    routes.write_text('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
-    monkeypatch.setenv(ROUTES_ENV_VAR, str(routes))
+def test_log_submission_summary(config, metric_definition, mocker, set_routes, caplog):
+    set_routes('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
 
     executor = CeleryExecutor(config=config)
     mocker.patch("climate_ref_celery.executor.app")
@@ -82,6 +84,10 @@ def test_log_submission_summary(config, metric_definition, mocker, monkeypatch, 
     executor.log_submission_summary()
 
     assert "Submitted 2 executions to queue mock_provider-large" in caplog.text
+
+    caplog.clear()
+    executor.log_submission_summary()
+    assert "Submitted" not in caplog.text
 
 
 def test_join_empty():

--- a/packages/climate-ref-celery/tests/unit/test_executor.py
+++ b/packages/climate-ref-celery/tests/unit/test_executor.py
@@ -45,7 +45,7 @@ def set_routes(monkeypatch, tmp_path):
 
 
 def test_run_routed_queue(config, metric_definition, mocker, set_routes):
-    set_routes('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
+    set_routes('[mock_provider]\nrules = [{ match = "mock", queue = "mock_provider-large" }]\n')
 
     executor = CeleryExecutor(config=config)
     mock_app = mocker.patch("climate_ref_celery.executor.app")
@@ -56,7 +56,7 @@ def test_run_routed_queue(config, metric_definition, mocker, set_routes):
 
 
 def test_run_routed_queue_no_match(config, metric_definition, mocker, set_routes):
-    set_routes('[mock_provider]\nrules = [{ match = "other-*", size = "large" }]\n')
+    set_routes('[mock_provider]\nrules = [{ match = "other-*", queue = "mock_provider-large" }]\n')
 
     executor = CeleryExecutor(config=config)
     mock_app = mocker.patch("climate_ref_celery.executor.app")
@@ -74,7 +74,7 @@ def test_malformed_routes_fails_construction(config, set_routes):
 
 
 def test_log_submission_summary(config, metric_definition, mocker, set_routes, caplog):
-    set_routes('[mock_provider]\nrules = [{ match = "mock", size = "large" }]\n')
+    set_routes('[mock_provider]\nrules = [{ match = "mock", queue = "mock_provider-large" }]\n')
 
     executor = CeleryExecutor(config=config)
     mocker.patch("climate_ref_celery.executor.app")

--- a/packages/climate-ref-celery/tests/unit/test_routing.py
+++ b/packages/climate-ref-celery/tests/unit/test_routing.py
@@ -7,18 +7,18 @@ from climate_ref_celery.routing import (
 )
 
 EXAMPLE = """
-default = "medium"
+default = "{provider}-medium"
 
 [esmvaltool]
-default = "medium"
+default = "esmvaltool-medium"
 rules = [
-  { match = "portrait-*", size = "large" },
-  { match = "climate-at-global-warming-level", size = "large" },
-  { match = "sea-ice-basic", size = "small" },
+  { match = "portrait-*", queue = "esmvaltool-large" },
+  { match = "climate-at-global-warming-level", queue = "esmvaltool-large" },
+  { match = "sea-ice-basic", queue = "{provider}-small" },
 ]
 
 [ilamb]
-default = "small"
+default = "ilamb-small"
 """
 
 
@@ -57,8 +57,8 @@ class TestQueueFor:
                 """
                 [pmp]
                 rules = [
-                  { match = "annual-*", size = "large" },
-                  { match = "annual-cycle", size = "small" },
+                  { match = "annual-*", queue = "pmp-large" },
+                  { match = "annual-cycle", queue = "pmp-small" },
                 ]
                 """
             )
@@ -70,12 +70,16 @@ class TestQueueFor:
             routes_file(
                 """
                 [pmp]
-                rules = [{ match = "annual-*", size = "large" }]
+                rules = [{ match = "annual-*", queue = "pmp-large" }]
                 """
             )
         )
         assert table.queue_for("pmp", "variability-modes") == "pmp"
         assert table.queue_for("ilamb", "gpp") == "ilamb"
+
+    def test_provider_placeholder_default(self, routes_file):
+        table = RoutingTable.from_file(routes_file('default = "{provider}"'))
+        assert table.queue_for("pmp", "annual-cycle") == "pmp"
 
     def test_empty_table(self):
         assert RoutingTable().queue_for("pmp", "annual-cycle") == "pmp"
@@ -95,9 +99,14 @@ class TestValidation:
         with pytest.raises(RoutingTableError, match="top-level 'default'"):
             RoutingTable.from_file(routes_file("default = 3"))
 
-    def test_non_string_size(self, routes_file):
-        with pytest.raises(RoutingTableError, match=r"\[pmp\] rule 0 'size'"):
-            RoutingTable.from_file(routes_file('[pmp]\nrules = [{ match = "a", size = 2 }]'))
+    def test_non_string_queue(self, routes_file):
+        with pytest.raises(RoutingTableError, match=r"\[pmp\] rule 0 'queue'"):
+            RoutingTable.from_file(routes_file('[pmp]\nrules = [{ match = "a", queue = 2 }]'))
+
+    @pytest.mark.parametrize("template", ["{diagnostic}", "{provider", "queue-{}"])
+    def test_invalid_queue_template(self, routes_file, template):
+        with pytest.raises(RoutingTableError, match="not a valid queue template"):
+            RoutingTable.from_file(routes_file(f'default = "{template}"'))
 
     def test_missing_rule_keys(self, routes_file):
         with pytest.raises(RoutingTableError, match=r"\[pmp\] rule 0"):
@@ -125,8 +134,8 @@ class TestValidation:
                 """
                 [pmp]
                 rules = [
-                  { match = "annual-*", size = "large" },
-                  { match = "annual-*", size = "small" },
+                  { match = "annual-*", queue = "pmp-large" },
+                  { match = "annual-*", queue = "pmp-small" },
                 ]
                 """
             )

--- a/packages/climate-ref-celery/tests/unit/test_routing.py
+++ b/packages/climate-ref-celery/tests/unit/test_routing.py
@@ -103,7 +103,18 @@ class TestValidation:
         with pytest.raises(RoutingTableError, match=r"\[pmp\] rule 0 'queue'"):
             RoutingTable.from_file(routes_file('[pmp]\nrules = [{ match = "a", queue = 2 }]'))
 
-    @pytest.mark.parametrize("template", ["{diagnostic}", "{provider", "queue-{}"])
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "{diagnostic}",
+            "{provider",
+            "queue-{}",
+            "{provider[0]}-large",
+            "{provider.name}",
+            "{provider!r}",
+            "{provider:>20}",
+        ],
+    )
     def test_invalid_queue_template(self, routes_file, template):
         with pytest.raises(RoutingTableError, match="not a valid queue template"):
             RoutingTable.from_file(routes_file(f'default = "{template}"'))

--- a/packages/climate-ref-celery/tests/unit/test_routing.py
+++ b/packages/climate-ref-celery/tests/unit/test_routing.py
@@ -1,0 +1,146 @@
+import pytest
+from climate_ref_celery.routing import (
+    ROUTES_ENV_VAR,
+    RoutingTable,
+    RoutingTableError,
+    load_routing_table,
+)
+
+EXAMPLE = """
+default = "medium"
+
+[esmvaltool]
+default = "medium"
+rules = [
+  { match = "portrait-*", size = "large" },
+  { match = "climate-at-global-warming-level", size = "large" },
+  { match = "sea-ice-basic", size = "small" },
+]
+
+[ilamb]
+default = "small"
+"""
+
+
+@pytest.fixture
+def routes_file(tmp_path):
+    def write(content):
+        path = tmp_path / "routes.toml"
+        path.write_text(content)
+        return path
+
+    return write
+
+
+class TestQueueFor:
+    @pytest.fixture
+    def table(self, routes_file):
+        return RoutingTable.from_file(routes_file(EXAMPLE))
+
+    @pytest.mark.parametrize(
+        "provider, diagnostic, expected",
+        [
+            ("esmvaltool", "portrait-plot", "esmvaltool-large"),
+            ("esmvaltool", "climate-at-global-warming-level", "esmvaltool-large"),
+            ("esmvaltool", "sea-ice-basic", "esmvaltool-small"),
+            ("esmvaltool", "anything-else", "esmvaltool-medium"),
+            ("ilamb", "gpp-fluxnet2015", "ilamb-small"),
+            ("pmp", "annual-cycle", "pmp-medium"),
+        ],
+    )
+    def test_resolution(self, table, provider, diagnostic, expected):
+        assert table.queue_for(provider, diagnostic) == expected
+
+    def test_first_match_wins(self, routes_file):
+        table = RoutingTable.from_file(
+            routes_file(
+                """
+                [pmp]
+                rules = [
+                  { match = "annual-*", size = "large" },
+                  { match = "annual-cycle", size = "small" },
+                ]
+                """
+            )
+        )
+        assert table.queue_for("pmp", "annual-cycle") == "pmp-large"
+
+    def test_no_match_no_defaults(self, routes_file):
+        table = RoutingTable.from_file(
+            routes_file(
+                """
+                [pmp]
+                rules = [{ match = "annual-*", size = "large" }]
+                """
+            )
+        )
+        assert table.queue_for("pmp", "variability-modes") == "pmp"
+        assert table.queue_for("ilamb", "gpp") == "ilamb"
+
+    def test_empty_table(self):
+        assert RoutingTable().queue_for("pmp", "annual-cycle") == "pmp"
+
+
+class TestValidation:
+    def test_missing_file(self, tmp_path):
+        path = tmp_path / "missing.toml"
+        with pytest.raises(RoutingTableError, match=str(path)):
+            RoutingTable.from_file(path)
+
+    def test_invalid_toml(self, routes_file):
+        with pytest.raises(RoutingTableError, match="invalid TOML"):
+            RoutingTable.from_file(routes_file("not = ["))
+
+    def test_non_string_default(self, routes_file):
+        with pytest.raises(RoutingTableError, match="top-level 'default'"):
+            RoutingTable.from_file(routes_file("default = 3"))
+
+    def test_non_string_size(self, routes_file):
+        with pytest.raises(RoutingTableError, match=r"\[pmp\] rule 0 'size'"):
+            RoutingTable.from_file(routes_file('[pmp]\nrules = [{ match = "a", size = 2 }]'))
+
+    def test_missing_rule_keys(self, routes_file):
+        with pytest.raises(RoutingTableError, match=r"\[pmp\] rule 0"):
+            RoutingTable.from_file(routes_file('[pmp]\nrules = [{ match = "a" }]'))
+
+    def test_unknown_provider_key(self, routes_file):
+        with pytest.raises(RoutingTableError, match=r"\[pmp\] has unknown keys \['rule'\]"):
+            RoutingTable.from_file(routes_file("[pmp]\nrule = []"))
+
+    def test_provider_entry_not_a_table(self, routes_file):
+        with pytest.raises(RoutingTableError, match="'pmp' must be a provider table"):
+            RoutingTable.from_file(routes_file('pmp = "small"'))
+
+    def test_unregistered_provider_warns(self, routes_file, caplog):
+        RoutingTable.from_file(routes_file(EXAMPLE), known_providers=["esmvaltool"])
+        assert "provider 'ilamb' is not currently registered" in caplog.text
+
+    def test_registered_providers_no_warning(self, routes_file, caplog):
+        RoutingTable.from_file(routes_file(EXAMPLE), known_providers=["esmvaltool", "ilamb"])
+        assert "not currently registered" not in caplog.text
+
+    def test_duplicate_pattern_warns(self, routes_file, caplog):
+        table = RoutingTable.from_file(
+            routes_file(
+                """
+                [pmp]
+                rules = [
+                  { match = "annual-*", size = "large" },
+                  { match = "annual-*", size = "small" },
+                ]
+                """
+            )
+        )
+        assert "duplicate pattern 'annual-*'" in caplog.text
+        assert table.queue_for("pmp", "annual-cycle") == "pmp-large"
+
+
+class TestLoadRoutingTable:
+    def test_unset(self, monkeypatch):
+        monkeypatch.delenv(ROUTES_ENV_VAR, raising=False)
+        assert load_routing_table() == RoutingTable()
+
+    def test_set(self, monkeypatch, routes_file):
+        monkeypatch.setenv(ROUTES_ENV_VAR, str(routes_file(EXAMPLE)))
+        table = load_routing_table()
+        assert table.queue_for("ilamb", "gpp") == "ilamb-small"

--- a/packages/climate-ref/src/climate_ref/solver.py
+++ b/packages/climate-ref/src/climate_ref/solver.py
@@ -850,6 +850,11 @@ def solve_required_executions(  # noqa: PLR0912, PLR0913, PLR0915
     for prov, count in provider_count.items():
         logger.info(f"  {prov}: {count} new executions")
 
+    # Executors may expose extra end-of-solve reporting, such as per-queue submission counts
+    log_submission_summary = getattr(executor, "log_submission_summary", None)
+    if log_submission_summary is not None:
+        log_submission_summary()
+
     if wait and executor is not None:
         executor.join(timeout=timeout)
         logger.info("All executions complete")

--- a/packages/climate-ref/tests/unit/test_solver.py
+++ b/packages/climate-ref/tests/unit/test_solver.py
@@ -718,6 +718,29 @@ def test_solve_skips_join_when_no_wait(mocker, mock_metric_execution, mock_execu
     mock_executor.return_value.join.assert_not_called()
 
 
+def test_solve_logs_executor_submission_summary(mocker, mock_metric_execution, mock_executor, db_seeded):
+    """The end-of-solve summary hook fires even when the solve does not wait"""
+    mock_build_solver = mocker.patch.object(ExecutionSolver, "build_from_db")
+    solver = mock.MagicMock(spec=ExecutionSolver)
+    solver.solve.return_value = [mock_metric_execution]
+    mock_build_solver.return_value = solver
+
+    solve_required_executions(db_seeded, wait=False, timeout=0)
+
+    mock_executor.return_value.log_submission_summary.assert_called_once_with()
+
+
+def test_solve_tolerates_executor_without_summary(mocker, mock_metric_execution, mock_executor, db_seeded):
+    """Executors without the optional summary hook are still valid"""
+    del mock_executor.return_value.log_submission_summary
+    mock_build_solver = mocker.patch.object(ExecutionSolver, "build_from_db")
+    solver = mock.MagicMock(spec=ExecutionSolver)
+    solver.solve.return_value = [mock_metric_execution]
+    mock_build_solver.return_value = solver
+
+    solve_required_executions(db_seeded, wait=False, timeout=0)
+
+
 def test_two_executions_same_group_distinct_output_fragments(
     mocker, mock_metric_execution, mock_executor, db_seeded
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -728,6 +728,7 @@ name = "climate-ref-celery"
 version = "0.16.2"
 source = { editable = "packages/climate-ref-celery" }
 dependencies = [
+    { name = "attrs" },
     { name = "celery", extra = ["redis"] },
     { name = "climate-ref" },
     { name = "climate-ref-core" },
@@ -745,6 +746,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "attrs", specifier = ">=23.2.0" },
     { name = "celery", extras = ["redis"], specifier = ">=5.4.0" },
     { name = "climate-ref", editable = "packages/climate-ref" },
     { name = "climate-ref-core", editable = "packages/climate-ref-core" },


### PR DESCRIPTION
Adds queue routing for the Celery executor. A deployment can supply a routing table that maps diagnostics to queue names, so each execution lands on a queue such as `esmvaltool-large` instead of the bare provider queue. Differently sized worker pools can then consume the queues independently, rather than sizing every worker for the largest diagnostic a provider can produce.

- The table is a TOML file named by the `REF_CELERY_ROUTES` environment variable.
- Rules match diagnostic slugs with fnmatch patterns, first match wins.
- Each rule names the target queue directly, and `{provider}` is available as a template placeholder.
- A per-provider default applies when no rule matches, and a global default applies when the provider has no entry.
- With no match and no default, the queue is the bare provider slug, equivalent to a default of `"{provider}"`.
- A malformed table fails executor construction with the file and offending entry named, because silent fallback would misplace large jobs onto small workers.
- Entries for unregistered providers and duplicate patterns are warnings only.
- Each submission logs its queue at debug level, and the solver logs a per-queue count at the end of a solve.

The `handle_result` and `handle_failure` follow-up tasks stay on the `celery` queue. With `REF_CELERY_ROUTES` unset, behaviour is unchanged.

This covers the submit side only. Workers consuming a routed queue must be started with that queue name explicitly, for example `ref-celery start-worker --provider climate_ref_esmvaltool -- --queues=esmvaltool-large`. A friendlier worker flag can follow separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Celery task routing through `REF_CELERY_ROUTES`.
  * Supports provider- and diagnostic-specific queues, defaults, ordered matching rules, and queue templates.
  * Added submission summaries showing task counts by queue.

* **Documentation**
  * Documented routing configuration, precedence, validation, fallback behaviour, and worker setup.

* **Bug Fixes**
  * Added validation and clear startup errors for unreadable or malformed routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->