### PR TITLE
Drop the immutable flag from read-only SQLite connections

### DIFF
--- a/changelog/908.fix.md
+++ b/changelog/908.fix.md
@@ -1,0 +1,3 @@
+Removed the `immutable` flag from read-only SQLite connections.
+The flag told SQLite to skip locking, which did not hold when a background run was writing
+to the same database. The connection is still opened read-only.

--- a/docs/background/architecture.md
+++ b/docs/background/architecture.md
@@ -365,7 +365,7 @@ Key characteristics:
 
 - The backend is a **read-only consumer** of the REF database.
   It opens the database without running migrations
-  (SQLite is opened read-only so the state volume can be mounted read-only)
+  (SQLite is opened with `mode=ro`, so the state volume can be mounted read-only)
   and reports the results the compute engine has already produced.
 - It depends on the `climate-ref` library directly for configuration, models and the provider registry.
   The database schema remains owned by `climate-ref` migrations.

--- a/docs/background/architecture.md
+++ b/docs/background/architecture.md
@@ -365,7 +365,7 @@ Key characteristics:
 
 - The backend is a **read-only consumer** of the REF database.
   It opens the database without running migrations
-  (SQLite can be opened immutable so the state volume can be mounted read-only)
+  (SQLite is opened read-only so the state volume can be mounted read-only)
   and reports the results the compute engine has already produced.
 - It depends on the `climate-ref` library directly for configuration, models and the provider registry.
   The database schema remains owned by `climate-ref` migrations.

--- a/docs/how-to-guides/reading-results-locally.md
+++ b/docs/how-to-guides/reading-results-locally.md
@@ -38,7 +38,7 @@ with Database.from_config(config, read_only=True) as db:
 # `df` is a plain DataFrame and remains valid out here, after the session has closed.
 ```
 
-`read_only=True` opens SQLite in immutable read-only mode and skips migrations,
+`read_only=True` opens SQLite in read-only mode and skips migrations,
 so the read layer never mutates the database you point it at.
 
 `Reader` is a thin entry point.

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -99,10 +99,10 @@ def _make_readonly_sqlite_url(database_url: str) -> tuple[str, dict[str, Any]]:
         return database_url, {}
 
     if encoded_path.startswith("file:"):
-        # Already URI form — caller is responsible for any ro/immutable flags.
+        # Already URI form — caller is responsible for any read-only flags.
         return database_url, {"uri": True}
 
-    return f"sqlite:///file:{encoded_path}?mode=ro&immutable=1&uri=true", {"uri": True}
+    return f"sqlite:///file:{encoded_path}?mode=ro&uri=true", {"uri": True}
 
 
 def _get_database_revision(connection: sqlalchemy.engine.Connection) -> str | None:
@@ -469,7 +469,7 @@ class Database:
         read_only
             If True, open the database in read-only mode and skip migrations.
 
-            SQLite URLs are rewritten to URI form with ``mode=ro&immutable=1``.
+            SQLite URLs are rewritten to URI form with ``mode=ro``.
             For other backends, callers must configure the connecting role as
             read-only themselves.
 

--- a/packages/climate-ref/src/climate_ref/database.py
+++ b/packages/climate-ref/src/climate_ref/database.py
@@ -99,7 +99,7 @@ def _make_readonly_sqlite_url(database_url: str) -> tuple[str, dict[str, Any]]:
         return database_url, {}
 
     if encoded_path.startswith("file:"):
-        # Already URI form — caller is responsible for any read-only flags.
+        # Already URI form, so the caller is responsible for any read-only flags.
         return database_url, {"uri": True}
 
     return f"sqlite:///file:{encoded_path}?mode=ro&uri=true", {"uri": True}

--- a/packages/climate-ref/tests/unit/test_database.py
+++ b/packages/climate-ref/tests/unit/test_database.py
@@ -556,14 +556,14 @@ class TestReadOnlyDatabase:
 
     def test_make_readonly_sqlite_url_rewrites_file_url(self):
         url, connect_args = _make_readonly_sqlite_url("sqlite:////tmp/foo.db")
-        assert url == "sqlite:///file:/tmp/foo.db?mode=ro&immutable=1&uri=true"
+        assert url == "sqlite:///file:/tmp/foo.db?mode=ro&uri=true"
         assert connect_args == {"uri": True}
 
     def test_make_readonly_sqlite_url_preserves_percent_encoding(self):
         """Percent-encoded characters must survive the rewrite unchanged."""
         original = "sqlite:///path%20with%20spaces/db.sqlite"
         url, connect_args = _make_readonly_sqlite_url(original)
-        assert url == "sqlite:///file:path%20with%20spaces/db.sqlite?mode=ro&immutable=1&uri=true"
+        assert url == "sqlite:///file:path%20with%20spaces/db.sqlite?mode=ro&uri=true"
         assert connect_args == {"uri": True}
 
     def test_make_readonly_sqlite_url_preserves_uri_form(self):
@@ -589,7 +589,7 @@ class TestReadOnlyDatabase:
     def test_validate_accepts_uri_form_without_mkdir(self, tmp_path):
         """URI-form URLs are accepted verbatim and do not trigger parent mkdir."""
         missing = tmp_path / "does-not-exist" / "foo.db"
-        url = f"sqlite:///file:{missing}?mode=ro&immutable=1&uri=true"
+        url = f"sqlite:///file:{missing}?mode=ro&uri=true"
 
         # Should not create the parent directory
         assert validate_database_url(url) == url


### PR DESCRIPTION
Removes the `immutable=1` flag from read-only SQLite connections, keeping `mode=ro`.

`immutable=1` promises SQLite that the file cannot change while it is open, so it skips locking and change detection altogether. That promise does not hold in practice, because a background run can be writing to the same database. The result is stale or torn reads that surface as flakiness in the read layer.

`mode=ro` still blocks writes on the connection, so the read-only guarantee is unchanged. The only thing lost is the small speedup from skipping locks.
