### PR TITLE
Fix CMIP7 test data coverage: fabricated versions and 360_day calendars

### DIFF
--- a/changelog/895.fix.md
+++ b/changelog/895.fix.md
@@ -1,6 +1,6 @@
-Fabricated CMIP7 test data now bumps its dataset version,
-so a series padded with repeated years no longer shares an `instance_id` with the real data.
-
-The synthetic CMIP7 catalog now extends full-length historical runs on every calendar.
-Five models using a 360_day calendar were previously left ending in 2014,
-so any diagnostic needing coverage past that year silently dropped them.
+- Fabricated CMIP7 test data now bumps its dataset version,
+  so a series padded with repeated years no longer shares an `instance_id` with the real data.
+- The synthetic CMIP7 catalog generator now extends full-length historical runs on every calendar.
+  Five models using a 360_day calendar were previously left ending in 2014,
+  so any diagnostic needing coverage past that year silently dropped them.
+  The committed catalog is regenerated separately.

--- a/changelog/895.fix.md
+++ b/changelog/895.fix.md
@@ -1,0 +1,6 @@
+Fabricated CMIP7 test data now bumps its dataset version,
+so a series padded with repeated years no longer shares an `instance_id` with the real data.
+
+The synthetic CMIP7 catalog now extends full-length historical runs on every calendar.
+Five models using a 360_day calendar were previously left ending in 2014,
+so any diagnostic needing coverage past that year silently dropped them.

--- a/changelog/895.fix.md
+++ b/changelog/895.fix.md
@@ -1,6 +1,3 @@
 - Fabricated CMIP7 test data now bumps its dataset version,
   so a series padded with repeated years no longer shares an `instance_id` with the real data.
 - The synthetic CMIP7 catalog generator now extends full-length historical runs on every calendar.
-  Five models using a 360_day calendar were previously left ending in 2014,
-  so any diagnostic needing coverage past that year silently dropped them.
-  The committed catalog is regenerated separately.

--- a/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
@@ -12,6 +12,8 @@ Regenerate with:
 The variable_id and table_id attributes are used to map the CMIP6 variable to its CMIP7 equivalent,
 and to determine the appropriate branding suffix and realm for the CMIP7 format.
 Grid information is not converted so the grid_labels may not be valid for CMIP7.
+
+This is a temporary work around until we have better CMIP7 coverage.
 """
 
 from __future__ import annotations

--- a/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
@@ -483,20 +483,24 @@ def convert_cmip6_to_cmip7_attrs(
     return attrs
 
 
-def month_index(t: Any) -> int:
-    """Return the absolute month index (``year * 12 + month - 1``) of a time value."""
-    if isinstance(t, cftime.datetime):
-        return t.year * 12 + t.month - 1
-    ts = pd.Timestamp(t)
-    return ts.year * 12 + ts.month - 1
-
-
 _MONTHS_PER_YEAR = 12
 
 
-def target_month_index(end_year: int, end_month: int) -> int:
-    """Return the absolute month index of the ``end_year``-``end_month`` timestep."""
-    return end_year * _MONTHS_PER_YEAR + (end_month - 1)
+def _month_index(t: Any) -> int:
+    """Return the absolute month index (``year * 12 + month - 1``) of a time value."""
+    if isinstance(t, cftime.datetime):
+        return t.year * _MONTHS_PER_YEAR + t.month - 1
+    ts = pd.Timestamp(t)
+    return ts.year * _MONTHS_PER_YEAR + ts.month - 1
+
+
+def months_to_extend(last: Any, end_year: int, end_month: int) -> int:
+    """
+    Return how many months short of ``end_year``-``end_month`` a series ending at ``last`` falls.
+
+    Zero or less means the series already reaches that month.
+    """
+    return end_year * _MONTHS_PER_YEAR + (end_month - 1) - _month_index(last)
 
 
 def repeat_final_year_to(ds: xr.Dataset, end_year: int, end_month: int = 12) -> xr.Dataset:
@@ -547,7 +551,7 @@ def repeat_final_year_to(ds: xr.Dataset, end_year: int, end_month: int = 12) -> 
             f"Got {type(last).__name__}. Decode with use_cftime=True."
         )
 
-    months_to_add = target_month_index(end_year, end_month) - month_index(last)
+    months_to_add = months_to_extend(last, end_year, end_month)
     if months_to_add <= 0:
         return ds
 

--- a/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
@@ -483,7 +483,7 @@ def convert_cmip6_to_cmip7_attrs(
     return attrs
 
 
-def _month_index(t: Any) -> int:
+def month_index(t: Any) -> int:
     """Return the absolute month index (``year * 12 + month - 1``) of a time value."""
     if isinstance(t, cftime.datetime):
         return t.year * 12 + t.month - 1
@@ -543,7 +543,7 @@ def repeat_final_year_to(ds: xr.Dataset, end_year: int, end_month: int = 12) -> 
         )
 
     target_index = end_year * _MONTHS_PER_YEAR + (end_month - 1)
-    months_to_add = target_index - _month_index(last)
+    months_to_add = target_index - month_index(last)
     if months_to_add <= 0:
         return ds
 

--- a/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/cmip6_to_cmip7.py
@@ -494,6 +494,11 @@ def month_index(t: Any) -> int:
 _MONTHS_PER_YEAR = 12
 
 
+def target_month_index(end_year: int, end_month: int) -> int:
+    """Return the absolute month index of the ``end_year``-``end_month`` timestep."""
+    return end_year * _MONTHS_PER_YEAR + (end_month - 1)
+
+
 def repeat_final_year_to(ds: xr.Dataset, end_year: int, end_month: int = 12) -> xr.Dataset:
     """
     Extend a monthly series to ``end_year``-``end_month`` by repeating its final year.
@@ -542,8 +547,7 @@ def repeat_final_year_to(ds: xr.Dataset, end_year: int, end_month: int = 12) -> 
             f"Got {type(last).__name__}. Decode with use_cftime=True."
         )
 
-    target_index = end_year * _MONTHS_PER_YEAR + (end_month - 1)
-    months_to_add = target_index - month_index(last)
+    months_to_add = target_month_index(end_year, end_month) - month_index(last)
     if months_to_add <= 0:
         return ds
 

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
@@ -7,6 +7,7 @@ a request class that fetches CMIP6 data and converts it to CMIP7 format.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -21,6 +22,7 @@ from climate_ref_core.cmip6_to_cmip7 import (
     format_cmip7_time_range,
     get_dreq_entry,
     get_frequency_from_table,
+    month_index,
     repeat_final_year_to,
     suppress_bounds_coordinates,
 )
@@ -36,7 +38,7 @@ def _get_cmip7_cache_dir() -> Path:
     return cache_dir
 
 
-def _latest_file(files: list[Path]) -> Path | None:
+def _latest_file(files: list[Path]) -> tuple[Path, Any] | None:
     """
     Find the file holding a dataset's final timestep.
 
@@ -50,8 +52,8 @@ def _latest_file(files: list[Path]) -> Path | None:
 
     Returns
     -------
-    Path | None
-        The file ending last, or ``None`` when none of them carry a time axis.
+    tuple[Path, Any] | None
+        The file ending last and its final timestep, or ``None`` when none of them carry a time axis.
     """
     time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
 
@@ -64,7 +66,31 @@ def _latest_file(files: list[Path]) -> Path | None:
             end = ds["time"].values[-1]
             if latest_end is None or end > latest_end:
                 latest, latest_end = path, end
-    return latest
+    if latest is None:
+        return None
+    return latest, latest_end
+
+
+def _bump_version(version: str) -> str:
+    """
+    Bump a DRS version so fabricated data does not share an ``instance_id`` with the real thing.
+
+    A version that is not already ``v<digits>`` is read as ``v0``, which is what the ingest
+    falls back to when it cannot parse one out of the path.
+
+    Parameters
+    ----------
+    version
+        The version the dataset would otherwise be published under.
+
+    Returns
+    -------
+    str
+        The next version.
+    """
+    match = re.fullmatch(r"v(\d+)", version)
+    current = int(match.group(1)) if match else 0
+    return f"v{current + 1}"
 
 
 def _convert_file_to_cmip7(
@@ -336,7 +362,13 @@ class CMIP7Request:
             files = row_dict.get("files", [])
             latest = None
             if self.extend_historical_to is not None:
-                latest = _latest_file([Path(f) for f in files if Path(f).exists()])
+                end_year, end_month = self.extend_historical_to
+                found = _latest_file([Path(f) for f in files if Path(f).exists()])
+                if found is not None and month_index(found[1]) < end_year * 12 + (end_month - 1):
+                    latest = found[0]
+                    # Fabricated years must not be published under the version the real
+                    # data carries, so bump it for every file in the dataset.
+                    cmip7_row["version"] = _bump_version(str(cmip7_row.get("version", "v0")))
 
             converted_files = []
             for file_path in files:

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
@@ -23,10 +23,9 @@ from climate_ref_core.cmip6_to_cmip7 import (
     format_cmip7_time_range,
     get_dreq_entry,
     get_frequency_from_table,
-    month_index,
+    months_to_extend,
     repeat_final_year_to,
     suppress_bounds_coordinates,
-    target_month_index,
 )
 from climate_ref_core.data import resolve_cache_dir
 from climate_ref_core.esgf.cmip6 import CMIP6Request
@@ -365,20 +364,18 @@ class CMIP7Request:
             cmip7_row = self._convert_to_cmip7_metadata(row_dict)
 
             # Get file paths and convert them
-            files = row_dict.get("files", [])
+            paths = [Path(file_path) for file_path in row_dict.get("files", [])]
             latest = None
             if self.extend_historical_to is not None:
-                end_year, end_month = self.extend_historical_to
-                found = _latest_file([Path(f) for f in files if Path(f).exists()])
-                if found is not None and month_index(found.end) < target_month_index(end_year, end_month):
+                found = _latest_file([path for path in paths if path.exists()])
+                if found is not None and months_to_extend(found.end, *self.extend_historical_to) > 0:
                     latest = found.path
                     # Fabricated years must not be published under the version the real
                     # data carries, so bump it for every file in the dataset.
-                    cmip7_row["version"] = _bump_version(str(cmip7_row.get("version", "v0")))
+                    cmip7_row["version"] = _bump_version(str(cmip7_row.get("version", "")))
 
             converted_files = []
-            for file_path in files:
-                cmip6_path = Path(file_path)
+            for cmip6_path in paths:
                 if cmip6_path.exists():
                     try:
                         cmip7_path = _convert_file_to_cmip7(
@@ -391,7 +388,7 @@ class CMIP7Request:
                         logger.exception(f"Failed to convert {cmip6_path.name}: {e}")
                         continue
                 else:
-                    logger.warning(f"CMIP6 file not found: {file_path}")
+                    logger.warning(f"CMIP6 file not found: {cmip6_path}")
 
             if converted_files:
                 cmip7_row["files"] = converted_files

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, NamedTuple
 
+import cftime
 import pandas as pd
 import xarray as xr
 from loguru import logger
@@ -25,6 +26,7 @@ from climate_ref_core.cmip6_to_cmip7 import (
     month_index,
     repeat_final_year_to,
     suppress_bounds_coordinates,
+    target_month_index,
 )
 from climate_ref_core.data import resolve_cache_dir
 from climate_ref_core.esgf.cmip6 import CMIP6Request
@@ -38,7 +40,14 @@ def _get_cmip7_cache_dir() -> Path:
     return cache_dir
 
 
-def _latest_file(files: list[Path]) -> tuple[Path, Any] | None:
+class LatestFile(NamedTuple):
+    """The file holding a dataset's final timestep, and that timestep."""
+
+    path: Path
+    end: cftime.datetime
+
+
+def _latest_file(files: list[Path]) -> LatestFile | None:
     """
     Find the file holding a dataset's final timestep.
 
@@ -52,23 +61,20 @@ def _latest_file(files: list[Path]) -> tuple[Path, Any] | None:
 
     Returns
     -------
-    tuple[Path, Any] | None
+    LatestFile | None
         The file ending last and its final timestep, or ``None`` when none of them carry a time axis.
     """
     time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
 
-    latest: Path | None = None
-    latest_end = None
+    latest: LatestFile | None = None
     for path in files:
         with xr.open_dataset(path, decode_times=time_coder) as ds:
             if "time" not in ds.coords or len(ds["time"]) == 0:
                 continue
             end = ds["time"].values[-1]
-            if latest_end is None or end > latest_end:
-                latest, latest_end = path, end
-    if latest is None:
-        return None
-    return latest, latest_end
+            if latest is None or end > latest.end:
+                latest = LatestFile(path, end)
+    return latest
 
 
 def _bump_version(version: str) -> str:
@@ -122,7 +128,7 @@ def _convert_file_to_cmip7(
     # CMIP6 activity_id can contain multiple activities separated by spaces
     # (e.g. "C4MIP CDRMIP"). Use only the first activity for the DRS path.
     activity_id = str(cmip7_facets.get("activity_id", "CMIP")).split()[0]
-    version = str(cmip7_facets.get("version", "v1"))
+    version = str(cmip7_facets.get("version", "v0"))
 
     # Build CMIP7 DRS path using the standard MIP-DRS7 path builder.
     # Provide defaults for fields that may not be in facets.
@@ -364,8 +370,8 @@ class CMIP7Request:
             if self.extend_historical_to is not None:
                 end_year, end_month = self.extend_historical_to
                 found = _latest_file([Path(f) for f in files if Path(f).exists()])
-                if found is not None and month_index(found[1]) < end_year * 12 + (end_month - 1):
-                    latest = found[0]
+                if found is not None and month_index(found.end) < target_month_index(end_year, end_month):
+                    latest = found.path
                     # Fabricated years must not be published under the version the real
                     # data carries, so bump it for every file in the dataset.
                     cmip7_row["version"] = _bump_version(str(cmip7_row.get("version", "v0")))

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
@@ -80,8 +80,8 @@ def _bump_version(version: str) -> str:
     """
     Bump a DRS version so fabricated data does not share an ``instance_id`` with the real thing.
 
-    A version that is not already ``v<digits>`` is read as ``v0``, which is what the ingest
-    falls back to when it cannot parse one out of the path.
+    A version that is not already ``v<digits>`` is read as ``v0``,
+    which is what the ingest falls back to when it cannot parse one out of the path.
 
     Parameters
     ----------
@@ -369,9 +369,8 @@ class CMIP7Request:
             if self.extend_historical_to is not None:
                 found = _latest_file([path for path in paths if path.exists()])
                 if found is not None and months_to_extend(found.end, *self.extend_historical_to) > 0:
+                    # if modified bump the version so they don't collide
                     latest = found.path
-                    # Fabricated years must not be published under the version the real
-                    # data carries, so bump it for every file in the dataset.
                     cmip7_row["version"] = _bump_version(str(cmip7_row.get("version", "")))
 
             converted_files = []

--- a/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
+++ b/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
@@ -760,15 +760,15 @@ class TestLatestFile:
         early = self._write_monthly_file(tmp_path / "early.nc", 1850, 1949)
         late = self._write_monthly_file(tmp_path / "late.nc", 1950, 2014)
 
-        assert _latest_file([early, late])[0] == late
-        assert _latest_file([late, early])[0] == late
+        assert _latest_file([early, late]).path == late
+        assert _latest_file([late, early]).path == late
 
     def test_returns_the_final_timestep(self, tmp_path):
         """The end is needed to tell whether the dataset falls short of the requested end."""
         late = self._write_monthly_file(tmp_path / "late.nc", 1950, 2014)
 
-        _, end = _latest_file([late])
-        assert (end.year, end.month) == (2014, 12)
+        latest = _latest_file([late])
+        assert (latest.end.year, latest.end.month) == (2014, 12)
 
     def test_skips_files_without_a_time_axis(self, tmp_path):
         """Fixed-frequency files carry no time axis, so they never win."""
@@ -776,7 +776,7 @@ class TestLatestFile:
         xr.Dataset({"areacella": ("lat", np.zeros(2))}, coords={"lat": [0.0, 1.0]}).to_netcdf(fixed)
         monthly = self._write_monthly_file(tmp_path / "a.nc", 1950, 2014)
 
-        assert _latest_file([fixed, monthly])[0] == monthly
+        assert _latest_file([fixed, monthly]).path == monthly
 
     def test_no_time_axes_at_all(self, tmp_path):
         """A dataset with nothing to extend has no latest file."""

--- a/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
+++ b/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
@@ -11,6 +11,7 @@ import xarray as xr
 
 from climate_ref_core.esgf import CMIP7Request
 from climate_ref_core.esgf.cmip7 import (
+    _bump_version,
     _convert_file_to_cmip7,
     _get_cmip7_cache_dir,
     _latest_file,
@@ -759,8 +760,15 @@ class TestLatestFile:
         early = self._write_monthly_file(tmp_path / "early.nc", 1850, 1949)
         late = self._write_monthly_file(tmp_path / "late.nc", 1950, 2014)
 
-        assert _latest_file([early, late]) == late
-        assert _latest_file([late, early]) == late
+        assert _latest_file([early, late])[0] == late
+        assert _latest_file([late, early])[0] == late
+
+    def test_returns_the_final_timestep(self, tmp_path):
+        """The end is needed to tell whether the dataset falls short of the requested end."""
+        late = self._write_monthly_file(tmp_path / "late.nc", 1950, 2014)
+
+        _, end = _latest_file([late])
+        assert (end.year, end.month) == (2014, 12)
 
     def test_skips_files_without_a_time_axis(self, tmp_path):
         """Fixed-frequency files carry no time axis, so they never win."""
@@ -768,7 +776,7 @@ class TestLatestFile:
         xr.Dataset({"areacella": ("lat", np.zeros(2))}, coords={"lat": [0.0, 1.0]}).to_netcdf(fixed)
         monthly = self._write_monthly_file(tmp_path / "a.nc", 1950, 2014)
 
-        assert _latest_file([fixed, monthly]) == monthly
+        assert _latest_file([fixed, monthly])[0] == monthly
 
     def test_no_time_axes_at_all(self, tmp_path):
         """A dataset with nothing to extend has no latest file."""
@@ -817,6 +825,10 @@ class TestFetchDatasetsExtendHistorical:
         extended = {call.args[0]: call.kwargs["extend_historical_to"] for call in mock_convert.call_args_list}
         assert extended == {early: None, late: (2021, 12)}
 
+        # Every file of the dataset moves to the bumped version, so the fabricated years
+        # do not share an instance_id with the real data.
+        assert {call.args[1]["version"] for call in mock_convert.call_args_list} == {"v1"}
+
     @patch("climate_ref_core.esgf.cmip7.CMIP6Request")
     @patch("climate_ref_core.esgf.cmip7._convert_file_to_cmip7")
     def test_no_extension_requested(self, mock_convert, mock_cmip6_request_class, tmp_path):
@@ -839,3 +851,52 @@ class TestFetchDatasetsExtendHistorical:
         CMIP7Request(slug="test", facets={"source_id": "GFDL-ESM4"}).fetch_datasets()
 
         assert mock_convert.call_args_list[0].kwargs["extend_historical_to"] is None
+
+    @patch("climate_ref_core.esgf.cmip7.CMIP6Request")
+    @patch("climate_ref_core.esgf.cmip7._convert_file_to_cmip7")
+    def test_version_untouched_when_nothing_is_fabricated(
+        self, mock_convert, mock_cmip6_request_class, tmp_path
+    ):
+        """A dataset already reaching the requested end is real data, so it keeps its version."""
+        only = self._write_monthly_file(tmp_path / "only.nc", 1950, 2021)
+
+        mock_cmip6_instance = MagicMock()
+        mock_cmip6_instance.fetch_datasets.return_value = pd.DataFrame(
+            {
+                "source_id": ["GFDL-ESM4"],
+                "member_id": ["r1i1p1f1"],
+                "variable_id": ["toz"],
+                "table_id": ["AERmon"],
+                "version": ["20190429"],
+                "files": [[str(only)]],
+            }
+        )
+        mock_cmip6_request_class.return_value = mock_cmip6_instance
+        mock_convert.return_value = tmp_path / "a.nc"
+
+        CMIP7Request(
+            slug="test",
+            facets={"source_id": "GFDL-ESM4"},
+            extend_historical_to=(2021, 12),
+        ).fetch_datasets()
+
+        assert mock_convert.call_args_list[0].kwargs["extend_historical_to"] is None
+        assert mock_convert.call_args_list[0].args[1]["version"] == "20190429"
+
+
+class TestBumpVersion:
+    """Test the version bump that keeps fabricated data out of the real instance_id."""
+
+    @pytest.mark.parametrize(
+        "version, expected",
+        [
+            ("v0", "v1"),
+            ("v1", "v2"),
+            ("v9", "v10"),
+            # The ingest cannot parse a version out of these, so it sees v0.
+            ("20190429", "v1"),
+            ("", "v1"),
+        ],
+    )
+    def test_bump(self, version, expected):
+        assert _bump_version(version) == expected

--- a/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
+++ b/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
@@ -795,13 +795,8 @@ class TestFetchDatasetsExtendHistorical:
         xr.Dataset({"toz": ("time", np.zeros(n))}, coords={"time": time}).to_netcdf(path)
         return path
 
-    @patch("climate_ref_core.esgf.cmip7.CMIP6Request")
-    @patch("climate_ref_core.esgf.cmip7._convert_file_to_cmip7")
-    def test_only_the_last_chunk_is_extended(self, mock_convert, mock_cmip6_request_class, tmp_path):
-        """The earlier chunks stay where they are, so the converted files do not overlap."""
-        early = self._write_monthly_file(tmp_path / "early.nc", 1850, 1949)
-        late = self._write_monthly_file(tmp_path / "late.nc", 1950, 2014)
-
+    def _stub_cmip6(self, mock_cmip6_request_class, files: list[Path], **extra: str) -> None:
+        """Stand in for the ESGF fetch with a single CMIP6 row covering ``files``."""
         mock_cmip6_instance = MagicMock()
         mock_cmip6_instance.fetch_datasets.return_value = pd.DataFrame(
             {
@@ -809,10 +804,20 @@ class TestFetchDatasetsExtendHistorical:
                 "member_id": ["r1i1p1f1"],
                 "variable_id": ["toz"],
                 "table_id": ["AERmon"],
-                "files": [[str(early), str(late)]],
+                "files": [[str(path) for path in files]],
+                **{key: [value] for key, value in extra.items()},
             }
         )
         mock_cmip6_request_class.return_value = mock_cmip6_instance
+
+    @patch("climate_ref_core.esgf.cmip7.CMIP6Request")
+    @patch("climate_ref_core.esgf.cmip7._convert_file_to_cmip7")
+    def test_only_the_last_chunk_is_extended(self, mock_convert, mock_cmip6_request_class, tmp_path):
+        """The earlier chunks stay where they are, so the converted files do not overlap."""
+        early = self._write_monthly_file(tmp_path / "early.nc", 1850, 1949)
+        late = self._write_monthly_file(tmp_path / "late.nc", 1950, 2014)
+
+        self._stub_cmip6(mock_cmip6_request_class, [early, late])
         mock_convert.side_effect = [tmp_path / "a.nc", tmp_path / "b.nc"]
 
         request = CMIP7Request(
@@ -835,17 +840,7 @@ class TestFetchDatasetsExtendHistorical:
         """Without the opt-in no file is extended, and the files are not opened to find out."""
         only = self._write_monthly_file(tmp_path / "only.nc", 1950, 2014)
 
-        mock_cmip6_instance = MagicMock()
-        mock_cmip6_instance.fetch_datasets.return_value = pd.DataFrame(
-            {
-                "source_id": ["GFDL-ESM4"],
-                "member_id": ["r1i1p1f1"],
-                "variable_id": ["toz"],
-                "table_id": ["AERmon"],
-                "files": [[str(only)]],
-            }
-        )
-        mock_cmip6_request_class.return_value = mock_cmip6_instance
+        self._stub_cmip6(mock_cmip6_request_class, [only])
         mock_convert.return_value = tmp_path / "a.nc"
 
         CMIP7Request(slug="test", facets={"source_id": "GFDL-ESM4"}).fetch_datasets()
@@ -860,18 +855,7 @@ class TestFetchDatasetsExtendHistorical:
         """A dataset already reaching the requested end is real data, so it keeps its version."""
         only = self._write_monthly_file(tmp_path / "only.nc", 1950, 2021)
 
-        mock_cmip6_instance = MagicMock()
-        mock_cmip6_instance.fetch_datasets.return_value = pd.DataFrame(
-            {
-                "source_id": ["GFDL-ESM4"],
-                "member_id": ["r1i1p1f1"],
-                "variable_id": ["toz"],
-                "table_id": ["AERmon"],
-                "version": ["20190429"],
-                "files": [[str(only)]],
-            }
-        )
-        mock_cmip6_request_class.return_value = mock_cmip6_instance
+        self._stub_cmip6(mock_cmip6_request_class, [only], version="20190429")
         mock_convert.return_value = tmp_path / "a.nc"
 
         CMIP7Request(

--- a/packages/climate-ref-esmvaltool/tests/test-data/climate-drivers-for-fire/cmip7/catalog.yaml
+++ b/packages/climate-ref-esmvaltool/tests/test-data/climate-drivers-for-fire/cmip7/catalog.yaml
@@ -1,5 +1,5 @@
 _metadata:
-  hash: 0a33e7dc76794bea1cae3db045b63d108dd41457
+  hash: 82ee685124acc6f4f9b7400d05fae30f2ab4cfa2
 cmip7:
   slug_column: instance_id
   selector:
@@ -57,7 +57,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.cVeg.tavg-u-hxy-lnd.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.cVeg.tavg-u-hxy-lnd.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: Carbon Mass in Vegetation
@@ -76,11 +76,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/3966d8f6-8fbb-459f-8016-6e7e0334eeff
+    tracking_id: hdl:21.14107/205caa4d-8ee1-4b82-b561-1cf3606a0c42
     units: kg m-2
     variable_id: cVeg
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -94,7 +94,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.hurs.tavg-h2m-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.hurs.tavg-h2m-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: Near-Surface Relative Humidity
@@ -113,11 +113,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/11b13f7e-48be-491a-be22-e19fc1dda4bd
+    tracking_id: hdl:21.14107/2aba34c8-068e-4f1c-a2dd-8af016590c95
     units: '%'
     variable_id: hurs
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -131,7 +131,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.pr.tavg-u-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.pr.tavg-u-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: Precipitation
@@ -150,11 +150,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/3f702c96-44cc-43e8-b81a-75f24d092eae
+    tracking_id: hdl:21.14107/e9170667-b4c8-4270-bc61-2f46e20dd066
     units: kg m-2 s-1
     variable_id: pr
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -168,7 +168,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.tas.tavg-h2m-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: Near-Surface Air Temperature
@@ -187,11 +187,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/82835f24-e327-4d10-b31d-82c9ee67adbf
+    tracking_id: hdl:21.14107/f16678cf-7c71-44f5-a4a0-9dddcffbe6ae
     units: K
     variable_id: tas
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -205,7 +205,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.tas.tmaxavg-h2m-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.tas.tmaxavg-h2m-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: Daily Maximum Near-Surface Air Temperature
@@ -224,11 +224,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/82fe41ae-fff7-4d41-83c3-557173667e81
+    tracking_id: hdl:21.14107/61d96892-9dbf-4578-8ede-79608d2c3549
     units: K
     variable_id: tas
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -242,7 +242,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.treeFrac.tavg-u-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.treeFrac.tavg-u-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: Tree Cover Percentage
@@ -261,11 +261,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/e4a7e0df-8b23-464a-be06-dfa2aa01719d
+    tracking_id: hdl:21.14107/d418d226-f1e1-46c9-b52a-0100e548f4cc
     units: '%'
     variable_id: treeFrac
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -279,7 +279,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.vegFrac.tavg-u-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.vegFrac.tavg-u-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: Total Vegetated Percentage Cover
@@ -298,8 +298,8 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/7a21df08-012b-40c3-a4e1-a0a113f1cee7
+    tracking_id: hdl:21.14107/078af338-f371-4068-a33f-f87e07784d04
     units: '%'
     variable_id: vegFrac
     variant_label: r1i1p1f1
-    version: v0
+    version: v1

--- a/packages/climate-ref-esmvaltool/tests/test-data/climate-drivers-for-fire/cmip7/manifest.json
+++ b/packages/climate-ref-esmvaltool/tests/test-data/climate-drivers-for-fire/cmip7/manifest.json
@@ -1,5 +1,5 @@
 {
-  "catalog_hash": "0a33e7dc76794bea1cae3db045b63d108dd41457",
+  "catalog_hash": "82ee685124acc6f4f9b7400d05fae30f2ab4cfa2",
   "committed": {
     "diagnostic.json": "183d82f3963ad19b5a556b8025e6990c444f292adda1d464e12136d05a5ef3b3",
     "output.json": "6a004337728d5817f91d8f308be2f589b950b2cacfdd56b5e112556db163dc5b",
@@ -32,7 +32,7 @@
       "size": 4739
     },
     "executions/recipe/work/fire_evaluation/fire_evaluation/tas_tavg-h2m-hxy-u_Amon_glb_gn_CanESM5_vpd_r1i1p1f1_2002-2021.nc": {
-      "sha256": "a7d692f13015d2172f475b19061b4c2855143f5522596da6363ded3d9a7e190a",
+      "sha256": "c5c5ea3990279764a3fdc1d3853bcb335857d91db65b40a6a4cf54621ea35acf",
       "size": 9981855
     },
     "output.json": {
@@ -45,5 +45,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 3
+  "test_case_version": 4
 }

--- a/packages/climate-ref-esmvaltool/tests/test-data/cloud-radiative-effects/cmip7/catalog.yaml
+++ b/packages/climate-ref-esmvaltool/tests/test-data/cloud-radiative-effects/cmip7/catalog.yaml
@@ -1,5 +1,5 @@
 _metadata:
-  hash: 0785449fa584248e1d89ab12e46ea24b4030e0ec
+  hash: 4c892beef7c743466cc65f8db266693e3cff6709
 cmip7:
   slug_column: instance_id
   selector:
@@ -57,7 +57,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rlut.tavg-u-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rlut.tavg-u-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: TOA Outgoing Longwave Radiation
@@ -76,11 +76,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/5d8e35e3-eb4d-4407-9ad3-05edb0773756
+    tracking_id: hdl:21.14107/de2f0e87-514f-45aa-afb0-d24bc0997814
     units: W m-2
     variable_id: rlut
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -94,7 +94,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rlutcs.tavg-u-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rlutcs.tavg-u-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: TOA Outgoing Clear-Sky Longwave Radiation
@@ -113,11 +113,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/6313eacb-0ec5-4659-a440-68569d8dadae
+    tracking_id: hdl:21.14107/ab10226c-19d6-4f61-8c48-de7e8f7f988d
     units: W m-2
     variable_id: rlutcs
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -131,7 +131,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rsut.tavg-u-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rsut.tavg-u-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: TOA Outgoing Shortwave Radiation
@@ -150,11 +150,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/f29f53fb-df74-4943-8f2a-caa7c8f8aed0
+    tracking_id: hdl:21.14107/7123fd2a-cbc1-434a-9d39-b3c82a6a1dd2
     units: W m-2
     variable_id: rsut
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
   - activity_id: CMIP
     branch_time_in_child: 0.0
     branch_time_in_parent: 1223115.0
@@ -168,7 +168,7 @@ cmip7:
     finalised: true
     frequency: mon
     grid_label: gn
-    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rsutcs.tavg-u-hxy-u.gn.v0
+    instance_id: CMIP7.CMIP.CCCma.CanESM5.historical.r1i1p1f1.glb.mon.rsutcs.tavg-u-hxy-u.gn.v1
     institution_id: CCCma
     license_id: CC-BY-4.0
     long_name: TOA Outgoing Clear-Sky Shortwave Radiation
@@ -187,11 +187,11 @@ cmip7:
     start_time: '1850-01-16 12:00:00'
     time_range: 1850-01-16 12:00:00-2021-12-16 12:00:00
     time_units: days since 1850-01-01
-    tracking_id: hdl:21.14107/327ef19b-488f-4e55-ac57-7a06d4256b31
+    tracking_id: hdl:21.14107/6fdbbb9b-0669-4044-852d-9270db623a95
     units: W m-2
     variable_id: rsutcs
     variant_label: r1i1p1f1
-    version: v0
+    version: v1
 obs4mips:
   slug_column: instance_id
   selector:

--- a/packages/climate-ref-esmvaltool/tests/test-data/cloud-radiative-effects/cmip7/manifest.json
+++ b/packages/climate-ref-esmvaltool/tests/test-data/cloud-radiative-effects/cmip7/manifest.json
@@ -1,5 +1,5 @@
 {
-  "catalog_hash": "0785449fa584248e1d89ab12e46ea24b4030e0ec",
+  "catalog_hash": "4c892beef7c743466cc65f8db266693e3cff6709",
   "committed": {
     "diagnostic.json": "183d82f3963ad19b5a556b8025e6990c444f292adda1d464e12136d05a5ef3b3",
     "output.json": "097d07332e39889ab51b9c55a9f03e4d3dc6a442a7f1693aa15d59bba50d7086",
@@ -32,44 +32,44 @@
       "size": 173904
     },
     "executions/recipe/run/plot_maps/plot/diagnostic_provenance.yml": {
-      "sha256": "bbdf7f91d9eddff5ae64968cb18ab31ed20eea4d05e12720887c000ee159a277",
+      "sha256": "3f306181473dc803768623cad0d5277ce81bcc99b5bc13998cc78aa13dce3c91",
       "size": 3682
     },
     "executions/recipe/run/plot_profiles/plot/diagnostic_provenance.yml": {
-      "sha256": "3111d6177c4dcdee98dd0c8485b9918c14975ba59c475ddf9ed5b217abd524db",
+      "sha256": "78ec756d03d4c998f59ceaf7ad22f17b8f2a83bf810a6aedcb74316afe8f12c1",
       "size": 1422
     },
     "executions/recipe/work/plot_maps/plot/map_lwcre_CanESM5_atmos_bottom.nc": {
-      "sha256": "2a7f1e36d1bfab0eb72f5554b6acf8b4f1c19f79a4cc0eab62fc42d31b57232a",
+      "sha256": "59294cabc7c15249f24700adf53028c99cca3554444980e4252aed5728db7a52",
       "size": 299088
     },
     "executions/recipe/work/plot_maps/plot/map_lwcre_CanESM5_atmos_top_left.nc": {
-      "sha256": "528e349f329a9943a85abacf7fc977560eb9b12902c42191eee264eae4ff58f9",
+      "sha256": "dab5abd1cfcfe9ab0e52ea6a2994b36bb81a03df14af8590d247bffb3ef87b48",
       "size": 296682
     },
     "executions/recipe/work/plot_maps/plot/map_lwcre_CanESM5_atmos_top_right.nc": {
-      "sha256": "2c4460b73f46dde5d00dd804665728924306a07e9984dffc398374d92cdf6adf",
-      "size": 293912
+      "sha256": "117f5ed8f8ca84da36ffec29370aeb718df226b012c6a883c05530eb91193eb4",
+      "size": 293886
     },
     "executions/recipe/work/plot_maps/plot/map_swcre_CanESM5_atmos_bottom.nc": {
-      "sha256": "b64b0a69b6329f1bb33fc535c6c9bd50f07ab95120893ac477824df3852acfd2",
+      "sha256": "dbbf05203d5dcf4fb1e3bd94a92d8a1d6a7d0c3e44c6c149e90a313884d331a9",
       "size": 299278
     },
     "executions/recipe/work/plot_maps/plot/map_swcre_CanESM5_atmos_top_left.nc": {
-      "sha256": "a0d1409207210b6a949664a348c3e2c65fad54e803a1af0bdf4ad261280da88c",
+      "sha256": "2b961f4c1a7827696f69360c1da94191cf25b23a0db82ba46dd3456b05925fae",
       "size": 296966
     },
     "executions/recipe/work/plot_maps/plot/map_swcre_CanESM5_atmos_top_right.nc": {
-      "sha256": "6e0b8b24754ff89be620ec54534d84c4a7a110dfe001025da2b12e7c66eb885f",
-      "size": 293912
+      "sha256": "9ca3a8fae17fe7dcb32ac75f88a930870f5c4ab7c2f64f9490e6902c53960c46",
+      "size": 293886
     },
     "executions/recipe/work/plot_profiles/plot/variable_vs_lat_lwcre_ambiguous_dataset_ambiguous_mip.nc": {
-      "sha256": "70106f8fef5ee8d5e47b3df9dc1cff8ca387613af43efd16453866c5ea434ca1",
-      "size": 12989
+      "sha256": "c5dfbaa2b3ab78faa508d62cc7196105762e533033ef9d11bf9064c6d7aeb242",
+      "size": 12999
     },
     "executions/recipe/work/plot_profiles/plot/variable_vs_lat_swcre_ambiguous_dataset_ambiguous_mip.nc": {
-      "sha256": "8357638c36e8c4b43144ba439bae6b2fde6fafec1aa25a37e37f0f50aaa1106e",
-      "size": 12991
+      "sha256": "3310dd910c3a39fe911275f2916342c2cc8ef00ebceaa5dde56d1c0157d66443",
+      "size": 13001
     },
     "output.json": {
       "sha256": "64e93ece3b9dc2b2bc8127681fd4c8a292cc3df8602f7ef5c9e208da6f5bb558",
@@ -81,5 +81,5 @@
     }
   },
   "schema": 2,
-  "test_case_version": 2
+  "test_case_version": 3
 }

--- a/scripts/generate_cmip7_catalog.py
+++ b/scripts/generate_cmip7_catalog.py
@@ -70,7 +70,9 @@ def _convert_row(row: pd.Series) -> dict | None:
 # The canonical last monthly timestep of a full CMIP6/CMIP7 ``historical`` run.
 # Only rows that already reach this end are lifted, which is what keeps the
 # extension from perturbing any other diagnostic (see ``_extend_historical_end``).
-FULL_HISTORICAL_END = "2014-12-16 12:00:00"
+# The date alone, because the time of day varies by calendar: a 360_day model stamps
+# mid-December at 00:00:00 rather than 12:00:00.
+FULL_HISTORICAL_END = "2014-12-16"
 
 
 def _extend_historical_end(
@@ -81,9 +83,11 @@ def _extend_historical_end(
     """
     Relabel full-length CMIP7 ``historical`` runs so their coverage reaches ``end_time``.
 
-    Only rows whose ``end_time`` is *exactly* ``only_from`` (the canonical full
-    historical end, 2014-12) are lifted. This deliberately narrow rule is what keeps
-    the extension from perturbing other diagnostics: those rows already satisfy every
+    Only rows whose ``end_time`` falls on ``only_from`` (the canonical full
+    historical end, 2014-12-16) are lifted. The date is matched without its time of day,
+    because a 360_day calendar stamps that timestep at 00:00:00 and the rest at 12:00:00.
+    This deliberately narrow rule is what keeps the extension from perturbing other
+    diagnostics: those rows already satisfy every
     diagnostic that requires coverage up to 2014-12 or earlier, so pushing their end
     further out never removes them and never newly-satisfies such a constraint. Only a
     diagnostic that requires coverage *beyond* 2014-12 (the fire diagnostic's 2002-2021
@@ -102,7 +106,7 @@ def _extend_historical_end(
     end_time
         Target ``end_time`` string (``YYYY-MM-DD HH:MM:SS``).
     only_from
-        Only rows whose ``end_time`` equals this value are extended.
+        Only rows whose ``end_time`` falls on this date (``YYYY-MM-DD``) are extended.
 
     Returns
     -------
@@ -110,7 +114,7 @@ def _extend_historical_end(
         Number of rows whose ``end_time`` was extended.
     """
     is_historical = cmip7_catalog["experiment_id"] == "historical"
-    is_full_run = cmip7_catalog["end_time"] == only_from
+    is_full_run = cmip7_catalog["end_time"].astype("string").str.slice(0, len(only_from)) == only_from
     mask = is_historical & is_full_run
 
     cmip7_catalog.loc[mask, "end_time"] = end_time

--- a/scripts/generate_cmip7_catalog.py
+++ b/scripts/generate_cmip7_catalog.py
@@ -68,7 +68,6 @@ def _convert_row(row: pd.Series) -> dict | None:
 
 
 # The canonical last monthly timestep of a full CMIP6/CMIP7 ``historical`` run.
-# The date alone, because a 360_day calendar stamps it at 00:00:00 and the rest at 12:00:00.
 FULL_HISTORICAL_END = "2014-12-16"
 
 
@@ -80,21 +79,13 @@ def _extend_historical_end(
     """
     Relabel full-length CMIP7 ``historical`` runs so their coverage reaches ``end_time``.
 
-    Only rows whose ``end_time`` falls on ``only_from`` (the canonical full historical end,
-    2014-12-16) are lifted.
-    The date is matched without its time of day, because a 360_day calendar stamps that
-    timestep at 00:00:00 and the rest at 12:00:00.
-    This deliberately narrow rule is what keeps the extension from perturbing other diagnostics.
-    Those rows already satisfy every diagnostic that requires coverage up to 2014-12 or earlier,
-    so pushing their end further out never removes them and never newly-satisfies such a constraint.
-    Only a diagnostic that requires coverage *beyond* 2014-12 (the fire diagnostic's 2002-2021 window)
-    sees any change.
+    This only adjusts the ``historical`` experiment.
+    There are other experiments that may have changed,
+    but our focus is the ``historical``.
 
-    Shorter historical runs (e.g. a 5-year GFDL slice ending 1854) are left alone so they cannot
-    suddenly satisfy another diagnostic's timerange.
     Fixed-frequency rows (``fx``, e.g. ``sftlf``) carry a null ``end_time`` and are untouched.
-    Only ``end_time`` is changed, so ``start_time``, ``instance_id``, ``path`` and every other
-    column are preserved.
+    Only ``end_time`` is changed,
+    so ``start_time``, ``instance_id``, ``path`` and every other column are preserved.
 
     Parameters
     ----------
@@ -111,6 +102,7 @@ def _extend_historical_end(
         Number of rows whose ``end_time`` was extended.
     """
     is_historical = cmip7_catalog["experiment_id"] == "historical"
+    # Check date only to avoid calendar differences
     is_full_run = cmip7_catalog["end_time"].str.startswith(only_from, na=False)
     mask = is_historical & is_full_run
 

--- a/scripts/generate_cmip7_catalog.py
+++ b/scripts/generate_cmip7_catalog.py
@@ -68,10 +68,7 @@ def _convert_row(row: pd.Series) -> dict | None:
 
 
 # The canonical last monthly timestep of a full CMIP6/CMIP7 ``historical`` run.
-# Only rows that already reach this end are lifted, which is what keeps the
-# extension from perturbing any other diagnostic (see ``_extend_historical_end``).
-# The date alone, because the time of day varies by calendar: a 360_day model stamps
-# mid-December at 00:00:00 rather than 12:00:00.
+# The date alone, because a 360_day calendar stamps it at 00:00:00 and the rest at 12:00:00.
 FULL_HISTORICAL_END = "2014-12-16"
 
 
@@ -83,20 +80,20 @@ def _extend_historical_end(
     """
     Relabel full-length CMIP7 ``historical`` runs so their coverage reaches ``end_time``.
 
-    Only rows whose ``end_time`` falls on ``only_from`` (the canonical full
-    historical end, 2014-12-16) are lifted. The date is matched without its time of day,
-    because a 360_day calendar stamps that timestep at 00:00:00 and the rest at 12:00:00.
-    This deliberately narrow rule is what keeps the extension from perturbing other
-    diagnostics: those rows already satisfy every
-    diagnostic that requires coverage up to 2014-12 or earlier, so pushing their end
-    further out never removes them and never newly-satisfies such a constraint. Only a
-    diagnostic that requires coverage *beyond* 2014-12 (the fire diagnostic's 2002-2021
-    window) sees any change.
+    Only rows whose ``end_time`` falls on ``only_from`` (the canonical full historical end,
+    2014-12-16) are lifted.
+    The date is matched without its time of day, because a 360_day calendar stamps that
+    timestep at 00:00:00 and the rest at 12:00:00.
+    This deliberately narrow rule is what keeps the extension from perturbing other diagnostics.
+    Those rows already satisfy every diagnostic that requires coverage up to 2014-12 or earlier,
+    so pushing their end further out never removes them and never newly-satisfies such a constraint.
+    Only a diagnostic that requires coverage *beyond* 2014-12 (the fire diagnostic's 2002-2021 window)
+    sees any change.
 
-    Shorter historical runs (e.g. a 5-year GFDL slice ending 1854) are left alone so
-    they cannot suddenly satisfy another diagnostic's timerange. Fixed-frequency rows
-    (``fx``, e.g. ``sftlf``) carry a null ``end_time`` and are untouched. Only
-    ``end_time`` is changed -- ``start_time``, ``instance_id``, ``path`` and every other
+    Shorter historical runs (e.g. a 5-year GFDL slice ending 1854) are left alone so they cannot
+    suddenly satisfy another diagnostic's timerange.
+    Fixed-frequency rows (``fx``, e.g. ``sftlf``) carry a null ``end_time`` and are untouched.
+    Only ``end_time`` is changed, so ``start_time``, ``instance_id``, ``path`` and every other
     column are preserved.
 
     Parameters
@@ -114,7 +111,7 @@ def _extend_historical_end(
         Number of rows whose ``end_time`` was extended.
     """
     is_historical = cmip7_catalog["experiment_id"] == "historical"
-    is_full_run = cmip7_catalog["end_time"].astype("string").str.slice(0, len(only_from)) == only_from
+    is_full_run = cmip7_catalog["end_time"].astype("string").str.startswith(only_from).fillna(False)
     mask = is_historical & is_full_run
 
     cmip7_catalog.loc[mask, "end_time"] = end_time

--- a/scripts/generate_cmip7_catalog.py
+++ b/scripts/generate_cmip7_catalog.py
@@ -111,7 +111,7 @@ def _extend_historical_end(
         Number of rows whose ``end_time`` was extended.
     """
     is_historical = cmip7_catalog["experiment_id"] == "historical"
-    is_full_run = cmip7_catalog["end_time"].astype("string").str.startswith(only_from).fillna(False)
+    is_full_run = cmip7_catalog["end_time"].str.startswith(only_from, na=False)
     mask = is_historical & is_full_run
 
     cmip7_catalog.loc[mask, "end_time"] = end_time

--- a/tests/scripts/test_generate_cmip7_catalog.py
+++ b/tests/scripts/test_generate_cmip7_catalog.py
@@ -13,17 +13,13 @@ import pytest
 SCRIPT = Path(__file__).parents[2] / "scripts" / "generate_cmip7_catalog.py"
 
 
-def _load_script():
+@pytest.fixture(scope="module")
+def script():
     spec = importlib.util.spec_from_file_location("generate_cmip7_catalog", SCRIPT)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-
-
-@pytest.fixture(scope="module")
-def script():
-    return _load_script()
 
 
 def _catalog(rows):

--- a/tests/scripts/test_generate_cmip7_catalog.py
+++ b/tests/scripts/test_generate_cmip7_catalog.py
@@ -1,7 +1,5 @@
 """
 Tests for the historical extension in `scripts/generate_cmip7_catalog.py`.
-
-The script is not an importable module, so it is loaded by path.
 """
 
 import importlib.util

--- a/tests/scripts/test_generate_cmip7_catalog.py
+++ b/tests/scripts/test_generate_cmip7_catalog.py
@@ -1,0 +1,65 @@
+"""
+Tests for the historical extension in `scripts/generate_cmip7_catalog.py`.
+
+The script is not an importable module, so it is loaded by path.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "generate_cmip7_catalog.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("generate_cmip7_catalog", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_script()
+
+
+def _catalog(rows):
+    return pd.DataFrame(
+        [{"experiment_id": experiment_id, "end_time": end_time} for experiment_id, end_time in rows]
+    )
+
+
+def test_extends_every_calendar(script):
+    """A 360_day model stamps mid-December at 00:00:00, so matching the full timestamp drops it."""
+    catalog = _catalog(
+        [
+            ("historical", "2014-12-16 12:00:00"),
+            ("historical", "2014-12-16 00:00:00"),
+        ]
+    )
+
+    extended = script._extend_historical_end(catalog, "2021-12-16 12:00:00")
+
+    assert extended == 2
+    assert list(catalog["end_time"]) == ["2021-12-16 12:00:00"] * 2
+
+
+def test_leaves_short_runs_and_other_experiments_alone(script):
+    """Only full-length historical runs are lifted, so nothing newly satisfies a timerange."""
+    catalog = _catalog(
+        [
+            ("historical", "1854-12-16 12:00:00"),
+            ("ssp585", "2014-12-16 12:00:00"),
+            ("historical", None),
+        ]
+    )
+
+    extended = script._extend_historical_end(catalog, "2021-12-16 12:00:00")
+
+    assert extended == 0
+    assert list(catalog["end_time"][:2]) == ["1854-12-16 12:00:00", "2014-12-16 12:00:00"]
+    # The fx row carries no end_time and must stay that way.
+    assert catalog["end_time"].isna().iloc[2]


### PR DESCRIPTION
Fixes two ways the CMIP7 test data lied about its own coverage.

A fabricated CMIP7 dataset, one padded out by repeating its final year, carried the same `instance_id` as the real unpadded data. Padded datasets now bump to `v1`, and the two affected esmvaltool baselines are re-minted on Gus. The committed bundles are byte-identical, so only provenance and NetCDF metadata move with the input paths.

The synthetic catalog then only extended a historical run whose `end_time` matched `2014-12-16 12:00:00` exactly. A 360_day calendar stamps that timestep at `00:00:00`, so HadGEM3-GC31-LL, HadGEM3-GC31-MM, KACE-1-0-G, UKESM1-0-LL and UKESM1-1-LL never matched. Any CMIP7 diagnostic needing coverage past 2014 silently lost all five.

Worth a close look: only the second commit changes solving behaviour, and it does so only once `cmip7_catalog.parquet` is regenerated. This does not regenerate it, because that shifts the solve baselines for every provider, not just esmvaltool. That belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Historical climate datasets are now extended correctly when additional coverage is required, including across different calendar formats.
  - Extended datasets now receive updated versions to prevent identifier conflicts with real data.
  - Historical runs are matched consistently regardless of whether timestamps use midnight or midday.

- **Tests**
  - Added coverage confirming all eligible calendars are extended while unaffected datasets remain unchanged.
  - Updated test catalogues and manifests to reflect refreshed dataset versions and generated artefacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->