### PR TITLE
Bound the provider compatibility jobs to 20 minutes

### DIFF
--- a/.github/workflows/provider-compat.yml
+++ b/.github/workflows/provider-compat.yml
@@ -37,6 +37,7 @@ concurrency:
 jobs:
   provider-compat:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The pmp job in Provider Compatibility hung twice on #880, once for 21 hours, printing no output past the command line. It is the only provider whose unit tests download reference data (`packages/climate-ref-pmp/conftest.py` fetches the `pmp-climatology` registry from obs4ref), pooch is used without a socket timeout, and the registry retries ten times. A stalled download therefore runs until GitHub's default six hour limit. This adds an explicit 20 minute cap so a stalled fetch fails fast instead of holding a runner. The jobs currently finish in one to four minutes, so there is plenty of headroom. This won't stop the stall itself, but it stops it eating a runner for the rest of the day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the provider compatibility check timeout to 20 minutes, allowing longer-running checks to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->