### PR TITLE
Order doctor's diagnostic references deterministically

### DIFF
--- a/changelog/870.fix.md
+++ b/changelog/870.fix.md
@@ -1,0 +1,2 @@
+Fixed `ref doctor` producing a different report on each run.
+Diagnostics that share a name were ordered by set iteration order, so two identical runs disagreed.

--- a/packages/climate-ref-core/src/climate_ref_core/summary.py
+++ b/packages/climate-ref-core/src/climate_ref_core/summary.py
@@ -267,9 +267,9 @@ class DiagnosticReference:
         return f"{self.name} ({self.provider_slug})"
 
     @property
-    def sort_key(self) -> str:
-        """Sort by provider then name."""
-        return f"{self.provider_slug}/{self.name}"
+    def sort_key(self) -> tuple[str, str, str]:
+        """Sort by provider, then name, then slug. Several diagnostics can share a name."""
+        return (self.provider_slug, self.name, self.slug)
 
 
 @frozen

--- a/packages/climate-ref-core/tests/unit/test_summary.py
+++ b/packages/climate-ref-core/tests/unit/test_summary.py
@@ -451,6 +451,17 @@ class TestCollectBySourceType:
         assert ref.provider_slug == "test-provider"
         assert ref.label == "Simple Diagnostic (test-provider)"
 
+    def test_sort_key_breaks_ties_on_slug(self):
+        """Several diagnostics can share a name, so the slug has to settle the order."""
+        shared = [
+            DiagnosticReference(name="Ozone Diagnostics", slug=slug, provider_slug="esmvaltool")
+            for slug in ("ozone-sh-oct", "ozone-annual-cycle", "ozone-nh-mar")
+        ]
+
+        ordered = sorted(shared, key=lambda r: r.sort_key)
+
+        assert [r.slug for r in ordered] == ["ozone-annual-cycle", "ozone-nh-mar", "ozone-sh-oct"]
+
     def test_empty_providers(self):
         result = collect_by_source_type([])
         assert result == []

--- a/packages/climate-ref/src/climate_ref/doctor/registry.py
+++ b/packages/climate-ref/src/climate_ref/doctor/registry.py
@@ -81,7 +81,7 @@ def register_check(registered: RegisteredCheck) -> None:
     ------
     ValueError
         If another check already claims the same slug. Two checks sharing a slug would be
-        indistinguishable in the output and in ``--only``.
+        indistinguishable in the report.
     """
     existing = _REGISTRY.get(registered.slug)
     if existing is not None:


### PR DESCRIPTION
Follow-up to #865.

`ref doctor` produced a different report on each run. Several diagnostics share a name (the four ozone ones are all "Ozone Diagnostics"), and `DiagnosticReference.sort_key` was provider plus name only, so the tie broke on set iteration order. Two identical runs gave different `missing-reference-data` details, which makes a pasted report hard to diff.

- Adds the slug as the tiebreak, so the order is total.
- Drops a docstring reference to a `--only` flag that does not exist.

Found by running the checks against a real deployment and diffing `--format json` across three runs. Same three runs are now byte-identical.