### PR TITLE
Remove the directory depth limit from dataset discovery

### DIFF
--- a/changelog/897.fix.md
+++ b/changelog/897.fix.md
@@ -1,3 +1,2 @@
-CMIP7 file discovery now walks the whole directory tree.
-The DRS nests files deeper than the previous limit of 10 directories,
-so ingesting a `MIP-DRS7` root found no files at all.
+Dataset discovery now walks the whole directory tree instead of stopping 10 directories below the root.
+The CMIP7 DRS nests files deeper than that, so ingesting a `MIP-DRS7` root found no files at all.

--- a/changelog/897.fix.md
+++ b/changelog/897.fix.md
@@ -1,3 +1,3 @@
-Removes the fixed directory depth limit when discovering CMIP7 files.
-The CMIP7 DRS nests files 12 levels below the archive root, so the old limit of 10 silently found nothing.
-File discovery now accepts `depth=None` to walk the whole tree, and the CMIP7 adapter uses it.
+CMIP7 file discovery now walks the whole directory tree.
+The DRS nests files deeper than the previous limit of 10 directories,
+so ingesting a `MIP-DRS7` root found no files at all.

--- a/changelog/897.fix.md
+++ b/changelog/897.fix.md
@@ -1,0 +1,3 @@
+Removes the fixed directory depth limit when discovering CMIP7 files.
+The CMIP7 DRS nests files 12 levels below the archive root, so the old limit of 10 silently found nothing.
+File discovery now accepts `depth=None` to walk the whole tree, and the CMIP7 adapter uses it.

--- a/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
+++ b/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
@@ -26,7 +26,7 @@ TRACEBACK = "TRACEBACK"
 def discover_files(
     paths: list[str],
     include_patterns: list[str] | None = None,
-    depth: int = 0,
+    depth: int | None = 0,
 ) -> list[str]:
     """
     Discover files matching the given glob patterns within the specified paths
@@ -41,6 +41,8 @@ def discover_files(
     depth
         Maximum directory depth below each root to search.
         ``0`` means only files directly inside the root directory.
+        ``None`` searches the whole tree, which is needed when the depth of the
+        files below the given root is not known ahead of time.
 
     Returns
     -------
@@ -62,7 +64,7 @@ def discover_files(
 
         for dirpath, dirnames, filenames in os.walk(root):
             current_depth = len(Path(dirpath).relative_to(root).parts)
-            if current_depth >= depth:
+            if depth is not None and current_depth >= depth:
                 # Still process files at this level, but don't descend further
                 dirnames.clear()
 
@@ -155,7 +157,7 @@ def build_catalog(
     paths: list[str],
     parsing_func: DatasetParsingFunction,
     include_patterns: list[str] | None = None,
-    depth: int = 0,
+    depth: int | None = 0,
     n_jobs: int = 1,
 ) -> pd.DataFrame:
     """
@@ -174,7 +176,7 @@ def build_catalog(
     include_patterns
         Glob patterns to include (e.g. ``["*.nc"]``)
     depth
-        Maximum directory depth to search
+        Maximum directory depth to search, or ``None`` to search the whole tree
     n_jobs
         Number of parallel workers for parsing.
         ``1`` = sequential, ``-1`` = all CPUs, ``>1`` = that many worker processes.
@@ -208,7 +210,7 @@ def build_catalog(
 def iter_discovered_chunks(
     paths: list[str],
     include_patterns: list[str] | None = None,
-    depth: int = 0,
+    depth: int | None = 0,
     chunk_size: int = 10_000,
 ) -> Iterator[list[str]]:
     """
@@ -226,7 +228,7 @@ def iter_discovered_chunks(
         Glob patterns to include (e.g. ``["*.nc"]``).
         Defaults to ``["*"]``.
     depth
-        Maximum directory depth below each root to search.
+        Maximum directory depth below each root to search, or ``None`` for the whole tree.
     chunk_size
         Soft target for the number of files per batch. A batch may exceed
         this if a single directory contains more matching files.
@@ -260,7 +262,7 @@ def iter_discovered_chunks(
         for dirpath, dirnames, filenames in os.walk(root):
             dirnames.sort()
             current_depth = len(Path(dirpath).relative_to(root).parts)
-            if current_depth >= depth:
+            if depth is not None and current_depth >= depth:
                 dirnames.clear()
 
             matched = [
@@ -300,7 +302,7 @@ def iter_built_catalogs(  # noqa: PLR0913
     paths: list[str],
     parsing_func: DatasetParsingFunction,
     include_patterns: list[str] | None = None,
-    depth: int = 0,
+    depth: int | None = 0,
     n_jobs: int = 1,
     chunk_size: int = 10_000,
 ) -> Iterator[pd.DataFrame]:
@@ -320,7 +322,7 @@ def iter_built_catalogs(  # noqa: PLR0913
     include_patterns
         Glob patterns to include (e.g. ``["*.nc"]``).
     depth
-        Maximum directory depth to search.
+        Maximum directory depth to search, or ``None`` to search the whole tree.
     n_jobs
         Number of parallel workers per chunk for parsing.
     chunk_size

--- a/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
+++ b/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
@@ -23,21 +23,14 @@ INVALID_ASSET = "INVALID_ASSET"
 TRACEBACK = "TRACEBACK"
 
 
-def _walk_within_depth(root: Path, depth: int | None) -> Iterator[tuple[str, list[str]]]:
+def _walk_sorted(root: Path) -> Iterator[tuple[str, list[str]]]:
     """
     Walk ``root``, descending into subdirectories in sorted order.
-
-    Yields ``(dirpath, filenames)`` for each directory visited.
-
-    Files at the depth limit are still yielded, the walk just stops descending past it.
 
     Parameters
     ----------
     root
         Directory to walk.
-    depth
-        Maximum directory depth below ``root``, or ``None`` to walk the whole tree.
-        ``0`` visits only ``root`` itself.
 
     Yields
     ------
@@ -46,15 +39,12 @@ def _walk_within_depth(root: Path, depth: int | None) -> Iterator[tuple[str, lis
     """
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames.sort()
-        if depth is not None and len(Path(dirpath).relative_to(root).parts) >= depth:
-            dirnames.clear()
         yield dirpath, filenames
 
 
 def discover_files(
     paths: list[str],
     include_patterns: list[str] | None = None,
-    depth: int | None = 0,
 ) -> list[str]:
     """
     Discover files matching the given glob patterns within the specified paths
@@ -66,11 +56,6 @@ def discover_files(
     include_patterns
         Glob patterns to include (e.g. ``["*.nc"]``).
         Defaults to ``["*"]`` if not provided.
-    depth
-        Maximum directory depth below each root to search.
-        ``0`` means only files directly inside the root directory.
-        ``None`` searches the whole tree, which is needed when the depth of the
-        files below the given root is not known ahead of time.
 
     Returns
     -------
@@ -90,7 +75,7 @@ def discover_files(
                 assets.append(str(root))
             continue
 
-        for dirpath, filenames in _walk_within_depth(root, depth):
+        for dirpath, filenames in _walk_sorted(root):
             for filename in filenames:
                 if any(fnmatch.fnmatch(filename, pat) for pat in include_patterns):
                     assets.append(os.path.join(dirpath, filename))
@@ -180,7 +165,6 @@ def build_catalog(
     paths: list[str],
     parsing_func: DatasetParsingFunction,
     include_patterns: list[str] | None = None,
-    depth: int | None = 0,
     n_jobs: int = 1,
 ) -> pd.DataFrame:
     """
@@ -198,8 +182,6 @@ def build_catalog(
         Must return a dict with an ``INVALID_ASSET`` key on failure.
     include_patterns
         Glob patterns to include (e.g. ``["*.nc"]``)
-    depth
-        Maximum directory depth to search, or ``None`` to search the whole tree
     n_jobs
         Number of parallel workers for parsing.
         ``1`` = sequential, ``-1`` = all CPUs, ``>1`` = that many worker processes.
@@ -214,7 +196,7 @@ def build_catalog(
     ValueError
         If no files matching the include patterns are found in the specified paths
     """
-    assets = discover_files(paths, include_patterns=include_patterns, depth=depth)
+    assets = discover_files(paths, include_patterns=include_patterns)
 
     if not assets:
         raise ValueError(f"No files matching {include_patterns} found in {paths}")
@@ -233,7 +215,6 @@ def build_catalog(
 def iter_discovered_chunks(
     paths: list[str],
     include_patterns: list[str] | None = None,
-    depth: int | None = 0,
     chunk_size: int = 10_000,
 ) -> Iterator[list[str]]:
     """
@@ -250,8 +231,6 @@ def iter_discovered_chunks(
     include_patterns
         Glob patterns to include (e.g. ``["*.nc"]``).
         Defaults to ``["*"]``.
-    depth
-        Maximum directory depth below each root to search, or ``None`` for the whole tree.
     chunk_size
         Soft target for the number of files per batch. A batch may exceed
         this if a single directory contains more matching files.
@@ -282,7 +261,7 @@ def iter_discovered_chunks(
                 yield from _flush()
             continue
 
-        for dirpath, filenames in _walk_within_depth(root, depth):
+        for dirpath, filenames in _walk_sorted(root):
             matched = [
                 os.path.join(dirpath, fn)
                 for fn in filenames
@@ -316,11 +295,10 @@ def _filter_invalid_rows(df: pd.DataFrame) -> pd.DataFrame:
     return df[df[INVALID_ASSET].isnull()].drop(columns=[INVALID_ASSET, TRACEBACK])
 
 
-def iter_built_catalogs(  # noqa: PLR0913
+def iter_built_catalogs(
     paths: list[str],
     parsing_func: DatasetParsingFunction,
     include_patterns: list[str] | None = None,
-    depth: int | None = 0,
     n_jobs: int = 1,
     chunk_size: int = 10_000,
 ) -> Iterator[pd.DataFrame]:
@@ -339,8 +317,6 @@ def iter_built_catalogs(  # noqa: PLR0913
         Must return a dict with an ``INVALID_ASSET`` key on failure.
     include_patterns
         Glob patterns to include (e.g. ``["*.nc"]``).
-    depth
-        Maximum directory depth to search, or ``None`` to search the whole tree.
     n_jobs
         Number of parallel workers per chunk for parsing.
     chunk_size
@@ -354,7 +330,7 @@ def iter_built_catalogs(  # noqa: PLR0913
     """
     any_emitted = False
     for chunk_paths in iter_discovered_chunks(
-        paths, include_patterns=include_patterns, depth=depth, chunk_size=chunk_size
+        paths, include_patterns=include_patterns, chunk_size=chunk_size
     ):
         logger.info(f"Parsing chunk of {len(chunk_paths)} files")
         entries = parse_files(chunk_paths, parsing_func, n_jobs=n_jobs)

--- a/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
+++ b/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
@@ -25,7 +25,9 @@ TRACEBACK = "TRACEBACK"
 
 def _walk_within_depth(root: Path, depth: int | None) -> Iterator[tuple[str, list[str]]]:
     """
-    Walk ``root`` in sorted order, yielding ``(dirpath, filenames)`` for each directory visited.
+    Walk ``root``, descending into subdirectories in sorted order.
+
+    Yields ``(dirpath, filenames)`` for each directory visited.
 
     Files at the depth limit are still yielded, the walk just stops descending past it.
 

--- a/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
+++ b/packages/climate-ref/src/climate_ref/datasets/catalog_builder.py
@@ -23,6 +23,32 @@ INVALID_ASSET = "INVALID_ASSET"
 TRACEBACK = "TRACEBACK"
 
 
+def _walk_within_depth(root: Path, depth: int | None) -> Iterator[tuple[str, list[str]]]:
+    """
+    Walk ``root`` in sorted order, yielding ``(dirpath, filenames)`` for each directory visited.
+
+    Files at the depth limit are still yielded, the walk just stops descending past it.
+
+    Parameters
+    ----------
+    root
+        Directory to walk.
+    depth
+        Maximum directory depth below ``root``, or ``None`` to walk the whole tree.
+        ``0`` visits only ``root`` itself.
+
+    Yields
+    ------
+    :
+        The directory path and the names of the files directly inside it.
+    """
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        if depth is not None and len(Path(dirpath).relative_to(root).parts) >= depth:
+            dirnames.clear()
+        yield dirpath, filenames
+
+
 def discover_files(
     paths: list[str],
     include_patterns: list[str] | None = None,
@@ -62,12 +88,7 @@ def discover_files(
                 assets.append(str(root))
             continue
 
-        for dirpath, dirnames, filenames in os.walk(root):
-            current_depth = len(Path(dirpath).relative_to(root).parts)
-            if depth is not None and current_depth >= depth:
-                # Still process files at this level, but don't descend further
-                dirnames.clear()
-
+        for dirpath, filenames in _walk_within_depth(root, depth):
             for filename in filenames:
                 if any(fnmatch.fnmatch(filename, pat) for pat in include_patterns):
                     assets.append(os.path.join(dirpath, filename))
@@ -259,12 +280,7 @@ def iter_discovered_chunks(
                 yield from _flush()
             continue
 
-        for dirpath, dirnames, filenames in os.walk(root):
-            dirnames.sort()
-            current_depth = len(Path(dirpath).relative_to(root).parts)
-            if depth is not None and current_depth >= depth:
-                dirnames.clear()
-
+        for dirpath, filenames in _walk_within_depth(root, depth):
             matched = [
                 os.path.join(dirpath, fn)
                 for fn in filenames
@@ -351,4 +367,4 @@ def iter_built_catalogs(  # noqa: PLR0913
         yield df
 
     if not any_emitted:
-        logger.info(f"No valid files found in {paths} matching {include_patterns}")
+        logger.warning(f"No valid files found in {paths} matching {include_patterns}")

--- a/packages/climate-ref/src/climate_ref/datasets/cmip6.py
+++ b/packages/climate-ref/src/climate_ref/datasets/cmip6.py
@@ -235,7 +235,6 @@ class CMIP6DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            depth=10,
             n_jobs=self.n_jobs,
         )
 
@@ -272,7 +271,6 @@ class CMIP6DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            depth=10,
             n_jobs=self.n_jobs,
             chunk_size=chunk_size,
         ):

--- a/packages/climate-ref/src/climate_ref/datasets/cmip7.py
+++ b/packages/climate-ref/src/climate_ref/datasets/cmip7.py
@@ -280,8 +280,6 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            # Unbounded: how deep the DRS sits below the root given is not known ahead of time.
-            depth=None,
             n_jobs=self.n_jobs,
         )
 
@@ -318,8 +316,6 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            # Unbounded: how deep the DRS sits below the root given is not known ahead of time.
-            depth=None,
             n_jobs=self.n_jobs,
             chunk_size=chunk_size,
         ):

--- a/packages/climate-ref/src/climate_ref/datasets/cmip7.py
+++ b/packages/climate-ref/src/climate_ref/datasets/cmip7.py
@@ -280,7 +280,8 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            depth=10,
+            # The DRS nests files 12 levels down, and the root given may sit above MIP-DRS7.
+            depth=None,
             n_jobs=self.n_jobs,
         )
 
@@ -317,7 +318,8 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            depth=10,
+            # The DRS nests files 12 levels down, and the root given may sit above MIP-DRS7.
+            depth=None,
             n_jobs=self.n_jobs,
             chunk_size=chunk_size,
         ):

--- a/packages/climate-ref/src/climate_ref/datasets/cmip7.py
+++ b/packages/climate-ref/src/climate_ref/datasets/cmip7.py
@@ -280,7 +280,7 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            # The DRS nests files 12 levels down, and the root given may sit above MIP-DRS7.
+            # Unbounded: how deep the DRS sits below the root given is not known ahead of time.
             depth=None,
             n_jobs=self.n_jobs,
         )
@@ -318,7 +318,7 @@ class CMIP7DatasetAdapter(FinaliseableDatasetAdapterMixin, DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parsing_function,
             include_patterns=["*.nc"],
-            # The DRS nests files 12 levels down, and the root given may sit above MIP-DRS7.
+            # Unbounded: how deep the DRS sits below the root given is not known ahead of time.
             depth=None,
             n_jobs=self.n_jobs,
             chunk_size=chunk_size,

--- a/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
+++ b/packages/climate-ref/src/climate_ref/datasets/esmvaltool_reference.py
@@ -103,7 +103,6 @@ class ESMValToolReferenceDatasetAdapter(DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=parse_esmvaltool_reference,
             include_patterns=["*.nc"],
-            depth=10,
             n_jobs=self.n_jobs,
         )
         if datasets.empty:

--- a/packages/climate-ref/src/climate_ref/datasets/obs4mips.py
+++ b/packages/climate-ref/src/climate_ref/datasets/obs4mips.py
@@ -201,7 +201,6 @@ class Obs4MIPsDatasetAdapter(DatasetAdapter):
             paths=[str(file_or_directory)],
             parsing_func=functools.partial(parse_obs4mips, accepted_activity_ids=self.accepted_activity_ids),
             include_patterns=["*.nc"],
-            depth=10,
             n_jobs=self.n_jobs,
         )
         if datasets.empty:

--- a/packages/climate-ref/tests/unit/datasets/test_catalog_builder.py
+++ b/packages/climate-ref/tests/unit/datasets/test_catalog_builder.py
@@ -60,7 +60,7 @@ def empty_dir(tmp_path):
 
 class TestDiscoverFiles:
     def test_finds_nc_files(self, tmp_tree):
-        files = discover_files([str(tmp_tree)], include_patterns=["*.nc"], depth=10)
+        files = discover_files([str(tmp_tree)], include_patterns=["*.nc"])
         names = [Path(f).name for f in files]
         assert "root.nc" in names
         assert "a.nc" in names
@@ -69,53 +69,34 @@ class TestDiscoverFiles:
         # .txt should be excluded
         assert "root.txt" not in names
 
-    def test_depth_limiting(self, tmp_tree):
-        # depth=0: only root directory
-        files_d0 = discover_files([str(tmp_tree)], include_patterns=["*.nc"], depth=0)
-        names_d0 = [Path(f).name for f in files_d0]
-        assert names_d0 == ["root.nc"]
-
-        # depth=1: root + sub
-        files_d1 = discover_files([str(tmp_tree)], include_patterns=["*.nc"], depth=1)
-        names_d1 = sorted(Path(f).name for f in files_d1)
-        assert names_d1 == ["a.nc", "root.nc"]
-
-        # depth=2: root + sub + deep
-        files_d2 = discover_files([str(tmp_tree)], include_patterns=["*.nc"], depth=2)
-        names_d2 = sorted(Path(f).name for f in files_d2)
-        assert names_d2 == ["a.nc", "b.nc", "root.nc"]
-
-    def test_unlimited_depth(self, tmp_path):
+    def test_walks_arbitrarily_deep_trees(self, tmp_path):
         leaf = tmp_path
         for level in range(14):
             leaf = leaf / f"level{level}"
         leaf.mkdir(parents=True)
         (leaf / "deep.nc").touch()
 
-        assert discover_files([str(tmp_path)], include_patterns=["*.nc"], depth=10) == []
-
-        files = discover_files([str(tmp_path)], include_patterns=["*.nc"], depth=None)
-        assert files == [str(leaf / "deep.nc")]
+        assert discover_files([str(tmp_path)], include_patterns=["*.nc"]) == [str(leaf / "deep.nc")]
 
     def test_nonexistent_path(self):
-        files = discover_files(["/nonexistent/path"], include_patterns=["*.nc"], depth=5)
+        files = discover_files(["/nonexistent/path"], include_patterns=["*.nc"])
         assert files == []
 
     def test_single_file_path(self, tmp_tree):
         nc_file = str(tmp_tree / "root.nc")
-        files = discover_files([nc_file], include_patterns=["*.nc"], depth=0)
+        files = discover_files([nc_file], include_patterns=["*.nc"])
         assert files == [nc_file]
 
         # Non-matching pattern
-        files = discover_files([nc_file], include_patterns=["*.txt"], depth=0)
+        files = discover_files([nc_file], include_patterns=["*.txt"])
         assert files == []
 
     def test_empty_directory(self, empty_dir):
-        files = discover_files([str(empty_dir)], include_patterns=["*.nc"], depth=5)
+        files = discover_files([str(empty_dir)], include_patterns=["*.nc"])
         assert files == []
 
     def test_default_include_all(self, tmp_tree):
-        files = discover_files([str(tmp_tree)], depth=0)
+        files = discover_files([str(tmp_tree)])
         names = sorted(Path(f).name for f in files)
         assert "root.nc" in names
         assert "root.txt" in names
@@ -157,7 +138,6 @@ class TestBuildCatalog:
             paths=[str(tmp_tree)],
             parsing_func=_good_parser,
             include_patterns=["*.nc"],
-            depth=10,
             n_jobs=1,
         )
         assert isinstance(df, pd.DataFrame)
@@ -170,7 +150,6 @@ class TestBuildCatalog:
             paths=[str(tmp_tree)],
             parsing_func=_good_parser,
             include_patterns=["*.nc"],
-            depth=10,
             n_jobs=2,
         )
         assert len(df) == 4
@@ -180,7 +159,6 @@ class TestBuildCatalog:
             paths=[str(tmp_tree)],
             parsing_func=_good_parser,
             include_patterns=["*.nc"],
-            depth=10,
             n_jobs=-1,
         )
         assert len(df) == 4
@@ -192,11 +170,10 @@ class TestBuildCatalog:
                 paths=[str(tmp_tree)],
                 parsing_func=_mixed_parser,
                 include_patterns=["*.nc", "*.txt"],
-                depth=0,
                 n_jobs=1,
             )
-        # Only root.nc should survive (depth=0, .txt filtered as INVALID)
-        assert len(df) == 1
+        # The four .nc files survive, root.txt is filtered as INVALID
+        assert len(df) == 4
         assert "INVALID_ASSET" not in df.columns
         assert "TRACEBACK" not in df.columns
 
@@ -206,7 +183,6 @@ class TestBuildCatalog:
                 paths=[str(empty_dir)],
                 parsing_func=_good_parser,
                 include_patterns=["*.nc"],
-                depth=5,
             )
 
     def test_all_invalid_returns_empty(self, tmp_tree):
@@ -218,7 +194,6 @@ class TestBuildCatalog:
                 paths=[str(tmp_tree)],
                 parsing_func=_all_invalid,
                 include_patterns=["*.nc"],
-                depth=10,
             )
         assert df.empty
 
@@ -235,7 +210,7 @@ class TestParallelParsingSafety:
     def test_parse_files_runs_in_worker_processes(self, tmp_path):
         """n_jobs > 1 must execute the parser out-of-process, not in threads."""
         root = _flat_tree(tmp_path, n=8)
-        assets = discover_files([str(root)], include_patterns=["*.nc"], depth=5)
+        assets = discover_files([str(root)], include_patterns=["*.nc"])
 
         results = parse_files(assets, _pid_parser, n_jobs=2)
 
@@ -248,7 +223,7 @@ class TestParallelParsingSafety:
     def test_parse_files_sequential_runs_in_process(self, tmp_path):
         """n_jobs == 1 stays in-process (no pool overhead)."""
         root = _flat_tree(tmp_path, n=4)
-        assets = discover_files([str(root)], include_patterns=["*.nc"], depth=5)
+        assets = discover_files([str(root)], include_patterns=["*.nc"])
 
         results = parse_files(assets, _pid_parser, n_jobs=1)
 
@@ -272,7 +247,6 @@ class TestParallelParsingSafety:
             paths=[str(root)],
             parsing_func=parse_cmip6_complete,
             include_patterns=["*.nc"],
-            depth=5,
             n_jobs=n_jobs,
         )
 
@@ -291,7 +265,6 @@ class TestParallelParsingSafety:
             paths=[str(root)],
             parsing_func=parse_cmip6_complete,
             include_patterns=["*.nc"],
-            depth=5,
         )
         sequential = build_catalog(n_jobs=1, **kwargs).sort_values("path").reset_index(drop=True)
         parallel = build_catalog(n_jobs=4, **kwargs).sort_values("path").reset_index(drop=True)
@@ -323,7 +296,7 @@ def _wide_tree(tmp_path: Path, num_dirs: int, files_per_dir: int) -> Path:
 class TestIterDiscoveredChunks:
     def test_yields_all_files(self, tmp_path):
         root = _flat_tree(tmp_path, n=25)
-        chunks = list(iter_discovered_chunks([str(root)], include_patterns=["*.nc"], depth=5, chunk_size=10))
+        chunks = list(iter_discovered_chunks([str(root)], include_patterns=["*.nc"], chunk_size=10))
         flat = [p for chunk in chunks for p in chunk]
         assert len(flat) == 25
         assert all(p.endswith(".nc") for p in flat)
@@ -331,7 +304,7 @@ class TestIterDiscoveredChunks:
     def test_chunk_size_respected_at_directory_boundaries(self, tmp_path):
         # 5 directories x 4 files = 20 files. chunk_size=8 forces splits between dirs.
         root = _wide_tree(tmp_path, num_dirs=5, files_per_dir=4)
-        chunks = list(iter_discovered_chunks([str(root)], include_patterns=["*.nc"], depth=5, chunk_size=8))
+        chunks = list(iter_discovered_chunks([str(root)], include_patterns=["*.nc"], chunk_size=8))
         # Every chunk groups whole directories together (no directory split across chunks).
         for chunk in chunks:
             dirs = {str(Path(p).parent) for p in chunk}
@@ -343,29 +316,15 @@ class TestIterDiscoveredChunks:
         total = sum(len(c) for c in chunks)
         assert total == 20
 
-    def test_unlimited_depth(self, tmp_path):
-        leaf = tmp_path
-        for level in range(14):
-            leaf = leaf / f"level{level}"
-        leaf.mkdir(parents=True)
-        (leaf / "deep.nc").touch()
-
-        chunks = list(
-            iter_discovered_chunks([str(tmp_path)], include_patterns=["*.nc"], depth=None, chunk_size=10)
-        )
-        assert chunks == [[str(leaf / "deep.nc")]]
-
     def test_empty_root_yields_nothing(self, tmp_path):
         empty = tmp_path / "empty"
         empty.mkdir()
-        chunks = list(iter_discovered_chunks([str(empty)], include_patterns=["*.nc"], depth=5, chunk_size=10))
+        chunks = list(iter_discovered_chunks([str(empty)], include_patterns=["*.nc"], chunk_size=10))
         assert chunks == []
 
     def test_single_file_path(self, tmp_tree):
         nc_file = tmp_tree / "root.nc"
-        chunks = list(
-            iter_discovered_chunks([str(nc_file)], include_patterns=["*.nc"], depth=0, chunk_size=10)
-        )
+        chunks = list(iter_discovered_chunks([str(nc_file)], include_patterns=["*.nc"], chunk_size=10))
         assert chunks == [[str(nc_file)]]
 
 
@@ -377,7 +336,6 @@ class TestIterBuiltCatalogs:
                 paths=[str(root)],
                 parsing_func=_good_parser,
                 include_patterns=["*.nc"],
-                depth=5,
                 n_jobs=1,
                 chunk_size=5,
             )
@@ -397,7 +355,6 @@ class TestIterBuiltCatalogs:
                     paths=[str(tmp_tree)],
                     parsing_func=_mixed_parser,
                     include_patterns=["*.nc", "*.txt"],
-                    depth=10,
                     chunk_size=2,
                 )
             )
@@ -416,7 +373,6 @@ class TestIterBuiltCatalogs:
                 paths=[str(empty)],
                 parsing_func=_good_parser,
                 include_patterns=["*.nc"],
-                depth=5,
                 chunk_size=10,
             )
         )
@@ -429,7 +385,6 @@ class TestIterBuiltCatalogs:
                 paths=[str(root)],
                 parsing_func=_good_parser,
                 include_patterns=["*.nc"],
-                depth=5,
                 n_jobs=1,
                 chunk_size=100,
             )
@@ -447,7 +402,6 @@ class TestIterBuiltCatalogs:
                     paths=[str(tmp_tree)],
                     parsing_func=_all_invalid,
                     include_patterns=["*.nc"],
-                    depth=10,
                     chunk_size=2,
                 )
             )
@@ -462,7 +416,6 @@ class TestIterBuiltCatalogs:
                 paths=[str(root)],
                 parsing_func=_good_parser,
                 include_patterns=["*.nc"],
-                depth=5,
                 chunk_size=2,
             )
         )
@@ -477,7 +430,6 @@ class TestDiscoverEdgeCases:
             iter_discovered_chunks(
                 ["/does/not/exist", str(root)],
                 include_patterns=["*.nc"],
-                depth=5,
                 chunk_size=10,
             )
         )
@@ -491,7 +443,7 @@ class TestDiscoverEdgeCases:
         for i in range(6):
             (root / f"f_{i}.nc").touch()
 
-        chunks = list(iter_discovered_chunks([str(root)], include_patterns=["*.nc"], depth=5, chunk_size=2))
+        chunks = list(iter_discovered_chunks([str(root)], include_patterns=["*.nc"], chunk_size=2))
         # All six files come from one directory; the buffer flushes once at the end.
         assert sum(len(c) for c in chunks) == 6
         for chunk in chunks:
@@ -506,8 +458,6 @@ class TestDiscoverEdgeCases:
         b.mkdir()
         (b / "2.nc").touch()
 
-        chunks = list(
-            iter_discovered_chunks([str(a), str(b)], include_patterns=["*.nc"], depth=5, chunk_size=10)
-        )
+        chunks = list(iter_discovered_chunks([str(a), str(b)], include_patterns=["*.nc"], chunk_size=10))
         flat = [p for chunk in chunks for p in chunk]
         assert len(flat) == 2

--- a/packages/climate-ref/tests/unit/datasets/test_catalog_builder.py
+++ b/packages/climate-ref/tests/unit/datasets/test_catalog_builder.py
@@ -85,6 +85,19 @@ class TestDiscoverFiles:
         names_d2 = sorted(Path(f).name for f in files_d2)
         assert names_d2 == ["a.nc", "b.nc", "root.nc"]
 
+    def test_unlimited_depth(self, tmp_path):
+        # A tree deeper than any previous fixed limit, matching the CMIP7 DRS nesting.
+        leaf = tmp_path
+        for level in range(14):
+            leaf = leaf / f"level{level}"
+        leaf.mkdir(parents=True)
+        (leaf / "deep.nc").touch()
+
+        assert discover_files([str(tmp_path)], include_patterns=["*.nc"], depth=10) == []
+
+        files = discover_files([str(tmp_path)], include_patterns=["*.nc"], depth=None)
+        assert files == [str(leaf / "deep.nc")]
+
     def test_nonexistent_path(self):
         files = discover_files(["/nonexistent/path"], include_patterns=["*.nc"], depth=5)
         assert files == []
@@ -330,6 +343,18 @@ class TestIterDiscoveredChunks:
 
         total = sum(len(c) for c in chunks)
         assert total == 20
+
+    def test_unlimited_depth(self, tmp_path):
+        leaf = tmp_path
+        for level in range(14):
+            leaf = leaf / f"level{level}"
+        leaf.mkdir(parents=True)
+        (leaf / "deep.nc").touch()
+
+        chunks = list(
+            iter_discovered_chunks([str(tmp_path)], include_patterns=["*.nc"], depth=None, chunk_size=10)
+        )
+        assert chunks == [[str(leaf / "deep.nc")]]
 
     def test_empty_root_yields_nothing(self, tmp_path):
         empty = tmp_path / "empty"

--- a/packages/climate-ref/tests/unit/datasets/test_catalog_builder.py
+++ b/packages/climate-ref/tests/unit/datasets/test_catalog_builder.py
@@ -86,7 +86,6 @@ class TestDiscoverFiles:
         assert names_d2 == ["a.nc", "b.nc", "root.nc"]
 
     def test_unlimited_depth(self, tmp_path):
-        # A tree deeper than any previous fixed limit, matching the CMIP7 DRS nesting.
         leaf = tmp_path
         for level in range(14):
             leaf = leaf / f"level{level}"

--- a/packages/climate-ref/tests/unit/datasets/test_cmip7.py
+++ b/packages/climate-ref/tests/unit/datasets/test_cmip7.py
@@ -284,9 +284,7 @@ class TestCMIP7IterLocalDatasets:
         config.cmip7_parser = "drs"
         adapter = CMIP7DatasetAdapter(config=config)
         _build_cmip7_archive(tmp_path / "archive", self.DATASETS)
-        # CMIP7DatasetAdapter walks with depth=10, so point it at the
-        # activity_id parent (MIP-DRS7/CMIP7) rather than the bare archive root.
-        root = tmp_path / "archive" / "MIP-DRS7" / "CMIP7" / "CMIP"
+        root = tmp_path / "archive"
 
         whole = adapter.find_local_datasets(root)
         streamed = pd.concat(list(adapter.iter_local_datasets(root, chunk_size=2)))
@@ -295,6 +293,18 @@ class TestCMIP7IterLocalDatasets:
             sort_data_catalog(whole.reset_index(drop=True)),
             sort_data_catalog(streamed.reset_index(drop=True)),
         )
+
+    def test_finds_datasets_from_the_archive_root(self, tmp_path, config):
+        """Both entry points must reach files nested a full DRS below the given root."""
+        config.cmip7_parser = "drs"
+        adapter = CMIP7DatasetAdapter(config=config)
+        _build_cmip7_archive(tmp_path / "archive", self.DATASETS)
+        root = tmp_path / "archive"
+
+        expected = sum(len(dataset["time_ranges"]) for dataset in self.DATASETS)
+
+        assert len(adapter.find_local_datasets(root)) == expected
+        assert sum(len(chunk) for chunk in adapter.iter_local_datasets(root)) == expected
 
     def test_streaming_yields_nonempty_chunks(self, tmp_path, config):
         config.cmip7_parser = "drs"


### PR DESCRIPTION
Fixes CMIP7 ingestion silently finding zero files. The CMIP7 DRS nests files 12 levels below the archive root, but discovery capped the walk at 10 levels, so an ingest against a `MIP-DRS7` root matched nothing and reported no error.

Rather than raise the cap, this removes the `depth` parameter from discovery entirely. Nothing configured it, every caller hardcoded 10, and it was not acting as a safety guard. Files that sit in the wrong place are already rejected by the DRS parsers and filtered as invalid assets, so the limit only ever decided how far the walk got before that check ran.

All adapters are affected, not just CMIP7, so the same latent failure is gone from CMIP6, obs4MIPs and the ESMValTool reference adapter. CMIP6's DRS is exactly 10 directories deep, so pointing it one level above the archive root used to lose everything in the same silent way.