### PR TITLE
Cap PMP at two threads per execution

### DIFF
--- a/changelog/911.fix.md
+++ b/changelog/911.fix.md
@@ -1,3 +1,4 @@
-Caps PMP at two threads per execution by default.
-The scientific stack sizes its thread pools from the machine's core count, so several concurrent executions oversubscribe the machine.
-Two threads recover most of the available speedup, and setting any of the thread limit variables in the environment keeps that value.
+PMP executions are now capped at two threads each.
+Without a limit the scientific stack sized its thread pools from the machine's core count,
+so a handful of concurrent executions oversubscribed the machine.
+Setting any of the thread limit variables in the environment still keeps that value.

--- a/changelog/911.fix.md
+++ b/changelog/911.fix.md
@@ -1,1 +1,3 @@
 Caps PMP at two threads per execution by default.
+The scientific stack sizes its thread pools from the machine's core count, so several concurrent executions oversubscribe the machine.
+Two threads recover most of the available speedup, and setting any of the thread limit variables in the environment keeps that value.

--- a/changelog/911.fix.md
+++ b/changelog/911.fix.md
@@ -1,4 +1,4 @@
 PMP executions are now capped at two threads each.
 Without a limit the scientific stack sized its thread pools from the machine's core count,
 so a handful of concurrent executions oversubscribed the machine.
-Setting any of the thread limit variables in the environment still keeps that value.
+Any of the thread limit variables already set in the environment is left alone.

--- a/changelog/911.fix.md
+++ b/changelog/911.fix.md
@@ -1,4 +1,2 @@
 PMP executions are now capped at two threads each.
-Without a limit the scientific stack sized its thread pools from the machine's core count,
-so a handful of concurrent executions oversubscribed the machine.
-Any of the thread limit variables already set in the environment is left alone.
+Without a limit the scientific stack sized its thread pools from the machine's core count.

--- a/changelog/911.fix.md
+++ b/changelog/911.fix.md
@@ -1,0 +1,1 @@
+Caps PMP at two threads per execution by default.

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
@@ -30,6 +30,19 @@ __version__ = importlib.metadata.version("climate-ref-pmp")
 
 _REGISTRY_NAME = "pmp-climatology"
 
+_THREAD_LIMIT_VARS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+)
+
+# Conservative default
+# Without a default BLAS will take as many CPUs as available
+# ~10% improvement over a single thread
+_DEFAULT_THREAD_LIMIT = "2"
+
 
 # Create the PMP diagnostics provider
 # PMP uses a conda environment to run the diagnostics
@@ -48,6 +61,11 @@ class PMPDiagnosticProvider(CondaDiagnosticProvider):
         if "FI_PROVIDER" not in os.environ:  # pragma: no branch
             logger.debug("Setting env variable 'FI_PROVIDER=tcp'")
             self.env_overrides["FI_PROVIDER"] = "tcp"
+
+        for name in _THREAD_LIMIT_VARS:
+            if name not in os.environ:
+                logger.debug(f"Setting env variable '{name}={_DEFAULT_THREAD_LIMIT}'")
+                self.env_overrides[name] = _DEFAULT_THREAD_LIMIT
 
     def fetch_data(self, config: Config) -> None:
         """Fetch PMP climatology data."""

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
@@ -62,9 +62,10 @@ class PMPDiagnosticProvider(CondaDiagnosticProvider):
             logger.debug("Setting env variable 'FI_PROVIDER=tcp'")
             self.env_overrides["FI_PROVIDER"] = "tcp"
 
-        for name in _THREAD_LIMIT_VARS:
-            if name not in os.environ:
-                logger.debug(f"Setting env variable '{name}={_DEFAULT_THREAD_LIMIT}'")
+        # One of these being set means someone has chosen a thread budget, so leave all five alone.
+        if not any(name in os.environ for name in _THREAD_LIMIT_VARS):
+            logger.debug(f"Limiting threads to {_DEFAULT_THREAD_LIMIT}")
+            for name in _THREAD_LIMIT_VARS:
                 self.env_overrides[name] = _DEFAULT_THREAD_LIMIT
 
     def fetch_data(self, config: Config) -> None:

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/__init__.py
@@ -38,9 +38,8 @@ _THREAD_LIMIT_VARS = (
     "VECLIB_MAXIMUM_THREADS",
 )
 
-# Conservative default
+# Conservative default for ~10% improvement over a single thread
 # Without a default BLAS will take as many CPUs as available
-# ~10% improvement over a single thread
 _DEFAULT_THREAD_LIMIT = "2"
 
 
@@ -62,7 +61,7 @@ class PMPDiagnosticProvider(CondaDiagnosticProvider):
             logger.debug("Setting env variable 'FI_PROVIDER=tcp'")
             self.env_overrides["FI_PROVIDER"] = "tcp"
 
-        # One of these being set means someone has chosen a thread budget, so leave all five alone.
+        # If any budgets are set, don't set default values
         if not any(name in os.environ for name in _THREAD_LIMIT_VARS):
             logger.debug(f"Limiting threads to {_DEFAULT_THREAD_LIMIT}")
             for name in _THREAD_LIMIT_VARS:

--- a/packages/climate-ref-pmp/tests/unit/test_provider.py
+++ b/packages/climate-ref-pmp/tests/unit/test_provider.py
@@ -2,7 +2,13 @@ import builtins
 from pathlib import Path
 
 import pooch
-from climate_ref_pmp import PMPDiagnosticProvider, __version__, provider
+from climate_ref_pmp import (
+    _DEFAULT_THREAD_LIMIT,
+    _THREAD_LIMIT_VARS,
+    PMPDiagnosticProvider,
+    __version__,
+    provider,
+)
 
 from climate_ref_core.data import LayeredResource, PackagedResource
 
@@ -110,6 +116,26 @@ class TestPMPProviderHooks:
         )
         assert "FI_PROVIDER" in test_provider.env_overrides
         assert test_provider.env_overrides["FI_PROVIDER"] == "tcp"
+        for name in _THREAD_LIMIT_VARS:
+            assert test_provider.env_overrides[name] == _DEFAULT_THREAD_LIMIT
+
+    def test_configure_keeps_user_thread_limits(self, mocker, tmp_path, monkeypatch):
+        """A thread limit already in the environment is left alone."""
+        monkeypatch.setenv("OMP_NUM_THREADS", "4")
+        test_provider = PMPDiagnosticProvider("PMP-Test", "1.0")
+        mock_config = mocker.Mock()
+        mock_config.paths.software = tmp_path / "software"
+        mock_config.ignore_datasets_file = tmp_path / "ignore.yaml"
+        mock_config.ignore_datasets_file.touch()
+        mock_config.ignore_datasets_resource = LayeredResource(
+            packaged=PackagedResource("climate_ref", "default_ignore_datasets.yaml"),
+            override=mock_config.ignore_datasets_file,
+        )
+
+        test_provider.configure(mock_config)
+
+        assert "OMP_NUM_THREADS" not in test_provider.env_overrides
+        assert test_provider.env_overrides["MKL_NUM_THREADS"] == _DEFAULT_THREAD_LIMIT
 
     def test_ingest_data_skips_when_climate_ref_not_installed(self, mocker, caplog):
         """Test ingest_data gracefully skips when climate-ref package is not installed."""

--- a/packages/climate-ref-pmp/tests/unit/test_provider.py
+++ b/packages/climate-ref-pmp/tests/unit/test_provider.py
@@ -13,6 +13,21 @@ from climate_ref_pmp import (
 from climate_ref_core.data import LayeredResource, PackagedResource
 
 
+def configured_provider(mocker, tmp_path):
+    """Build a provider and run `configure` against a mock config rooted at `tmp_path`."""
+    test_provider = PMPDiagnosticProvider("PMP-Test", "1.0")
+    mock_config = mocker.Mock()
+    mock_config.paths.software = tmp_path / "software"
+    mock_config.ignore_datasets_file = tmp_path / "ignore.yaml"
+    mock_config.ignore_datasets_file.touch()
+    mock_config.ignore_datasets_resource = LayeredResource(
+        packaged=PackagedResource("climate_ref", "default_ignore_datasets.yaml"),
+        override=mock_config.ignore_datasets_file,
+    )
+    test_provider.configure(mock_config)
+    return test_provider, mock_config
+
+
 def test_provider():
     assert provider.name == "PMP"
     assert provider.slug == "pmp"
@@ -97,17 +112,7 @@ class TestPMPProviderHooks:
 
     def test_configure_sets_env_vars(self, mocker, tmp_path):
         """Test that configure sets the required environment variables."""
-        test_provider = PMPDiagnosticProvider("PMP-Test", "1.0")
-        mock_config = mocker.Mock()
-        mock_config.paths.software = tmp_path / "software"
-        mock_config.ignore_datasets_file = tmp_path / "ignore.yaml"
-        mock_config.ignore_datasets_file.touch()
-        mock_config.ignore_datasets_resource = LayeredResource(
-            packaged=PackagedResource("climate_ref", "default_ignore_datasets.yaml"),
-            override=mock_config.ignore_datasets_file,
-        )
-
-        test_provider.configure(mock_config)
+        test_provider, mock_config = configured_provider(mocker, tmp_path)
 
         assert "PCMDI_CONDA_EXE" in test_provider.env_overrides
         # The path is recorded without installing anything, so `configure` stays offline.
@@ -120,22 +125,12 @@ class TestPMPProviderHooks:
             assert test_provider.env_overrides[name] == _DEFAULT_THREAD_LIMIT
 
     def test_configure_keeps_user_thread_limits(self, mocker, tmp_path, monkeypatch):
-        """A thread limit already in the environment is left alone."""
+        """One thread limit in the environment suppresses the default for all of them."""
         monkeypatch.setenv("OMP_NUM_THREADS", "4")
-        test_provider = PMPDiagnosticProvider("PMP-Test", "1.0")
-        mock_config = mocker.Mock()
-        mock_config.paths.software = tmp_path / "software"
-        mock_config.ignore_datasets_file = tmp_path / "ignore.yaml"
-        mock_config.ignore_datasets_file.touch()
-        mock_config.ignore_datasets_resource = LayeredResource(
-            packaged=PackagedResource("climate_ref", "default_ignore_datasets.yaml"),
-            override=mock_config.ignore_datasets_file,
-        )
+        test_provider, _ = configured_provider(mocker, tmp_path)
 
-        test_provider.configure(mock_config)
-
-        assert "OMP_NUM_THREADS" not in test_provider.env_overrides
-        assert test_provider.env_overrides["MKL_NUM_THREADS"] == _DEFAULT_THREAD_LIMIT
+        for name in _THREAD_LIMIT_VARS:
+            assert name not in test_provider.env_overrides
 
     def test_ingest_data_skips_when_climate_ref_not_installed(self, mocker, caplog):
         """Test ingest_data gracefully skips when climate-ref package is not installed."""

--- a/packages/climate-ref-pmp/tests/unit/test_provider.py
+++ b/packages/climate-ref-pmp/tests/unit/test_provider.py
@@ -110,8 +110,10 @@ class TestPMPProviderHooks:
         result = provider.validate_setup(mock_config)
         assert result is True
 
-    def test_configure_sets_env_vars(self, mocker, tmp_path):
+    def test_configure_sets_env_vars(self, mocker, tmp_path, monkeypatch):
         """Test that configure sets the required environment variables."""
+        for name in _THREAD_LIMIT_VARS:
+            monkeypatch.delenv(name, raising=False)
         test_provider, mock_config = configured_provider(mocker, tmp_path)
 
         assert "PCMDI_CONDA_EXE" in test_provider.env_overrides


### PR DESCRIPTION
Caps PMP at two threads per execution by default, by setting the usual thread limit variables in the provider's environment overrides.

The scientific stack sizes its thread pools from the machine's core count, so a handful of concurrent PMP executions is enough to oversubscribe a box like gus. The cap is all or nothing. If any of the five variables is already set then none of them are touched, so a deliberate `OMP_NUM_THREADS=8` is not half-overridden by a forced MKL limit.

Timings for the PDO cmip6 test case on a laptop, same passing output in all three runs:

- 1 thread: 189.7s wall, 189.6s cpu
- 2 threads: 161.8s wall, 176.0s cpu
- 4 threads: 163.9s wall, 195.4s cpu

Two threads gets essentially all of the speedup that is there. Beyond that the diagnostics are bound by serial Python and I/O, so extra cores only add contention.

Two things this does not cover. Dask sizes its own threaded scheduler from the core count and ignores these variables, so xcdat work inside PMP can still spread wider than two. The other conda providers have the same exposure and are worth a separate look.
