### PR TITLE
ci: skip the changelog check on renovate PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,7 +207,7 @@ jobs:
   # Only runs on pull requests
   check-for-changelog:
     runs-on: ubuntu-latest
-    if: github.event.pull_request && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     steps:
       - name: Check out repository
         uses: actions/checkout@v7

--- a/changelog/878.trivial.md
+++ b/changelog/878.trivial.md
@@ -1,0 +1,1 @@
+Exempted Renovate pull requests from the changelog check, as Dependabot already was.


### PR DESCRIPTION
Skips the changelog check on renovate PRs.

The `check-for-changelog` job already exempted dependabot. Renovate opens the same shape of PR here (a `uv.lock` bump, or a GitHub action version bump) and none of them carry anything worth a release note, so the job just fails and someone hand-writes a fragment nobody reads.

I looked at whether anything else could be skipped for renovate and concluded no:

- `provider-compat.yml` and the `packaging.yaml` helm jobs already skip them, because both are path-filtered to paths a renovate PR never touches.
- `regression-pr-gate.yaml` should keep running. A numpy or xarray bump moving a diagnostic number is exactly what that gate exists to catch, and the renovate grouping rules are built around keeping those bumps reviewable.
- The test, build and smoke jobs should keep running for the same reason. Catching a broken dependency bump is the whole point of running CI on one.

So the changelog check was the only genuinely pointless job.
