### PR TITLE
Report the baseline diff after a mint

### DIFF
--- a/.github/workflows/regression-mint.yaml
+++ b/.github/workflows/regression-mint.yaml
@@ -169,19 +169,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          # Two reports: the full one is small enough to keep as an artefact whatever the mint's
+          # size, while the capped one fits the comment and job-summary limits.
           uv run python scripts/ci/mint_diff.py \
             --base "origin/${DEFAULT_BRANCH}" \
-            --output mint-diff.md
+            --output mint-diff.md \
+            --comment-output mint-diff-comment.md
 
-          # The job summary always gets the report, whether or not a pull request exists.
-          cat mint-diff.md >> "${GITHUB_STEP_SUMMARY}"
+          # The job summary always gets a report, whether or not a pull request exists.
+          cat mint-diff-comment.md >> "${GITHUB_STEP_SUMMARY}"
 
           pr="$(gh pr list --head "${GITHUB_REF_NAME}" --state open --json number --jq '.[0].number')"
           if [ -z "${pr}" ]; then
             echo "No open pull request for ${GITHUB_REF_NAME}; the report is in the job summary only."
             exit 0
           fi
-          gh pr comment "${pr}" --body-file mint-diff.md
+          gh pr comment "${pr}" --body-file mint-diff-comment.md
       - name: Upload the full baseline diff
         # The comment is capped at GitHub's 65 KB limit, so keep the untruncated report too.
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/regression-mint.yaml
+++ b/.github/workflows/regression-mint.yaml
@@ -35,9 +35,11 @@ on:
         type: boolean
         default: false
 
-# Needed to commit the regenerated manifest/bundle back to the dispatched branch.
+# `contents` to commit the regenerated manifest/bundle back to the dispatched branch,
+# `pull-requests` to post the baseline diff on the branch's open pull request.
 permissions:
   contents: write
+  pull-requests: write
 
 # Never cancel an in-flight mint: it performs object-store writes and a push.
 concurrency:
@@ -67,6 +69,9 @@ jobs:
           exit 1
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          # Full history so the baseline diff can find the merge-base with the default branch.
+          fetch-depth: 0
       - uses: ./.github/actions/setup
         with:
           python-version: "3.13"
@@ -109,6 +114,13 @@ jobs:
           if [ "${BUMP_VERSION}" = "true" ]; then args+=(--bump-version); fi
           if [ "${DRY_RUN}" = "true" ]; then args+=(--dry-run); fi
           uv run ref test-cases mint "${args[@]}"
+      - name: Fetch the default branch for the baseline diff
+        if: ${{ !inputs.dry_run }}
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
       - name: Commit regenerated baselines
         if: ${{ !inputs.dry_run }}
         env:
@@ -148,3 +160,34 @@ jobs:
           done
           echo "::error::failed to push regenerated baselines after retries"
           exit 1
+      - name: Report the baseline diff
+        # Runs after the commit so HEAD carries the regenerated manifests.
+        # Reporting only, so a failure here must not fail an otherwise successful mint.
+        if: ${{ !inputs.dry_run }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          uv run python scripts/ci/mint_diff.py \
+            --base "origin/${DEFAULT_BRANCH}" \
+            --output mint-diff.md
+
+          # The job summary always gets the report, whether or not a pull request exists.
+          cat mint-diff.md >> "${GITHUB_STEP_SUMMARY}"
+
+          pr="$(gh pr list --head "${GITHUB_REF_NAME}" --state open --json number --jq '.[0].number')"
+          if [ -z "${pr}" ]; then
+            echo "No open pull request for ${GITHUB_REF_NAME}; the report is in the job summary only."
+            exit 0
+          fi
+          gh pr comment "${pr}" --body-file mint-diff.md
+      - name: Upload the full baseline diff
+        # The comment is capped at GitHub's 65 KB limit, so keep the untruncated report too.
+        if: ${{ !inputs.dry_run }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: mint-diff
+          path: mint-diff.md
+          if-no-files-found: ignore

--- a/scripts/ci/mint_diff.py
+++ b/scripts/ci/mint_diff.py
@@ -394,6 +394,21 @@ def render_case(diff: CaseDiff, store_url: str) -> str:
     return "".join(out)
 
 
+def _omission_notice(remaining: list[CaseDiff], budget: int) -> str:
+    """
+    Render the notice naming the cases whose detail did not fit.
+
+    Falls back to a bare count when the labels themselves would not fit ``budget``, because a
+    notice that overflows the limit costs the entire comment rather than just its own text.
+    """
+    tail = "\n_The full report is attached to the workflow run as the `mint-diff` artefact._\n"
+    labels = ", ".join(f"`{d.label}`" for d in remaining)
+    listed = f"\n_Detail omitted to fit the comment size limit: {labels}._\n{tail}"
+    if _utf8_len(listed) <= budget:
+        return listed
+    return f"\n_Detail omitted for {len(remaining)} further case(s) to fit the comment size limit._\n{tail}"
+
+
 def render(diffs: list[CaseDiff], base: str, store_url: str, max_bytes: int | None = None) -> str:
     """
     Render the whole report.
@@ -410,24 +425,29 @@ def render(diffs: list[CaseDiff], base: str, store_url: str, max_bytes: int | No
 
     diffs = sorted(diffs, key=lambda d: d.label)
     total = sum(len(d.native) for d in diffs)
-    header = (
+    preamble = (
         "### Regression baseline diff\n\n"
         f"{len(diffs)} test case(s) and {total} native file(s) changed against `{base}`. "
         "Text outputs are diffed inline. NetCDF and PNG outputs are listed with a size delta "
         "and a link to each blob.\n\n"
-        f"{render_summary(diffs)}\n"
     )
+    header = f"{preamble}{render_summary(diffs)}\n"
+
+    if max_bytes is not None and _utf8_len(header) > max_bytes:
+        # Enough cases that even the summary overflows. Keep the preamble and point at the
+        # artefact, because posting a comment that names nothing beats posting none at all.
+        return preamble + _omission_notice(diffs, max_bytes - _utf8_len(preamble))
+
+    # Hold back part of the budget for the omission notice. Without it the notice can push the
+    # report past the limit, and `gh pr comment` then rejects the whole thing.
+    notice_budget = max_bytes // 10 if max_bytes is not None else 0
 
     used = _utf8_len(header)
     body = ""
     for index, diff in enumerate(diffs):
         section = render_case(diff, store_url)
-        if max_bytes is not None and used + _utf8_len(section) > max_bytes:
-            remaining = ", ".join(f"`{d.label}`" for d in diffs[index:])
-            body += (
-                f"\n_Detail omitted to fit the comment size limit: {remaining}._\n"
-                "\n_The full report is attached to the workflow run as the `mint-diff` artefact._\n"
-            )
+        if max_bytes is not None and used + _utf8_len(section) > max_bytes - notice_budget:
+            body += _omission_notice(diffs[index:], notice_budget)
             break
         body += section
         used += _utf8_len(section)

--- a/scripts/ci/mint_diff.py
+++ b/scripts/ci/mint_diff.py
@@ -320,12 +320,11 @@ def render_summary(diffs: list[CaseDiff]) -> str:
     """
     rows = ["| case | versions | native files |\n| --- | --- | --- |\n"]
     for diff in diffs:
-        if diff.is_new:
+        base_manifest = diff.base
+        if base_manifest is None:
             versions = "new"
         else:
-            base = diff.base  # narrowed by is_new
-            assert base is not None
-            versions = f"v{base.test_case_version} -> v{diff.head.test_case_version}"
+            versions = f"v{base_manifest.test_case_version} -> v{diff.head.test_case_version}"
         rows.append(f"| `{diff.label}` | {versions} | {_counts(diff)} |\n")
     return "".join(rows)
 

--- a/scripts/ci/mint_diff.py
+++ b/scripts/ci/mint_diff.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python
+"""
+Render a human-readable diff of the regression baselines changed on a branch.
+
+A mint rewrites each test case's ``manifest.json`` and uploads the curated native outputs to the
+content-addressed object store.
+The manifest diff therefore names every native file that changed, and both the old and the new blob
+remain fetchable by digest, so the change can be reviewed without checking anything out locally.
+
+Text outputs (JSON, CSV, YAML, HTML) are fetched from the store and rendered as a unified diff.
+Binary outputs (NetCDF, PNG) are reported by size delta and linked, because a byte diff would be noise.
+
+Usage:
+  uv run python scripts/ci/mint_diff.py [--base origin/main] [--output summary.md]
+
+  --base        git ref to compare against. Defaults to origin/${GITHUB_BASE_REF:-main}.
+  --output      write the markdown here as well as to stdout.
+  --store-url   base URL of the native store. Defaults to $REF_NATIVE_STORE_URL.
+  --no-fetch    skip all network access and report size deltas only.
+
+Exits 0 whether or not anything changed. This reports, it does not gate.
+"""
+
+import argparse
+import difflib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from git import GitCommandError, Repo
+
+from climate_ref_core.regression.manifest import Manifest, NativeEntry
+
+DEFAULT_STORE_URL = "https://baselines.climate-ref.org"
+
+# Cloudflare serves a 403 to the stdlib default agent, so identify the script instead.
+USER_AGENT = "climate-ref-mint-diff"
+
+# A manifest path needs a diagnostic and test-case directory before a label can be built from it.
+_MIN_LABEL_PARTS = 3
+
+# Extensions whose blobs are worth fetching and diffing line by line.
+TEXT_SUFFIXES = frozenset({".json", ".csv", ".yml", ".yaml", ".html", ".txt", ".md", ".log"})
+
+# A blob larger than this is summarised rather than diffed. Keeps a runaway HTML report
+# from stalling the job on the download alone.
+MAX_FETCH_BYTES = 2_000_000
+
+# Unified-diff lines kept per file before the rest is elided.
+MAX_DIFF_LINES = 200
+
+# Binary rows listed per case before the rest is elided. A large ILAMB or PMP case emits
+# hundreds of plots, and the per-file size delta stops being informative long before then.
+MAX_BINARY_ROWS = 30
+
+# GitHub rejects a comment body over 65536 bytes, so leave headroom for the truncation notice.
+MAX_COMMENT_BYTES = 60_000
+
+
+def open_repo() -> Repo:
+    """Return the repository containing the current directory."""
+    return Repo(Path.cwd(), search_parent_directories=True)
+
+
+def changed_manifests(repo: Repo, base: str) -> list[str]:
+    """
+    Return the repo-relative paths of every test-case manifest that differs from ``base``.
+
+    Uses the merge-base (``base...HEAD``) so commits landing on the base branch after the
+    feature branch forked are not misreported as baseline changes.
+    """
+    pathspec = ":(glob)packages/**/test-data/**/manifest.json"
+    try:
+        out = repo.git.diff("--name-only", f"{base}...HEAD", "--", pathspec)
+    except GitCommandError:
+        # A shallow clone may have no merge-base with the base ref. A two-dot diff over-reports
+        # (it also shows base-branch commits), which is the safe direction for a report.
+        out = repo.git.diff("--name-only", base, "HEAD", "--", pathspec)
+    return sorted(line for line in out.splitlines() if line.strip())
+
+
+def load_at_ref(repo: Repo, ref: str, rel_path: str) -> Manifest | None:
+    """Load a manifest as it exists at ``ref``, or ``None`` when absent there."""
+    try:
+        text = repo.git.show(f"{ref}:{rel_path}")
+    except GitCommandError:
+        return None
+    return Manifest.loads(text, source=f"{ref}:{rel_path}")
+
+
+def case_label(rel_path: str) -> str:
+    """
+    Derive a ``provider/diagnostic/test-case`` label from a manifest path.
+
+    ``packages/climate-ref-pmp/tests/test-data/annual-cycle/cmip6-ts/manifest.json``
+    becomes ``pmp/annual-cycle/cmip6-ts``.
+    """
+    parts = Path(rel_path).parts
+    provider = parts[1].removeprefix("climate-ref-") if len(parts) > 1 else "?"
+    tail = parts[-3:-1] if len(parts) >= _MIN_LABEL_PARTS else ()
+    return "/".join((provider, *tail))
+
+
+@dataclass
+class FileChange:
+    """One native output file that was added, removed, or changed by the mint."""
+
+    name: str
+    old: NativeEntry | None
+    new: NativeEntry | None
+    diff: str | None = None
+    note: str | None = None
+
+    @property
+    def status(self) -> str:
+        """``added``, ``removed`` or ``changed``."""
+        if self.old is None:
+            return "added"
+        if self.new is None:
+            return "removed"
+        return "changed"
+
+    @property
+    def is_text(self) -> bool:
+        """Whether this file's contents are worth diffing line by line."""
+        return Path(self.name).suffix.lower() in TEXT_SUFFIXES
+
+
+@dataclass
+class CaseDiff:
+    """Everything that changed for a single test case."""
+
+    label: str
+    rel_path: str
+    base: Manifest | None
+    head: Manifest
+    native: list[FileChange] = field(default_factory=list)
+    committed: list[str] = field(default_factory=list)
+    metadata: list[str] = field(default_factory=list)
+
+    @property
+    def is_new(self) -> bool:
+        """Whether the whole test case is new on this branch."""
+        return self.base is None
+
+
+def _metadata_changes(base: Manifest | None, head: Manifest) -> list[str]:
+    """Describe the scalar manifest fields that moved."""
+    if base is None:
+        return [f"new test case at `test_case_version` {head.test_case_version}"]
+    changes = []
+    for name in ("test_case_version", "diagnostic_version", "catalog_hash", "schema"):
+        old, new = getattr(base, name), getattr(head, name)
+        if old != new:
+            changes.append(f"`{name}`: `{old}` -> `{new}`")
+    return changes
+
+
+def _committed_changes(base: Manifest | None, head: Manifest) -> list[str]:
+    """Name the committed regression artefacts whose digest moved."""
+    old = base.committed if base else {}
+    names = sorted(set(old) | set(head.committed))
+    out = []
+    for name in names:
+        if old.get(name) != head.committed.get(name):
+            if name not in old:
+                out.append(f"`{name}` (added)")
+            elif name not in head.committed:
+                out.append(f"`{name}` (removed)")
+            else:
+                out.append(f"`{name}`")
+    return out
+
+
+def _fetch(store_url: str, digest: str) -> tuple[bytes | None, str]:
+    """
+    Fetch a blob by digest.
+
+    Returns a ``(payload, reason)`` pair, where ``payload`` is ``None`` on failure and
+    ``reason`` describes it. Cloudflare rejects the stdlib default agent, so one is set.
+    """
+    url = f"{store_url.rstrip('/')}/{digest}"
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})  # noqa: S310
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310
+            return response.read(MAX_FETCH_BYTES + 1), ""
+    except urllib.error.HTTPError as exc:
+        return None, f"store returned HTTP {exc.code}"
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return None, f"store unreachable ({exc})"
+
+
+def _as_lines(raw: bytes, name: str) -> list[str]:
+    """
+    Decode a blob into diffable lines.
+
+    JSON is re-serialised with indentation first, because a minified bundle would otherwise
+    diff as a single unreadable line.
+    """
+    text = raw.decode("utf-8", errors="replace")
+    if Path(name).suffix.lower() == ".json":
+        try:
+            text = json.dumps(json.loads(text), indent=2, sort_keys=True)
+        except json.JSONDecodeError:
+            pass
+    return text.splitlines()
+
+
+def _text_diff(store_url: str, change: FileChange) -> tuple[str | None, str | None]:
+    """
+    Build the unified diff for one text file.
+
+    Returns a ``(diff, note)`` pair. Exactly one is set: ``note`` explains why no diff
+    could be produced (too large, or the store did not serve a blob).
+    """
+    for entry in (change.old, change.new):
+        if entry is not None and entry.size > MAX_FETCH_BYTES:
+            return None, f"too large to diff ({entry.size:,} B)"
+
+    old_raw, old_reason = _fetch(store_url, change.old.sha256) if change.old else (b"", "")
+    new_raw, new_reason = _fetch(store_url, change.new.sha256) if change.new else (b"", "")
+    if old_raw is None or new_raw is None:
+        return None, old_reason or new_reason
+
+    lines = list(
+        difflib.unified_diff(
+            _as_lines(old_raw, change.name),
+            _as_lines(new_raw, change.name),
+            fromfile=f"old {change.old.sha256[:12] if change.old else '(absent)'}",
+            tofile=f"new {change.new.sha256[:12] if change.new else '(absent)'}",
+            lineterm="",
+            n=3,
+        )
+    )
+    if not lines:
+        return None, "identical after decoding"
+    if len(lines) > MAX_DIFF_LINES:
+        elided = len(lines) - MAX_DIFF_LINES
+        lines = [*lines[:MAX_DIFF_LINES], f"... {elided:,} more diff line(s) elided"]
+    return "\n".join(lines), None
+
+
+def build_case_diff(repo: Repo, base: str, rel_path: str, store_url: str, fetch: bool) -> CaseDiff | None:
+    """Collect every change to one test case, or ``None`` if its manifest was deleted."""
+    head_path = Path(repo.working_tree_dir or ".") / rel_path
+    if not head_path.exists():
+        return None
+    head = Manifest.load(head_path)
+    base_manifest = load_at_ref(repo, base, rel_path)
+
+    diff = CaseDiff(
+        label=case_label(rel_path),
+        rel_path=rel_path,
+        base=base_manifest,
+        head=head,
+        committed=_committed_changes(base_manifest, head),
+        metadata=_metadata_changes(base_manifest, head),
+    )
+
+    old_native = base_manifest.native if base_manifest else {}
+    for name in sorted(set(old_native) | set(head.native)):
+        old, new = old_native.get(name), head.native.get(name)
+        if old is not None and new is not None and old.sha256 == new.sha256:
+            continue
+        change = FileChange(name=name, old=old, new=new)
+        if change.is_text:
+            if fetch:
+                change.diff, change.note = _text_diff(store_url, change)
+            else:
+                change.note = "fetching disabled"
+        diff.native.append(change)
+
+    return diff
+
+
+def _size_delta(change: FileChange) -> str:
+    """Render the size column for a native file."""
+    if change.old is None:
+        return f"{change.new.size:,} B"  # type: ignore[union-attr]
+    if change.new is None:
+        return f"was {change.old.size:,} B"
+    delta = change.new.size - change.old.size
+    return f"{change.old.size:,} -> {change.new.size:,} B ({delta:+,})"
+
+
+def _blob_links(store_url: str, change: FileChange) -> str:
+    """Render download links for whichever blobs exist."""
+    root = store_url.rstrip("/")
+    links = []
+    if change.old:
+        links.append(f"[old]({root}/{change.old.sha256})")
+    if change.new:
+        links.append(f"[new]({root}/{change.new.sha256})")
+    return " ".join(links)
+
+
+def _counts(diff: CaseDiff) -> str:
+    """Summarise a case's native changes as a short ``+a ~c -r`` string."""
+    tally = {"added": 0, "changed": 0, "removed": 0}
+    for change in diff.native:
+        tally[change.status] += 1
+    parts = [
+        f"+{tally['added']}" if tally["added"] else "",
+        f"~{tally['changed']}" if tally["changed"] else "",
+        f"-{tally['removed']}" if tally["removed"] else "",
+    ]
+    return " ".join(p for p in parts if p) or "none"
+
+
+def render_summary(diffs: list[CaseDiff]) -> str:
+    """
+    Render the one-row-per-case overview table.
+
+    Every changed case appears here, whether or not its detail section survives the size cap,
+    so nothing is silently invisible.
+    """
+    rows = ["| case | versions | native files |\n| --- | --- | --- |\n"]
+    for diff in diffs:
+        if diff.is_new:
+            versions = "new"
+        else:
+            base = diff.base  # narrowed by is_new
+            assert base is not None
+            versions = f"v{base.test_case_version} -> v{diff.head.test_case_version}"
+        rows.append(f"| `{diff.label}` | {versions} | {_counts(diff)} |\n")
+    return "".join(rows)
+
+
+def render_case(diff: CaseDiff, store_url: str) -> str:
+    """Render one test case as a collapsible markdown section."""
+    text_changes = [c for c in diff.native if c.is_text]
+    binary_changes = [c for c in diff.native if not c.is_text]
+    headline = f"{len(diff.native)} native file(s)"
+    if diff.is_new:
+        headline = f"new case, {headline}"
+
+    out = [f"<details>\n<summary><b>{diff.label}</b> -- {headline}</summary>\n"]
+
+    if diff.metadata:
+        out.append("".join(f"- {line}\n" for line in diff.metadata))
+    if diff.committed:
+        out.append(f"\nCommitted artefacts changed: {', '.join(diff.committed)}\n")
+
+    if binary_changes:
+        out.append("\n| file | status | size | blobs |\n| --- | --- | --- | --- |\n")
+        for change in binary_changes[:MAX_BINARY_ROWS]:
+            out.append(
+                f"| `{change.name}` | {change.status} | {_size_delta(change)} "
+                f"| {_blob_links(store_url, change)} |\n"
+            )
+        if len(binary_changes) > MAX_BINARY_ROWS:
+            elided = len(binary_changes) - MAX_BINARY_ROWS
+            out.append(f"\n_{elided} further binary file(s) not listed._\n")
+
+    for change in text_changes:
+        out.append(f"\n**`{change.name}`** ({change.status}, {_size_delta(change)})")
+        if change.diff:
+            out.append(f"\n\n```diff\n{change.diff}\n```\n")
+        else:
+            out.append(f" -- {change.note}, {_blob_links(store_url, change)}\n")
+
+    out.append("\n</details>\n")
+    return "".join(out)
+
+
+def render(diffs: list[CaseDiff], base: str, store_url: str) -> str:
+    """
+    Render the whole report.
+
+    The summary table always covers every case. Detail sections are appended until the
+    GitHub comment size limit is in sight, then the remainder is named rather than expanded.
+    """
+    if not diffs:
+        return f"### Regression baseline diff\n\nNo baseline manifests changed against `{base}`.\n"
+
+    diffs = sorted(diffs, key=lambda d: d.label)
+    total = sum(len(d.native) for d in diffs)
+    header = (
+        "### Regression baseline diff\n\n"
+        f"{len(diffs)} test case(s) and {total} native file(s) changed against `{base}`. "
+        "Text outputs are diffed inline. NetCDF and PNG outputs are listed with a size delta "
+        "and a link to each blob.\n\n"
+        f"{render_summary(diffs)}\n"
+    )
+
+    body = ""
+    for index, diff in enumerate(diffs):
+        section = render_case(diff, store_url)
+        if len(header) + len(body) + len(section) > MAX_COMMENT_BYTES:
+            remaining = ", ".join(f"`{d.label}`" for d in diffs[index:])
+            body += f"\n_Detail omitted to fit the comment size limit: {remaining}._\n"
+            break
+        body += section
+    return header + body
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=f"origin/{os.environ.get('GITHUB_BASE_REF', 'main')}")
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--store-url", default=os.environ.get("REF_NATIVE_STORE_URL", DEFAULT_STORE_URL))
+    parser.add_argument("--no-fetch", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo = open_repo()
+    diffs = []
+    for rel_path in changed_manifests(repo, args.base):
+        diff = build_case_diff(repo, args.base, rel_path, args.store_url, fetch=not args.no_fetch)
+        if diff is not None:
+            diffs.append(diff)
+
+    markdown = render(diffs, args.base, args.store_url)
+    sys.stdout.write(markdown)
+    if args.output:
+        args.output.write_text(markdown, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/mint_diff.py
+++ b/scripts/ci/mint_diff.py
@@ -13,10 +13,11 @@ Binary outputs (NetCDF, PNG) are reported by size delta and linked, because a by
 Usage:
   uv run python scripts/ci/mint_diff.py [--base origin/main] [--output summary.md]
 
-  --base        git ref to compare against. Defaults to origin/${GITHUB_BASE_REF:-main}.
-  --output      write the markdown here as well as to stdout.
-  --store-url   base URL of the native store. Defaults to $REF_NATIVE_STORE_URL.
-  --no-fetch    skip all network access and report size deltas only.
+  --base            git ref to compare against. Defaults to origin/${GITHUB_BASE_REF:-main}.
+  --output          write the full, uncapped report here as well as to stdout.
+  --comment-output  write a copy capped to GitHub's comment size limit here.
+  --store-url       base URL of the native store. Defaults to $REF_NATIVE_STORE_URL.
+  --no-fetch        skip all network access and report size deltas only.
 
 Exits 0 whether or not anything changed. This reports, it does not gate.
 """
@@ -137,7 +138,7 @@ class CaseDiff:
     label: str
     rel_path: str
     base: Manifest | None
-    head: Manifest
+    head: Manifest | None
     native: list[FileChange] = field(default_factory=list)
     committed: list[str] = field(default_factory=list)
     metadata: list[str] = field(default_factory=list)
@@ -147,9 +148,16 @@ class CaseDiff:
         """Whether the whole test case is new on this branch."""
         return self.base is None
 
+    @property
+    def is_removed(self) -> bool:
+        """Whether the whole test case was deleted on this branch."""
+        return self.head is None
 
-def _metadata_changes(base: Manifest | None, head: Manifest) -> list[str]:
+
+def _metadata_changes(base: Manifest | None, head: Manifest | None) -> list[str]:
     """Describe the scalar manifest fields that moved."""
+    if head is None:
+        return ["test case removed"]
     if base is None:
         return [f"new test case at `test_case_version` {head.test_case_version}"]
     changes = []
@@ -160,16 +168,17 @@ def _metadata_changes(base: Manifest | None, head: Manifest) -> list[str]:
     return changes
 
 
-def _committed_changes(base: Manifest | None, head: Manifest) -> list[str]:
+def _committed_changes(base: Manifest | None, head: Manifest | None) -> list[str]:
     """Name the committed regression artefacts whose digest moved."""
     old = base.committed if base else {}
-    names = sorted(set(old) | set(head.committed))
+    new = head.committed if head else {}
+    names = sorted(set(old) | set(new))
     out = []
     for name in names:
-        if old.get(name) != head.committed.get(name):
+        if old.get(name) != new.get(name):
             if name not in old:
                 out.append(f"`{name}` (added)")
-            elif name not in head.committed:
+            elif name not in new:
                 out.append(f"`{name}` (removed)")
             else:
                 out.append(f"`{name}`")
@@ -245,12 +254,18 @@ def _text_diff(store_url: str, change: FileChange) -> tuple[str | None, str | No
 
 
 def build_case_diff(repo: Repo, base: str, rel_path: str, store_url: str, fetch: bool) -> CaseDiff | None:
-    """Collect every change to one test case, or ``None`` if its manifest was deleted."""
+    """
+    Collect every change to one test case.
+
+    A case deleted on this branch has no head manifest. It is still reported, as a removal,
+    because dropping a test case is a baseline change a reviewer needs to see.
+    Returns ``None`` only when the manifest is absent from both sides, which leaves nothing to say.
+    """
     head_path = Path(repo.working_tree_dir or ".") / rel_path
-    if not head_path.exists():
-        return None
-    head = Manifest.load(head_path)
+    head = Manifest.load(head_path) if head_path.exists() else None
     base_manifest = load_at_ref(repo, base, rel_path)
+    if head is None and base_manifest is None:
+        return None
 
     diff = CaseDiff(
         label=case_label(rel_path),
@@ -262,8 +277,9 @@ def build_case_diff(repo: Repo, base: str, rel_path: str, store_url: str, fetch:
     )
 
     old_native = base_manifest.native if base_manifest else {}
-    for name in sorted(set(old_native) | set(head.native)):
-        old, new = old_native.get(name), head.native.get(name)
+    new_native = head.native if head else {}
+    for name in sorted(set(old_native) | set(new_native)):
+        old, new = old_native.get(name), new_native.get(name)
         if old is not None and new is not None and old.sha256 == new.sha256:
             continue
         change = FileChange(name=name, old=old, new=new)
@@ -298,6 +314,11 @@ def _blob_links(store_url: str, change: FileChange) -> str:
     return " ".join(links)
 
 
+def _utf8_len(text: str) -> int:
+    """Return the UTF-8 byte length of ``text``, which is what GitHub's comment limit measures."""
+    return len(text.encode("utf-8"))
+
+
 def _counts(diff: CaseDiff) -> str:
     """Summarise a case's native changes as a short ``+a ~c -r`` string."""
     tally = {"added": 0, "changed": 0, "removed": 0}
@@ -320,11 +341,13 @@ def render_summary(diffs: list[CaseDiff]) -> str:
     """
     rows = ["| case | versions | native files |\n| --- | --- | --- |\n"]
     for diff in diffs:
-        base_manifest = diff.base
-        if base_manifest is None:
+        base_manifest, head_manifest = diff.base, diff.head
+        if head_manifest is None:
+            versions = "removed"
+        elif base_manifest is None:
             versions = "new"
         else:
-            versions = f"v{base_manifest.test_case_version} -> v{diff.head.test_case_version}"
+            versions = f"v{base_manifest.test_case_version} -> v{head_manifest.test_case_version}"
         rows.append(f"| `{diff.label}` | {versions} | {_counts(diff)} |\n")
     return "".join(rows)
 
@@ -334,7 +357,9 @@ def render_case(diff: CaseDiff, store_url: str) -> str:
     text_changes = [c for c in diff.native if c.is_text]
     binary_changes = [c for c in diff.native if not c.is_text]
     headline = f"{len(diff.native)} native file(s)"
-    if diff.is_new:
+    if diff.is_removed:
+        headline = f"removed case, {headline}"
+    elif diff.is_new:
         headline = f"new case, {headline}"
 
     out = [f"<details>\n<summary><b>{diff.label}</b> -- {headline}</summary>\n"]
@@ -366,12 +391,16 @@ def render_case(diff: CaseDiff, store_url: str) -> str:
     return "".join(out)
 
 
-def render(diffs: list[CaseDiff], base: str, store_url: str) -> str:
+def render(diffs: list[CaseDiff], base: str, store_url: str, max_bytes: int | None = None) -> str:
     """
     Render the whole report.
 
-    The summary table always covers every case. Detail sections are appended until the
-    GitHub comment size limit is in sight, then the remainder is named rather than expanded.
+    The summary table always covers every case. When ``max_bytes`` is set, detail sections are
+    appended only while the encoded report stays under it and the remainder is named rather than
+    expanded. Pass ``None`` for the full report, which is what the workflow artefact carries.
+
+    The budget counts UTF-8 bytes rather than characters, because that is what GitHub's comment
+    limit measures and a diff may carry non-ASCII content.
     """
     if not diffs:
         return f"### Regression baseline diff\n\nNo baseline manifests changed against `{base}`.\n"
@@ -386,14 +415,19 @@ def render(diffs: list[CaseDiff], base: str, store_url: str) -> str:
         f"{render_summary(diffs)}\n"
     )
 
+    used = _utf8_len(header)
     body = ""
     for index, diff in enumerate(diffs):
         section = render_case(diff, store_url)
-        if len(header) + len(body) + len(section) > MAX_COMMENT_BYTES:
+        if max_bytes is not None and used + _utf8_len(section) > max_bytes:
             remaining = ", ".join(f"`{d.label}`" for d in diffs[index:])
-            body += f"\n_Detail omitted to fit the comment size limit: {remaining}._\n"
+            body += (
+                f"\n_Detail omitted to fit the comment size limit: {remaining}._\n"
+                "\n_The full report is attached to the workflow run as the `mint-diff` artefact._\n"
+            )
             break
         body += section
+        used += _utf8_len(section)
     return header + body
 
 
@@ -401,7 +435,18 @@ def main(argv: list[str] | None = None) -> int:
     """Entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base", default=f"origin/{os.environ.get('GITHUB_BASE_REF', 'main')}")
-    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="write the full, uncapped report here",
+    )
+    parser.add_argument(
+        "--comment-output",
+        type=Path,
+        default=None,
+        help="write a copy capped to GitHub's comment size limit here",
+    )
     parser.add_argument("--store-url", default=os.environ.get("REF_NATIVE_STORE_URL", DEFAULT_STORE_URL))
     parser.add_argument("--no-fetch", action="store_true")
     args = parser.parse_args(argv)
@@ -413,10 +458,13 @@ def main(argv: list[str] | None = None) -> int:
         if diff is not None:
             diffs.append(diff)
 
-    markdown = render(diffs, args.base, args.store_url)
-    sys.stdout.write(markdown)
+    full = render(diffs, args.base, args.store_url)
+    sys.stdout.write(full)
     if args.output:
-        args.output.write_text(markdown, encoding="utf-8")
+        args.output.write_text(full, encoding="utf-8")
+    if args.comment_output:
+        capped = render(diffs, args.base, args.store_url, max_bytes=MAX_COMMENT_BYTES)
+        args.comment_output.write_text(capped, encoding="utf-8")
     return 0
 
 

--- a/scripts/ci/mint_diff.py
+++ b/scripts/ci/mint_diff.py
@@ -362,12 +362,15 @@ def render_case(diff: CaseDiff, store_url: str) -> str:
     elif diff.is_new:
         headline = f"new case, {headline}"
 
-    out = [f"<details>\n<summary><b>{diff.label}</b> -- {headline}</summary>\n"]
+    # The blank line after </summary> is load-bearing: GitHub parses markdown inside an HTML
+    # block only after one, so without it the first list renders as raw text with its backticks.
+    out = [f"<details>\n<summary><b>{diff.label}</b> -- {headline}</summary>\n\n"]
 
     if diff.metadata:
         out.append("".join(f"- {line}\n" for line in diff.metadata))
     if diff.committed:
-        out.append(f"\nCommitted artefacts changed: {', '.join(diff.committed)}\n")
+        out.append("\nCommitted artefacts changed:\n\n")
+        out.append("".join(f"- {name}\n" for name in diff.committed))
 
     if binary_changes:
         out.append("\n| file | status | size | blobs |\n| --- | --- | --- | --- |\n")


### PR DESCRIPTION
Adds a CI report that shows what a mint actually changed, so a regenerated baseline can be reviewed from the pull request rather than by checking it out locally.

A mint rewrites each test case's `manifest.json` and uploads the curated native outputs to the content-addressed store. The manifest diff therefore already names every native file that moved, and both the old and the new blob stay fetchable by digest. That is enough to reconstruct a readable diff without ever putting a binary in the repository.

`scripts/ci/mint_diff.py` walks the manifests that changed against the base branch and renders markdown:

- Text outputs (JSON, CSV, YAML, HTML) are pulled from the store and rendered as a unified diff. JSON is pretty-printed first, so a minified bundle does not diff as a single unreadable line.
- NetCDF and PNG outputs are listed with a size delta and a link to each blob. A byte diff of those would be noise.
- `test_case_version`, `diagnostic_version`, `catalog_hash` and committed-artefact changes are reported alongside.
- A summary table always covers every changed case, so nothing is invisible even when detail sections are trimmed.

The mint workflow runs it after the commit step, appends the report to the job summary, and posts it on the branch's open pull request. A comment is capped at GitHub's 65 KB limit, so the untruncated report is uploaded as an artifact too. Both new steps are `continue-on-error`, because a reporting hiccup must not fail an otherwise successful mint. The checkout gains `fetch-depth: 0` since the diff needs a merge-base with the default branch.

Two details worth knowing. Cloudflare serves a 403 to the stdlib default user agent, so the script sets its own. Git access goes through GitPython the same way `ci_gate.py` does, which keeps the later fold into `ref test-cases diff` a lift-and-shift.

## Testing

Run against two real past mints:

- `2f2c304b` (the pmp `level` fix, which added a test case) renders the new case and its 15 added native files.
- `7c165d57` (a 17-case re-mint) renders real content diffs, and surfaced the `kind` dimension being added to `json_structure`.

This is deliberately the cheap tier. It does not render plots side by side, and it says nothing about what changed inside a NetCDF beyond its size. Those are worth adding once we know what reviewers keep asking for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated regression baseline reports for branch changes.
  * Reports are available in CI job summaries, pull request comments and downloadable build artifacts.
  * Text output changes appear as readable unified diffs, while binary changes include size comparisons and links.
  * Reports summarise all changed test cases, including removed cases, and keep detailed output within comment limits.
* **Reliability**
  * Missing data, network issues and oversized files are reported clearly without failing the workflow.
  * Reporting is skipped during dry runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->