### PR TITLE
feat(database): add a scoped session factory for concurrent readers

### DIFF
--- a/changelog/876.feature.md
+++ b/changelog/876.feature.md
@@ -1,4 +1,6 @@
 Added `Database.session_scope`, a context manager that hands out a short-lived database session.
-The session is rolled back if the block raises and always closed, while the engine and its connection pool stay shared.
-`Reader` and its sub-readers now accept an optional `session`, so a concurrent caller such as a web request can read
-through its own scope instead of the shared `Database.session`, whose behaviour is unchanged.
+The session is rolled back if the block raises and always closed,
+while the engine and its connection pool stay shared.
+`Reader` and its sub-readers now accept an optional `session`,
+so a concurrent caller such as a web request can read through its own scope
+instead of the shared `Database.session`, whose behaviour is unchanged.

--- a/changelog/876.feature.md
+++ b/changelog/876.feature.md
@@ -1,0 +1,4 @@
+Added `Database.session_scope`, a context manager that hands out a short-lived database session.
+The session is rolled back if the block raises and always closed, while the engine and its connection pool stay shared.
+`Reader` and its sub-readers now accept an optional `session`, so a concurrent caller such as a web request can read
+through its own scope instead of the shared `Database.session`, whose behaviour is unchanged.

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -301,13 +301,12 @@ class Database:
         """
         Open a short-lived session for the duration of a block
 
-        The session comes from a factory bound to the shared engine, so the connection pool
-        stays shared while the session itself is private to the caller.
-        This is what a concurrent reader (a web request, a thread) should use instead of the
-        long-lived `session` attribute, which is not safe to share.
+        A concurrent reader, such as a web request or a thread,
+        should use this rather than the long-lived `session` attribute, which is not safe to share.
+        The engine and its connection pool stay shared, so only the session is private to the caller.
 
-        The session is rolled back if the block raises, and always closed so its connection
-        returns to the pool. Neither `session` nor the engine is touched.
+        The session is rolled back if the block raises,
+        and is always closed so its connection returns to the pool.
 
         Returns
         -------
@@ -317,7 +316,9 @@ class Database:
         session = self._session_factory()
         try:
             yield session
-        except Exception:
+        except BaseException:
+            # BaseException rather than Exception, because a cancelled request raises
+            # CancelledError and its writes must not survive either.
             session.rollback()
             raise
         finally:

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -11,6 +11,8 @@ It provides a session object that can be used to interact with the database and 
 import enum
 import importlib.resources
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from types import TracebackType
@@ -26,7 +28,7 @@ from alembic.script import ScriptDirectory
 from loguru import logger
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import ArgumentError, IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from climate_ref.models import MetricValue, Table
 from climate_ref.models.execution import ExecutionOutput
@@ -290,8 +292,36 @@ class Database:
         if connect_args:
             engine_kwargs["connect_args"] = connect_args
         self._engine = sqlalchemy.create_engine(self.url, **engine_kwargs)
+        self._session_factory = sessionmaker(bind=self._engine)
         # TODO: Set autobegin=False
         self.session = Session(self._engine)
+
+    @contextmanager
+    def session_scope(self) -> Iterator[Session]:
+        """
+        Open a short-lived session for the duration of a block
+
+        The session comes from a factory bound to the shared engine, so the connection pool
+        stays shared while the session itself is private to the caller.
+        This is what a concurrent reader (a web request, a thread) should use instead of the
+        long-lived `session` attribute, which is not safe to share.
+
+        The session is rolled back if the block raises, and always closed so its connection
+        returns to the pool. Neither `session` nor the engine is touched.
+
+        Returns
+        -------
+        :
+            A context manager yielding a fresh session.
+        """
+        session = self._session_factory()
+        try:
+            yield session
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     def __enter__(self) -> "Database":
         return self

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -307,6 +307,8 @@ class Database:
 
         The session is rolled back if the block raises,
         and is always closed so its connection returns to the pool.
+        Nothing is committed on the caller's behalf,
+        so a block that writes has to commit before it ends or the close discards the work.
 
         Returns
         -------

--- a/packages/climate-ref/src/climate_ref/results/datasets.py
+++ b/packages/climate-ref/src/climate_ref/results/datasets.py
@@ -153,7 +153,7 @@ class DatasetsReader:
     keeps taking a bare slug, which is globally unique and needs no ``source_type``.
     """
 
-    def __init__(self, database: Database, session: Session | None = None) -> None:
+    def __init__(self, database: Database, *, session: Session | None = None) -> None:
         self._db = database
         self._session = session
 

--- a/packages/climate-ref/src/climate_ref/results/datasets.py
+++ b/packages/climate-ref/src/climate_ref/results/datasets.py
@@ -153,13 +153,14 @@ class DatasetsReader:
     keeps taking a bare slug, which is globally unique and needs no ``source_type``.
     """
 
-    def __init__(self, database: Database) -> None:
+    def __init__(self, database: Database, session: Session | None = None) -> None:
         self._db = database
+        self._session = session
 
     @property
     def session(self) -> Session:
         """The underlying database session."""
-        return self._db.session
+        return self._session if self._session is not None else self._db.session
 
     def _to_view(self, dataset: Dataset, *, include_files: bool) -> DatasetView:
         adapter = get_dataset_adapter(dataset.dataset_type.value)

--- a/packages/climate-ref/src/climate_ref/results/diagnostics.py
+++ b/packages/climate-ref/src/climate_ref/results/diagnostics.py
@@ -192,7 +192,7 @@ class DiagnosticsReader:
     All read methods return detached DTOs that outlive the session.
     """
 
-    def __init__(self, database: Database, session: Session | None = None) -> None:
+    def __init__(self, database: Database, *, session: Session | None = None) -> None:
         self._db = database
         self._session = session
 

--- a/packages/climate-ref/src/climate_ref/results/diagnostics.py
+++ b/packages/climate-ref/src/climate_ref/results/diagnostics.py
@@ -192,13 +192,14 @@ class DiagnosticsReader:
     All read methods return detached DTOs that outlive the session.
     """
 
-    def __init__(self, database: Database) -> None:
+    def __init__(self, database: Database, session: Session | None = None) -> None:
         self._db = database
+        self._session = session
 
     @property
     def session(self) -> Session:
         """The underlying database session."""
-        return self._db.session
+        return self._session if self._session is not None else self._db.session
 
     def _to_view(self, row: Any, stats_by_key: Mapping[tuple[str, str], ExecutionStats]) -> DiagnosticView:
         stat = stats_by_key.get((row.provider_slug, row.slug))

--- a/packages/climate-ref/src/climate_ref/results/executions.py
+++ b/packages/climate-ref/src/climate_ref/results/executions.py
@@ -400,13 +400,14 @@ class ExecutionsReader:
     All read methods return detached DTOs that outlive the session.
     """
 
-    def __init__(self, database: Database) -> None:
+    def __init__(self, database: Database, session: Session | None = None) -> None:
         self._db = database
+        self._session = session
 
     @property
     def session(self) -> Session:
         """The underlying database session."""
-        return self._db.session
+        return self._session if self._session is not None else self._db.session
 
     def _to_execution_view(self, execution: Execution) -> ExecutionView:
         return ExecutionView(

--- a/packages/climate-ref/src/climate_ref/results/executions.py
+++ b/packages/climate-ref/src/climate_ref/results/executions.py
@@ -400,7 +400,7 @@ class ExecutionsReader:
     All read methods return detached DTOs that outlive the session.
     """
 
-    def __init__(self, database: Database, session: Session | None = None) -> None:
+    def __init__(self, database: Database, *, session: Session | None = None) -> None:
         self._db = database
         self._session = session
 

--- a/packages/climate-ref/src/climate_ref/results/resources.py
+++ b/packages/climate-ref/src/climate_ref/results/resources.py
@@ -638,13 +638,14 @@ class ResourcesReader:
     All read methods return detached DTOs that outlive the session.
     """
 
-    def __init__(self, database: Database) -> None:
+    def __init__(self, database: Database, session: Session | None = None) -> None:
         self._db = database
+        self._session = session
 
     @property
     def session(self) -> Session:
         """The underlying database session."""
-        return self._db.session
+        return self._session if self._session is not None else self._db.session
 
     def _to_view(self, row: Any) -> ResourceMeasurementView:
         return ResourceMeasurementView(

--- a/packages/climate-ref/src/climate_ref/results/resources.py
+++ b/packages/climate-ref/src/climate_ref/results/resources.py
@@ -638,7 +638,7 @@ class ResourcesReader:
     All read methods return detached DTOs that outlive the session.
     """
 
-    def __init__(self, database: Database, session: Session | None = None) -> None:
+    def __init__(self, database: Database, *, session: Session | None = None) -> None:
         self._db = database
         self._session = session
 

--- a/packages/climate-ref/src/climate_ref/results/values.py
+++ b/packages/climate-ref/src/climate_ref/results/values.py
@@ -240,8 +240,8 @@ class ValuesReader:
     Constructed from a [Database][climate_ref.database.Database], which owns the session and the
     read-only story. All read methods return detached collections that outlive the session.
 
-    Pass ``session`` to read through a caller-owned session, for example one opened by
-    [Database.session_scope][climate_ref.database.Database.session_scope].
+    Pass ``session`` to read through a caller-owned session instead,
+    for example one opened by [Database.session_scope][climate_ref.database.Database.session_scope].
     """
 
     def __init__(self, database: Database, session: Session | None = None) -> None:
@@ -460,13 +460,13 @@ class Reader:
     (only available when a ``results`` root is supplied).
 
     By default every sub-reader queries through the database's long-lived session.
-    Pass ``session`` to read through a caller-owned session instead, for example one opened by
-    [Database.session_scope][climate_ref.database.Database.session_scope]. A concurrent caller
-    (a web request, a thread) should do that, because the long-lived session is not safe to share.
+    Pass ``session`` to read through a caller-owned session instead,
+    for example one opened by [Database.session_scope][climate_ref.database.Database.session_scope].
+    The sub-readers are cached, so a reader built this way must not outlive the scope it was given.
     """
 
     def __init__(
-        self, database: Database, results: Path | None = None, session: Session | None = None
+        self, database: Database, results: Path | None = None, *, session: Session | None = None
     ) -> None:
         self._db = database
         self._results = results

--- a/packages/climate-ref/src/climate_ref/results/values.py
+++ b/packages/climate-ref/src/climate_ref/results/values.py
@@ -244,7 +244,7 @@ class ValuesReader:
     for example one opened by [Database.session_scope][climate_ref.database.Database.session_scope].
     """
 
-    def __init__(self, database: Database, session: Session | None = None) -> None:
+    def __init__(self, database: Database, *, session: Session | None = None) -> None:
         self._db = database
         self._session = session
 
@@ -480,33 +480,33 @@ class Reader:
     @functools.cached_property
     def values(self) -> ValuesReader:
         """Metric-value reads (scalar/series/facets)."""
-        return ValuesReader(self._db, self._session)
+        return ValuesReader(self._db, session=self._session)
 
     @functools.cached_property
     def executions(self) -> ExecutionsReader:
         """Execution-group and execution reads."""
-        return ExecutionsReader(self._db, self._session)
+        return ExecutionsReader(self._db, session=self._session)
 
     @functools.cached_property
     def datasets(self) -> "DatasetsReader":
         """Dataset reads."""
         from climate_ref.results.datasets import DatasetsReader  # noqa: PLC0415
 
-        return DatasetsReader(self._db, self._session)
+        return DatasetsReader(self._db, session=self._session)
 
     @functools.cached_property
     def diagnostics(self) -> "DiagnosticsReader":
         """Diagnostic reads."""
         from climate_ref.results.diagnostics import DiagnosticsReader  # noqa: PLC0415
 
-        return DiagnosticsReader(self._db, self._session)
+        return DiagnosticsReader(self._db, session=self._session)
 
     @functools.cached_property
     def resources(self) -> "ResourcesReader":
         """Per-execution resource measurement reads."""
         from climate_ref.results.resources import ResourcesReader  # noqa: PLC0415
 
-        return ResourcesReader(self._db, self._session)
+        return ResourcesReader(self._db, session=self._session)
 
     @functools.cached_property
     def artifacts(self) -> "ArtifactsReader":

--- a/packages/climate-ref/src/climate_ref/results/values.py
+++ b/packages/climate-ref/src/climate_ref/results/values.py
@@ -239,15 +239,19 @@ class ValuesReader:
 
     Constructed from a [Database][climate_ref.database.Database], which owns the session and the
     read-only story. All read methods return detached collections that outlive the session.
+
+    Pass ``session`` to read through a caller-owned session, for example one opened by
+    [Database.session_scope][climate_ref.database.Database.session_scope].
     """
 
-    def __init__(self, database: Database) -> None:
+    def __init__(self, database: Database, session: Session | None = None) -> None:
         self._db = database
+        self._session = session
 
     @property
     def session(self) -> Session:
         """The underlying database session."""
-        return self._db.session
+        return self._session if self._session is not None else self._db.session
 
     def _facets(self, base_stmt: Any, entity: Any) -> tuple[Facet, ...]:
         facet_map = collect_facets(self.session, base_stmt, entity)
@@ -454,47 +458,55 @@ class Reader:
     measurements, and
     [artifacts][climate_ref.results.values.Reader.artifacts] for output path resolution
     (only available when a ``results`` root is supplied).
+
+    By default every sub-reader queries through the database's long-lived session.
+    Pass ``session`` to read through a caller-owned session instead, for example one opened by
+    [Database.session_scope][climate_ref.database.Database.session_scope]. A concurrent caller
+    (a web request, a thread) should do that, because the long-lived session is not safe to share.
     """
 
-    def __init__(self, database: Database, results: Path | None = None) -> None:
+    def __init__(
+        self, database: Database, results: Path | None = None, session: Session | None = None
+    ) -> None:
         self._db = database
         self._results = results
+        self._session = session
 
     @property
     def session(self) -> Session:
         """The underlying database session."""
-        return self._db.session
+        return self._session if self._session is not None else self._db.session
 
     @functools.cached_property
     def values(self) -> ValuesReader:
         """Metric-value reads (scalar/series/facets)."""
-        return ValuesReader(self._db)
+        return ValuesReader(self._db, self._session)
 
     @functools.cached_property
     def executions(self) -> ExecutionsReader:
         """Execution-group and execution reads."""
-        return ExecutionsReader(self._db)
+        return ExecutionsReader(self._db, self._session)
 
     @functools.cached_property
     def datasets(self) -> "DatasetsReader":
         """Dataset reads."""
         from climate_ref.results.datasets import DatasetsReader  # noqa: PLC0415
 
-        return DatasetsReader(self._db)
+        return DatasetsReader(self._db, self._session)
 
     @functools.cached_property
     def diagnostics(self) -> "DiagnosticsReader":
         """Diagnostic reads."""
         from climate_ref.results.diagnostics import DiagnosticsReader  # noqa: PLC0415
 
-        return DiagnosticsReader(self._db)
+        return DiagnosticsReader(self._db, self._session)
 
     @functools.cached_property
     def resources(self) -> "ResourcesReader":
         """Per-execution resource measurement reads."""
         from climate_ref.results.resources import ResourcesReader  # noqa: PLC0415
 
-        return ResourcesReader(self._db)
+        return ResourcesReader(self._db, self._session)
 
     @functools.cached_property
     def artifacts(self) -> "ArtifactsReader":

--- a/packages/climate-ref/tests/unit/results/test_results.py
+++ b/packages/climate-ref/tests/unit/results/test_results.py
@@ -437,6 +437,10 @@ class TestDetectScalarOutliers:
         assert all(v is False for v in flags.values())
 
 
+def _unusable_session(database):
+    raise AssertionError("the shared session must not be used when an explicit one was given")
+
+
 class TestReaderSession:
     def test_defaults_to_the_database_session(self, dal_db):
         reader = Reader(dal_db)
@@ -457,7 +461,12 @@ class TestReaderSession:
             assert reader.diagnostics.session is session
             assert reader.resources.session is session
 
-    def test_reads_through_an_explicit_session(self, dal_db):
+    def test_a_read_goes_through_the_explicit_session(self, dal_db, mocker):
+        expected = Reader(dal_db).values.scalar_values()
+
         with dal_db.session_scope() as session:
+            # Reaching for the shared session now fails, so the read can only use the scope's one.
+            mocker.patch.object(type(dal_db), "session", property(_unusable_session), create=True)
             values = Reader(dal_db, session=session).values.scalar_values()
-        assert len(values.items) > 0
+
+        assert len(values.items) == len(expected.items) > 0

--- a/packages/climate-ref/tests/unit/results/test_results.py
+++ b/packages/climate-ref/tests/unit/results/test_results.py
@@ -437,7 +437,7 @@ class TestDetectScalarOutliers:
         assert all(v is False for v in flags.values())
 
 
-def _unusable_session(database):
+def _shared_session_is_off_limits(database):
     raise AssertionError("the shared session must not be used when an explicit one was given")
 
 
@@ -466,7 +466,7 @@ class TestReaderSession:
 
         with dal_db.session_scope() as session:
             # Reaching for the shared session now fails, so the read can only use the scope's one.
-            mocker.patch.object(type(dal_db), "session", property(_unusable_session), create=True)
+            mocker.patch.object(type(dal_db), "session", property(_shared_session_is_off_limits), create=True)
             values = Reader(dal_db, session=session).values.scalar_values()
 
         assert len(values.items) == len(expected.items) > 0

--- a/packages/climate-ref/tests/unit/results/test_results.py
+++ b/packages/climate-ref/tests/unit/results/test_results.py
@@ -435,3 +435,29 @@ class TestDetectScalarOutliers:
         ]
         flags = _flags(scalars, min_n=4)
         assert all(v is False for v in flags.values())
+
+
+class TestReaderSession:
+    def test_defaults_to_the_database_session(self, dal_db):
+        reader = Reader(dal_db)
+        assert reader.session is dal_db.session
+        assert reader.values.session is dal_db.session
+        assert reader.executions.session is dal_db.session
+        assert reader.datasets.session is dal_db.session
+        assert reader.diagnostics.session is dal_db.session
+        assert reader.resources.session is dal_db.session
+
+    def test_an_explicit_session_is_used_by_every_sub_reader(self, dal_db):
+        with dal_db.session_scope() as session:
+            reader = Reader(dal_db, session=session)
+            assert reader.session is session
+            assert reader.values.session is session
+            assert reader.executions.session is session
+            assert reader.datasets.session is session
+            assert reader.diagnostics.session is session
+            assert reader.resources.session is session
+
+    def test_reads_through_an_explicit_session(self, dal_db):
+        with dal_db.session_scope() as session:
+            values = Reader(dal_db, session=session).values.scalar_values()
+        assert len(values.items) > 0

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -1,4 +1,5 @@
 import re
+import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -682,17 +683,41 @@ class TestMigrationStatus:
 class TestSessionScope:
     """Tests for ``Database.session_scope``."""
 
-    def test_concurrent_scopes_get_different_sessions(self, db):
+    def test_overlapping_scopes_get_different_sessions(self, db):
         with db.session_scope() as first, db.session_scope() as second:
             assert first is not second
             assert first is not db.session
             assert second is not db.session
 
+    def test_scopes_opened_from_separate_threads_get_different_sessions(self, db):
+        started = threading.Barrier(2, timeout=10)
+        sessions = []
+        lock = threading.Lock()
+
+        def open_scope():
+            with db.session_scope() as session:
+                with lock:
+                    sessions.append(session)
+                # Hold the scope open until the other thread has one too,
+                # so the two are genuinely live at the same moment.
+                started.wait()
+                assert session.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
+
+        threads = [threading.Thread(target=open_scope) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+
+        assert len(sessions) == 2
+        assert sessions[0] is not sessions[1]
+        assert db.session not in sessions
+
     def test_closing_one_scope_leaves_the_other_usable(self, db):
         with db.session_scope() as outer:
             with db.session_scope() as inner:
                 inner.execute(sqlalchemy.text("SELECT 1"))
-            # The inner scope has closed, so the outer one and the shared session keep working.
             assert outer.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
             assert db.session.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
 
@@ -703,7 +728,15 @@ class TestSessionScope:
         assert db._engine.pool is pool
         assert db.session.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
 
-    def test_exception_rolls_back_and_closes(self, db):
+    def test_connection_returns_to_the_pool_on_exit(self, db):
+        before = db._engine.pool.checkedout()
+        with db.session_scope() as session:
+            session.execute(sqlalchemy.text("SELECT 1"))
+            assert db._engine.pool.checkedout() == before + 1
+        assert db._engine.pool.checkedout() == before
+
+    def test_exception_rolls_back_and_closes(self, db, mocker):
+        rollback = mocker.spy(sqlalchemy.orm.Session, "rollback")
         db.session.add(Provider(slug="committed", name="Committed", version="v1"))
         db.session.commit()
 
@@ -716,6 +749,8 @@ class TestSessionScope:
                 raise RuntimeError("boom")
 
         assert escaped is not None
+        assert rollback.call_args_list[0].args[0] is escaped
         assert not escaped.in_transaction()
         assert db.session.query(Provider).filter_by(slug="rolled-back").first() is None
+        assert db.session.query(Provider).filter_by(slug="committed").first() is not None
         assert db.session.query(Provider).filter_by(slug="committed").first() is not None

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -680,6 +680,10 @@ class TestMigrationStatus:
         assert status["head"] != "not_the_head_rev"
 
 
+class _Cancelled(BaseException):
+    """Stands in for the cancellation error a dropped request raises."""
+
+
 class TestSessionScope:
     """Tests for ``Database.session_scope``."""
 
@@ -743,18 +747,21 @@ class TestSessionScope:
             assert db._engine.pool.checkedout() == before + 1
         assert db._engine.pool.checkedout() == before
 
-    def test_exception_rolls_back_and_closes(self, db, mocker):
+    @pytest.mark.parametrize("raised", [RuntimeError, _Cancelled])
+    def test_exception_rolls_back_and_closes(self, db, mocker, raised):
+        # _Cancelled derives from BaseException, as a cancelled request's error does,
+        # so narrowing the catch back to Exception fails this.
         rollback = mocker.spy(sqlalchemy.orm.Session, "rollback")
         db.session.add(Provider(slug="committed", name="Committed", version="v1"))
         db.session.commit()
 
         escaped = None
-        with pytest.raises(RuntimeError):
+        with pytest.raises(raised):
             with db.session_scope() as session:
                 escaped = session
                 session.add(Provider(slug="rolled-back", name="Rolled back", version="v1"))
                 session.flush()
-                raise RuntimeError("boom")
+                raise raised("boom")
 
         assert escaped is not None
         assert rollback.call_args_list[0].args[0] is escaped

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -677,3 +677,45 @@ class TestMigrationStatus:
         assert status["state"] is MigrationState.BEHIND
         assert status["current"] == "not_the_head_rev"
         assert status["head"] != "not_the_head_rev"
+
+
+class TestSessionScope:
+    """Tests for ``Database.session_scope``."""
+
+    def test_concurrent_scopes_get_different_sessions(self, db):
+        with db.session_scope() as first, db.session_scope() as second:
+            assert first is not second
+            assert first is not db.session
+            assert second is not db.session
+
+    def test_closing_one_scope_leaves_the_other_usable(self, db):
+        with db.session_scope() as outer:
+            with db.session_scope() as inner:
+                inner.execute(sqlalchemy.text("SELECT 1"))
+            # The inner scope has closed, so the outer one and the shared session keep working.
+            assert outer.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
+            assert db.session.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
+
+    def test_engine_is_not_disposed_on_exit(self, db):
+        pool = db._engine.pool
+        with db.session_scope() as session:
+            session.execute(sqlalchemy.text("SELECT 1"))
+        assert db._engine.pool is pool
+        assert db.session.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
+
+    def test_exception_rolls_back_and_closes(self, db):
+        db.session.add(Provider(slug="committed", name="Committed", version="v1"))
+        db.session.commit()
+
+        escaped = None
+        with pytest.raises(RuntimeError):
+            with db.session_scope() as session:
+                escaped = session
+                session.add(Provider(slug="rolled-back", name="Rolled back", version="v1"))
+                session.flush()
+                raise RuntimeError("boom")
+
+        assert escaped is not None
+        assert not escaped.in_transaction()
+        assert db.session.query(Provider).filter_by(slug="rolled-back").first() is None
+        assert db.session.query(Provider).filter_by(slug="committed").first() is not None

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -692,16 +692,23 @@ class TestSessionScope:
     def test_scopes_opened_from_separate_threads_get_different_sessions(self, db):
         started = threading.Barrier(2, timeout=10)
         sessions = []
+        failures = []
         lock = threading.Lock()
 
         def open_scope():
-            with db.session_scope() as session:
+            # A thread swallows its own exceptions, so anything that goes wrong here has to be
+            # carried back out and asserted on by the test body.
+            try:
+                with db.session_scope() as session:
+                    with lock:
+                        sessions.append(session)
+                    # Hold the scope open until the other thread has one too,
+                    # so the two are genuinely live at the same moment.
+                    started.wait()
+                    assert session.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
+            except BaseException as exc:
                 with lock:
-                    sessions.append(session)
-                # Hold the scope open until the other thread has one too,
-                # so the two are genuinely live at the same moment.
-                started.wait()
-                assert session.execute(sqlalchemy.text("SELECT 1")).scalar() == 1
+                    failures.append(exc)
 
         threads = [threading.Thread(target=open_scope) for _ in range(2)]
         for thread in threads:
@@ -710,6 +717,7 @@ class TestSessionScope:
             thread.join(timeout=10)
             assert not thread.is_alive()
 
+        assert failures == []
         assert len(sessions) == 2
         assert sessions[0] is not sessions[1]
         assert db.session not in sessions
@@ -752,5 +760,4 @@ class TestSessionScope:
         assert rollback.call_args_list[0].args[0] is escaped
         assert not escaped.in_transaction()
         assert db.session.query(Provider).filter_by(slug="rolled-back").first() is None
-        assert db.session.query(Provider).filter_by(slug="committed").first() is not None
         assert db.session.query(Provider).filter_by(slug="committed").first() is not None


### PR DESCRIPTION
Lets a caller get its own short-lived database session, while every existing caller keeps using the shared one unchanged.

`ref-app` currently works around the single long-lived `Database.session` by caching a `Database` per request and closing the session in a `finally`, which disposes the engine and its pool along with it. This gives it a proper seam instead.

- `Database` builds one `sessionmaker` bound to the existing `self._engine`, so the engine and its pool stay shared and only sessions become per-caller.
- `Database.session_scope()` hands out a fresh session, rolls back on exception, and always closes so the connection returns to the pool. It leaves `self.session` and the engine alone. The catch is `BaseException`, so a cancelled request rolls back too.
- `Reader` and its five sub-readers take a keyword-only `session`, threaded through the `cached_property` accessors. With `session=None` they fall back to `self._db.session`, which is today's behaviour. The sub-readers are cached, so a reader built this way must not outlive its scope.

`Database.session` is unchanged, so nothing in `solver.py`, `executor/*`, `datasets/*` or celery needed touching.

`get_or_create` and `update_or_create` still hardcode `self.session`. They are writer-path and `ref-app` is read-only, so threading a session through them buys nothing yet.

Worth flagging: the `# TODO: Set autobegin=False` above the `Session(...)` line is the same root cause, but it changes behaviour for every existing caller, so it is out of scope here.

## Follow-up in ref-app

`deps.py` becomes a shared `Database` singleton plus a request dependency that opens a `session_scope()` and builds the `Reader` with that session. The `_database_cache` dict and the `finally: database.session.close()` both go away.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added short-lived database sessions that automatically roll back failed operations and close safely.
  * Readers can now use isolated sessions for concurrent or independent reads.
  * Existing shared database session behaviour remains supported.

* **Documentation**
  * Documented session lifecycle requirements and usage.

* **Tests**
  * Added coverage for session isolation, rollback, cleanup, nesting and reader session propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->