### PR TITLE
Accept esm-hist alongside historical in diagnostic data requirements

### DIFF
--- a/changelog/893.feature.md
+++ b/changelog/893.feature.md
@@ -1,0 +1,1 @@
+Accepts esm-hist alongside historical in diagnostic data requirements.

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_drivers_for_fire.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/climate_drivers_for_fire.py
@@ -34,21 +34,21 @@ class ClimateDriversForFire(ESMValToolDiagnostic):
                     FacetFilter(
                         {
                             "variable_id": ("hurs", "pr", "tas", "tasmax"),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         }
                     ),
                     FacetFilter(
                         {
                             "variable_id": ("cVeg", "treeFrac"),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Lmon",
                         }
                     ),
                     FacetFilter(
                         {
                             "variable_id": "vegFrac",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Emon",
                         }
                     ),
@@ -89,7 +89,7 @@ class ClimateDriversForFire(ESMValToolDiagnostic):
                                 "tas_tavg-h2m-hxy-u",
                                 "tas_tmaxavg-h2m-hxy-u",
                             ),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         }
@@ -101,7 +101,7 @@ class ClimateDriversForFire(ESMValToolDiagnostic):
                                 "treeFrac_tavg-u-hxy-u",
                                 "vegFrac_tavg-u-hxy-u",
                             ),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         }

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
@@ -77,7 +77,7 @@ class CloudRadiativeEffects(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": variables,
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         }
                     ),
@@ -108,7 +108,7 @@ class CloudRadiativeEffects(ESMValToolDiagnostic):
                                 "rsut_tavg-u-hxy-u",
                                 "rsutcs_tavg-u-hxy-u",
                             ),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         }

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
@@ -25,7 +25,7 @@ def get_cmip_data_requirements(
 ) -> tuple[tuple[DataRequirement, ...], ...]:
     """Create data requirements for CMIP6 and CMIP7 data."""
     cmip7_facets: dict[str, str | Collection[str]] = {
-        "experiment_id": "historical",
+        "experiment_id": ("historical", "esm-hist"),
         "frequency": "mon",
         "region": "glb",
     }
@@ -39,7 +39,7 @@ def get_cmip_data_requirements(
                     FacetFilter(
                         facets={
                             "variable_id": variables,
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         },
                     ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/enso.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/enso.py
@@ -38,14 +38,14 @@ class ENSOBasicClimatology(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": ("pr", "tauu"),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         },
                     ),
                     FacetFilter(
                         facets={
                             "variable_id": "tos",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Omon",
                         },
                     ),
@@ -75,7 +75,7 @@ class ENSOBasicClimatology(ESMValToolDiagnostic):
                                 "pr_tavg-u-hxy-u",
                                 "tauu_tavg-u-hxy-u",
                             ),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         },
@@ -83,7 +83,7 @@ class ENSOBasicClimatology(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "branded_variable": "tos_tavg-u-hxy-sea",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         },
@@ -310,7 +310,7 @@ class ENSOCharacteristics(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": "tos",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Omon",
                         },
                     ),
@@ -331,7 +331,7 @@ class ENSOCharacteristics(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "branded_variable": "tos_tavg-u-hxy-sea",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         },

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/ozone.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/ozone.py
@@ -33,7 +33,7 @@ toz_data_requirement = (
                 FacetFilter(
                     facets={
                         "variable_id": "toz",
-                        "experiment_id": "historical",
+                        "experiment_id": ("historical", "esm-hist"),
                         "table_id": "AERmon",
                     },
                 ),
@@ -69,7 +69,7 @@ toz_data_requirement = (
                 FacetFilter(
                     facets={
                         "variable_id": "toz",
-                        "experiment_id": "historical",
+                        "experiment_id": ("historical", "esm-hist"),
                         "branded_variable": "toz_tavg-u-hxy-u",
                         "frequency": "mon",
                         "region": "glb",
@@ -307,7 +307,7 @@ class O3ZonalMeanProfiles(ESMValToolDiagnostic):
                 FacetFilter(
                     facets={
                         "variable_id": "o3",
-                        "experiment_id": "historical",
+                        "experiment_id": ("historical", "esm-hist"),
                         "table_id": "Amon",
                     },
                 ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/regional_historical_changes.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/regional_historical_changes.py
@@ -130,7 +130,7 @@ class RegionalHistoricalAnnualCycle(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": variables,
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         },
                     ),
@@ -159,7 +159,7 @@ class RegionalHistoricalAnnualCycle(ESMValToolDiagnostic):
                                 "tas_tavg-h2m-hxy-u",
                                 "ua_tavg-p19-hxy-air",
                             ),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                         },
                     ),
@@ -415,7 +415,7 @@ class RegionalHistoricalTimeSeries(RegionalHistoricalAnnualCycle):
                     FacetFilter(
                         facets={
                             "variable_id": variables,
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         },
                     ),
@@ -444,7 +444,7 @@ class RegionalHistoricalTimeSeries(RegionalHistoricalAnnualCycle):
                                 "tas_tavg-h2m-hxy-u",
                                 "ua_tavg-p19-hxy-air",
                             ),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         },
@@ -671,7 +671,7 @@ class RegionalHistoricalTrend(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": variables,
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         },
                     ),
@@ -700,7 +700,7 @@ class RegionalHistoricalTrend(ESMValToolDiagnostic):
                                 "tas_tavg-h2m-hxy-u",
                                 "ua_tavg-p19-hxy-air",
                             ),
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                         },
                     ),

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_area_basic.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_area_basic.py
@@ -98,7 +98,7 @@ class SeaIceAreaBasic(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": "siconc",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "SImon",
                         },
                     ),
@@ -123,7 +123,7 @@ class SeaIceAreaBasic(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "branded_variable": "siconc_tavg-u-hxy-u",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         },

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_sensitivity.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/sea_ice_sensitivity.py
@@ -39,14 +39,14 @@ class SeaIceSensitivity(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": "siconc",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "SImon",
                         },
                     ),
                     FacetFilter(
                         facets={
                             "variable_id": "tas",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "table_id": "Amon",
                         },
                     ),
@@ -83,7 +83,7 @@ class SeaIceSensitivity(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "branded_variable": "siconc_tavg-u-hxy-u",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         },
@@ -91,7 +91,7 @@ class SeaIceSensitivity(ESMValToolDiagnostic):
                     FacetFilter(
                         facets={
                             "branded_variable": "tas_tavg-h2m-hxy-u",
-                            "experiment_id": "historical",
+                            "experiment_id": ("historical", "esm-hist"),
                             "frequency": "mon",
                             "region": "glb",
                         },

--- a/packages/climate-ref-example/src/climate_ref_example/surface_temperature.py
+++ b/packages/climate-ref-example/src/climate_ref_example/surface_temperature.py
@@ -338,7 +338,7 @@ class GlobalMeanSurfaceTemperatureBias(Diagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": (_MODEL_VARIABLE,),
-                            "experiment_id": ("historical",),
+                            "experiment_id": ("historical", "esm-hist"),
                         }
                     ),
                 ),
@@ -358,7 +358,7 @@ class GlobalMeanSurfaceTemperatureBias(Diagnostic):
                     FacetFilter(
                         facets={
                             "variable_id": (_MODEL_VARIABLE,),
-                            "experiment_id": ("historical",),
+                            "experiment_id": ("historical", "esm-hist"),
                         }
                     ),
                 ),

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
@@ -914,7 +914,7 @@ class ILAMBStandard(Diagnostic):
             filters={
                 "variable_id": all_variable_ids,
                 "frequency": "mon",
-                "experiment_id": ("historical", "land-hist"),
+                "experiment_id": ("historical", "esm-hist", "land-hist"),
                 "table_id": (
                     "AERmonZ",
                     "Amon",
@@ -938,7 +938,7 @@ class ILAMBStandard(Diagnostic):
             filters={
                 "branded_variable": branded_variables,
                 "frequency": "mon",
-                "experiment_id": ("historical", "land-hist"),
+                "experiment_id": ("historical", "esm-hist", "land-hist"),
                 "region": "glb",
             },
             group_by=("experiment_id", "source_id", "variant_label", "grid_label"),

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/annual_cycle.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/annual_cycle.py
@@ -82,7 +82,7 @@ def make_data_requirement(
         FacetFilter(
             facets={
                 "frequency": "mon",
-                "experiment_id": ("amip", "historical", "hist-GHG"),
+                "experiment_id": ("amip", "historical", "esm-hist", "hist-GHG"),
                 "variable_id": (variable_id,),
             }
         ),
@@ -92,7 +92,7 @@ def make_data_requirement(
         FacetFilter(
             facets={
                 "branded_variable": (_BRANDED_VARIABLE_NAMES[variable_id],),
-                "experiment_id": ("amip", "historical", "hist-GHG"),
+                "experiment_id": ("amip", "historical", "esm-hist", "hist-GHG"),
                 "frequency": "mon",
                 "region": "glb",
             }

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/enso.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/enso.py
@@ -56,7 +56,9 @@ class ENSO(CommandLineDiagnostic):
         "reference_source_id",
     )
 
-    def __init__(self, metrics_collection: str, experiments: Collection[str] = ("historical",)) -> None:
+    def __init__(
+        self, metrics_collection: str, experiments: Collection[str] = ("historical", "esm-hist")
+    ) -> None:
         self.name = metrics_collection
         self.slug = metrics_collection.lower()
         self.metrics_collection = metrics_collection
@@ -193,7 +195,7 @@ class ENSO(CommandLineDiagnostic):
 
     def _get_data_requirements(
         self,
-        experiments: Collection[str] = ("historical",),
+        experiments: Collection[str] = ("historical", "esm-hist"),
     ) -> tuple[tuple[DataRequirement, DataRequirement], ...]:
         cmip6_filters = [
             FacetFilter(

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
@@ -71,7 +71,7 @@ class ExtratropicalModesOfVariability(CommandLineDiagnostic):
                 FacetFilter(
                     facets={
                         "frequency": "mon",
-                        "experiment_id": ("historical", "hist-GHG", *extra_experiments),
+                        "experiment_id": ("historical", "esm-hist", "hist-GHG", *extra_experiments),
                         "variable_id": model_variable,
                     }
                 )
@@ -81,7 +81,7 @@ class ExtratropicalModesOfVariability(CommandLineDiagnostic):
                 FacetFilter(
                     facets={
                         "branded_variable": (_BRANDED_VARIABLE_NAMES[model_variable],),
-                        "experiment_id": ("historical", "hist-GHG", *extra_experiments),
+                        "experiment_id": ("historical", "esm-hist", "hist-GHG", *extra_experiments),
                         "frequency": "mon",
                         "region": "glb",
                     }

--- a/packages/climate-ref/tests/unit/test_doctor/test_diagnose_snapshot_seeded.yml
+++ b/packages/climate-ref/tests/unit/test_doctor/test_diagnose_snapshot_seeded.yml
@@ -107,17 +107,17 @@
   summary: HadISST-1-1 is carried by 2 registries
 - check: unsolvable-diagnostics
   command: ''
-  detail: 'Unmet: no cmip6 datasets match experiment_id=historical, table_id=Amon,
-    variable_id=hurs|pr|tas|tasmax and experiment_id=historical, table_id=Lmon, variable_id=cVeg|treeFrac
-    and experiment_id=historical, table_id=Emon, variable_id=vegFrac. nothing is ingested
-    as cmip7.'
+  detail: 'Unmet: no cmip6 datasets match experiment_id=historical|esm-hist, table_id=Amon,
+    variable_id=hurs|pr|tas|tasmax and experiment_id=historical|esm-hist, table_id=Lmon,
+    variable_id=cVeg|treeFrac and experiment_id=historical|esm-hist, table_id=Emon,
+    variable_id=vegFrac. nothing is ingested as cmip7.'
   remedy: Ingest the data the unmet requirement names, then run the solver again.
   severity: warning
   summary: esmvaltool/climate-drivers-for-fire has no executions
 - check: unsolvable-diagnostics
   command: ''
-  detail: 'Unmet: no cmip6 datasets match experiment_id=historical|land-hist, frequency=mon,
-    table_id=AERmonZ|Amon|CFmon|Emon|EmonZ|LImon|Lmon|Omon|SImon, variable_id=emp|evspsbl.
+  detail: 'Unmet: no cmip6 datasets match experiment_id=historical|esm-hist|land-hist,
+    frequency=mon, table_id=AERmonZ|Amon|CFmon|Emon|EmonZ|LImon|Lmon|Omon|SImon, variable_id=emp|evspsbl.
     nothing is ingested as cmip7.'
   remedy: Ingest the data the unmet requirement names, then run the solver again.
   severity: warning

--- a/packages/climate-ref/tests/unit/test_solver/test_solve_snapshot_all_providers.yml
+++ b/packages/climate-ref/tests/unit/test_solver/test_solve_snapshot_all_providers.yml
@@ -39,12 +39,12 @@ esmvaltool/cloud-scatterplots-reference/obs4mips_obs4MIPs.obs4MIPs.ECMWF.ERA-5.m
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ta.25km.gn.v20250220
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ta.25km.gn.v20250220
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ta.25km.gn.v20250220
-esmvaltool/enso-basic-climatology/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
+esmvaltool/enso-basic-climatology/cmip6_historical_gn_r1i1p1f1_ACCESS-ESM1-5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.pr.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.tauu.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Omon.tos.gn.v20191115
-esmvaltool/enso-characteristics/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
+esmvaltool/enso-characteristics/cmip6_historical_gn_r1i1p1f1_ACCESS-ESM1-5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Ofx.areacello.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Omon.tos.gn.v20191115
@@ -106,30 +106,30 @@ esmvaltool/global-mean-timeseries/cmip6_ssp126_gn_r1i1p1f1_ACCESS-ESM1-5_Amon_ta
   SourceDatasetType.CMIP6:
   - CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn.v20210318
   - CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.fx.areacella.gn.v20210318
-esmvaltool/ozone-annual-cycle/cmip6_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
+esmvaltool/ozone-annual-cycle/cmip6_historical_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CNRM-CERFACS.CNRM-ESM2-1.historical.r1i1p1f2.AERmon.toz.gr.v20181206
   SourceDatasetType.obs4MIPs:
   - obs4MIPs.obs4MIPs.DLR-BIRA.C3S-GTO-ECV-9-0.mon.toz.1x1degree.gn.v20231115
-esmvaltool/ozone-lat-time/cmip6_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
+esmvaltool/ozone-lat-time/cmip6_historical_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CNRM-CERFACS.CNRM-ESM2-1.historical.r1i1p1f2.AERmon.toz.gr.v20181206
   SourceDatasetType.obs4MIPs:
   - obs4MIPs.obs4MIPs.DLR-BIRA.C3S-GTO-ECV-9-0.mon.toz.1x1degree.gn.v20231115
-esmvaltool/ozone-nh-mar/cmip6_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
+esmvaltool/ozone-nh-mar/cmip6_historical_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CNRM-CERFACS.CNRM-ESM2-1.historical.r1i1p1f2.AERmon.toz.gr.v20181206
   SourceDatasetType.obs4MIPs:
   - obs4MIPs.obs4MIPs.DLR-BIRA.C3S-GTO-ECV-9-0.mon.toz.1x1degree.gn.v20231115
-esmvaltool/ozone-sh-oct/cmip6_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
+esmvaltool/ozone-sh-oct/cmip6_historical_gr_r1i1p1f2_CNRM-ESM2-1__obs4mips_C3S-GTO-ECV-9-0:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CNRM-CERFACS.CNRM-ESM2-1.historical.r1i1p1f2.AERmon.toz.gr.v20181206
   SourceDatasetType.obs4MIPs:
   - obs4MIPs.obs4MIPs.DLR-BIRA.C3S-GTO-ECV-9-0.mon.toz.1x1degree.gn.v20231115
-esmvaltool/ozone-zonal/cmip6_gr_r1i1p1f2_CNRM-ESM2-1:
+esmvaltool/ozone-zonal/cmip6_historical_gr_r1i1p1f2_CNRM-ESM2-1:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CNRM-CERFACS.CNRM-ESM2-1.historical.r1i1p1f2.Amon.o3.gr.v20181206
-esmvaltool/regional-historical-annual-cycle/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
+esmvaltool/regional-historical-annual-cycle/cmip6_historical_gn_r1i1p1f1_ACCESS-ESM1-5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.hus.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.pr.gn.v20191115
@@ -137,11 +137,11 @@ esmvaltool/regional-historical-annual-cycle/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.tas.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.ua.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.fx.areacella.gn.v20191115
-esmvaltool/regional-historical-annual-cycle/cmip6_gn_r1i1p1f1_CanESM5:
+esmvaltool/regional-historical-annual-cycle/cmip6_historical_gn_r1i1p1f1_CanESM5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Amon.tas.gn.v20190429
   - CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.fx.areacella.gn.v20190429
-esmvaltool/regional-historical-annual-cycle/cmip6_gn_r1i1p1f3_HadGEM3-GC31-LL:
+esmvaltool/regional-historical-annual-cycle/cmip6_historical_gn_r1i1p1f3_HadGEM3-GC31-LL:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.MOHC.HadGEM3-GC31-LL.historical.r1i1p1f3.Amon.tas.gn.v20190624
   - CMIP6.CMIP.MOHC.HadGEM3-GC31-LL.piControl.r1i1p1f1.fx.areacella.gn.v20190709
@@ -217,7 +217,7 @@ esmvaltool/regional-historical-annual-cycle/obs4mips_ERA-5:
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ua.25km.gn.v20250220
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ua.25km.gn.v20250220
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ua.25km.gn.v20250220
-esmvaltool/regional-historical-timeseries/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
+esmvaltool/regional-historical-timeseries/cmip6_historical_gn_r1i1p1f1_ACCESS-ESM1-5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.hus.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.pr.gn.v20191115
@@ -225,11 +225,11 @@ esmvaltool/regional-historical-timeseries/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.tas.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.ua.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.fx.areacella.gn.v20191115
-esmvaltool/regional-historical-timeseries/cmip6_gn_r1i1p1f1_CanESM5:
+esmvaltool/regional-historical-timeseries/cmip6_historical_gn_r1i1p1f1_CanESM5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Amon.tas.gn.v20190429
   - CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.fx.areacella.gn.v20190429
-esmvaltool/regional-historical-timeseries/cmip6_gn_r1i1p1f3_HadGEM3-GC31-LL:
+esmvaltool/regional-historical-timeseries/cmip6_historical_gn_r1i1p1f3_HadGEM3-GC31-LL:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.MOHC.HadGEM3-GC31-LL.historical.r1i1p1f3.Amon.tas.gn.v20190624
   - CMIP6.CMIP.MOHC.HadGEM3-GC31-LL.piControl.r1i1p1f1.fx.areacella.gn.v20190709
@@ -305,7 +305,7 @@ esmvaltool/regional-historical-timeseries/obs4mips_ERA-5:
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ua.25km.gn.v20250220
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ua.25km.gn.v20250220
   - obs4MIPs.obs4MIPs.ECMWF.ERA-5.mon.ua.25km.gn.v20250220
-esmvaltool/regional-historical-trend/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
+esmvaltool/regional-historical-trend/cmip6_historical_gn_r1i1p1f1_ACCESS-ESM1-5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.hus.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.pr.gn.v20191115
@@ -313,11 +313,11 @@ esmvaltool/regional-historical-trend/cmip6_gn_r1i1p1f1_ACCESS-ESM1-5:
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.tas.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.Amon.ua.gn.v20191115
   - CMIP6.CMIP.CSIRO.ACCESS-ESM1-5.historical.r1i1p1f1.fx.areacella.gn.v20191115
-esmvaltool/regional-historical-trend/cmip6_gn_r1i1p1f1_CanESM5:
+esmvaltool/regional-historical-trend/cmip6_historical_gn_r1i1p1f1_CanESM5:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Amon.tas.gn.v20190429
   - CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.fx.areacella.gn.v20190429
-esmvaltool/regional-historical-trend/cmip6_gn_r1i1p1f3_HadGEM3-GC31-LL:
+esmvaltool/regional-historical-trend/cmip6_historical_gn_r1i1p1f3_HadGEM3-GC31-LL:
   SourceDatasetType.CMIP6:
   - CMIP6.CMIP.MOHC.HadGEM3-GC31-LL.historical.r1i1p1f3.Amon.tas.gn.v20190624
   - CMIP6.CMIP.MOHC.HadGEM3-GC31-LL.piControl.r1i1p1f1.fx.areacella.gn.v20190709


### PR DESCRIPTION
Adds `esm-hist` to every diagnostic data requirement that currently filters on `historical`. This is mainly for testing CMIP7, where only `esm-hist` data has been published so far.

- Only the solver-side filters change. Test-case download requests still fetch `historical` sample data.
- The global warming levels diagnostic keeps requiring `historical`, because it splices it onto the ssp runs.
- Diagnostics that group by `experiment_id` will now run once for each of `historical` and `esm-hist` when a model has both.

This is a testing branch and may not be suitable for every diagnostic, so it may not end up merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Diagnostic data requirements now recognise `esm-hist` experiments alongside existing historical runs across climate, ENSO, ozone, sea-ice, variability, and surface-temperature analyses.
  - Annual-cycle, trend, and time-series diagnostics can now include `esm-hist` model data.
  - Default experiment selections for relevant diagnostics include `esm-hist`, while preserving existing experiment options.

- **Documentation**
  - Updated release information to record `esm-hist` support.

- **Tests**
  - Updated diagnostic validation snapshots to reflect the expanded experiment matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->