### PR TITLE
feat: publish the baseline diff report and write the PR comment

### DIFF
--- a/changelog/912.feature.md
+++ b/changelog/912.feature.md
@@ -1,8 +1,4 @@
 `ref test-cases diff --upload <prefix>` publishes the report to a public object store,
 and `--comment-output <path>` writes the pull request comment markdown that links into it.
-The comment is one table row per changed case, so its size no longer grows with the diff.
 
-Reports go to their own store, configured by `REF_REPORT_STORE_URL`, `REF_REPORT_STORE_BUCKET`
-and `REF_REPORT_STORE_S3_ENDPOINT_URL`, with credentials read from
-`REF_REPORT_STORE_ACCESS_KEY_ID` / `REF_REPORT_STORE_SECRET_ACCESS_KEY` at upload time.
-It is a separate bucket to the baselines store because an R2 token cannot be scoped to a prefix.
+Reports are stored in their own bucket, separate from the baselines.

--- a/changelog/912.feature.md
+++ b/changelog/912.feature.md
@@ -1,0 +1,8 @@
+`ref test-cases diff --upload <prefix>` publishes the report to a public object store,
+and `--comment-output <path>` writes the pull request comment markdown that links into it.
+The comment is one table row per changed case, so its size no longer grows with the diff.
+
+Reports go to their own store, configured by `REF_REPORT_STORE_URL`, `REF_REPORT_STORE_BUCKET`
+and `REF_REPORT_STORE_S3_ENDPOINT_URL`, with credentials read from
+`REF_REPORT_STORE_ACCESS_KEY_ID` / `REF_REPORT_STORE_SECRET_ACCESS_KEY` at upload time.
+It is a separate bucket to the baselines store because an R2 token cannot be scoped to a prefix.

--- a/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
@@ -37,6 +37,10 @@ from climate_ref_core.regression.manifest import (
     sha256_file,
     verify_committed_integrity,
 )
+from climate_ref_core.regression.report_store import (
+    ReportStore,
+    build_report_store,
+)
 from climate_ref_core.regression.store import (
     NativeStore,
     NativeStoreUnavailableError,
@@ -53,11 +57,13 @@ __all__ = [
     "NativeEntry",
     "NativeStore",
     "NativeStoreUnavailableError",
+    "ReportStore",
     "S3WriteConfig",
     "Tolerance",
     "assert_bundle_regression",
     "build_native_snapshot",
     "build_native_store",
+    "build_report_store",
     "compare_json_content",
     "compute_committed_digests",
     "decide_coupling",

--- a/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
@@ -6,12 +6,12 @@ That makes it the opposite of :class:`~climate_ref_core.regression.store.NativeS
 content-addressed and must stay that way, so this is a sibling class rather than a new method on it.
 
 Reports live in their own public bucket, served at ``{url}/{key}``.
-The bucket is separate from the baselines bucket because an R2 token cannot be scoped to a prefix,
-so a token that can write reports must not also be able to overwrite baseline blobs.
 
-Write credentials are resolved from ``REF_REPORT_STORE_ACCESS_KEY_ID`` /
-``REF_REPORT_STORE_SECRET_ACCESS_KEY``, then ``REF_REPORT_STORE_PROFILE``, then boto3's default
-chain. They are never read from the persisted config.
+Write credentials are resolved from the following in order:
+
+- ``REF_REPORT_STORE_ACCESS_KEY_ID`` / ``REF_REPORT_STORE_SECRET_ACCESS_KEY``,
+- ``REF_REPORT_STORE_PROFILE``,
+- boto3's default chain
 """
 
 import os

--- a/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
@@ -2,8 +2,10 @@
 Named-key store for hosted baseline diff reports.
 
 A diff report is a small static site, so its objects are addressed by path rather than by digest.
-That makes it the opposite of :class:`~climate_ref_core.regression.store.NativeStore`, which is
-content-addressed and must stay that way, so this is a sibling class rather than a new method on it.
+That is the one thing it does not share with :class:`~climate_ref_core.regression.store.NativeStore`,
+which is content-addressed and must stay that way.
+Everything below the key (where the store lives, how it authenticates, preflight, putting a file)
+is the shared transport in :mod:`~climate_ref_core.regression.store`.
 
 Reports live in their own public bucket, served at ``{url}/{key}``.
 
@@ -14,11 +16,9 @@ Write credentials are resolved from the following in order:
 - boto3's default chain
 """
 
-import os
 import re
 import shutil
 from pathlib import Path
-from typing import Protocol
 
 from attrs import field, frozen
 from loguru import logger
@@ -26,14 +26,11 @@ from loguru import logger
 from climate_ref_core.paths import safe_path
 
 from .store import (
-    _AUTH_REJECTED_STATUSES,
-    _HTTP_FORBIDDEN,
-    _HTTP_NOT_FOUND,
-    _PREFLIGHT_PROBE_KEY,
-    NativeStoreUnavailableError,
     S3WriteConfig,
-    _http_status,
     _local_root,
+    _preflight_store,
+    _StoreConfigProtocol,
+    _write_config_from_env,
 )
 
 _KEY_PATTERN = re.compile(r"[A-Za-z0-9._/-]+")
@@ -177,90 +174,15 @@ class ReportStore:
         """
         Verify the store is reachable and usable before uploading to it.
 
-        A local store's root is created if needed and checked for writability.
-        A writable remote store performs a cheap authenticated ``HEAD`` on a sentinel key,
-        which is expected to be absent, so a bad credential is caught before the upload starts.
-
         Raises
         ------
         NativeStoreUnavailableError
             If the store cannot be reached or used, with an operator-facing message.
         """
-        root = self.root
-        if root is not None:
-            try:
-                root.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
-                raise NativeStoreUnavailableError(
-                    f"Local report store root {root} could not be created: {exc}"
-                ) from exc
-            if not os.access(root, os.W_OK):
-                raise NativeStoreUnavailableError(f"Local report store root {root} is not writable.")
-            logger.debug(f"Local report store ready at {root}")
-            return
-        write = self.write
-        if write is None:
-            return
-
-        from botocore.exceptions import BotoCoreError, ClientError  # noqa: PLC0415 - optional dep
-
-        try:
-            write.client().head_object(Bucket=write.bucket, Key=_PREFLIGHT_PROBE_KEY)
-        except BotoCoreError as exc:
-            # Covers NoCredentialsError, where the whole chain resolved nothing, and DNS failures.
-            raise NativeStoreUnavailableError(
-                f"Report store could not be reached for bucket {write.bucket!r} at "
-                f"{write.endpoint_url}: {exc} Check REF_REPORT_STORE_PROFILE, or "
-                f"REF_REPORT_STORE_ACCESS_KEY_ID / REF_REPORT_STORE_SECRET_ACCESS_KEY."
-            ) from exc
-        except ClientError as exc:
-            status = _http_status(exc)
-            if status == _HTTP_NOT_FOUND:
-                pass  # authenticated, and the probe object is simply absent, so the store is usable
-            elif status in _AUTH_REJECTED_STATUSES:
-                raise NativeStoreUnavailableError(
-                    f"Report store authentication failed (HTTP {status}) for bucket {write.bucket!r} at "
-                    f"{write.endpoint_url}: the credentials were rejected or malformed. Check "
-                    f"REF_REPORT_STORE_PROFILE, or REF_REPORT_STORE_ACCESS_KEY_ID / "
-                    f"REF_REPORT_STORE_SECRET_ACCESS_KEY."
-                ) from exc
-            elif status == _HTTP_FORBIDDEN:
-                raise NativeStoreUnavailableError(
-                    f"Report store access denied (HTTP 403) for bucket {write.bucket!r} at "
-                    f"{write.endpoint_url}: the request was forbidden. The secret key may be wrong, "
-                    f"or the token may lack object read and write on this bucket. Check the "
-                    f"credentials and the token's permissions."
-                ) from exc
-            else:
-                raise NativeStoreUnavailableError(
-                    f"Report store preflight failed (HTTP {status}) for bucket {write.bucket!r} at "
-                    f"{write.endpoint_url}: {exc}"
-                ) from exc
-        logger.info(f"Report store authenticated: bucket {write.bucket!r} at {write.endpoint_url}")
+        _preflight_store(self.root, self.write, "Report store")
 
 
-class _ReportStoreConfigProtocol(Protocol):
-    """
-    Structural protocol for the report-store config object expected by :func:`build_report_store`.
-
-    Keeps ``climate_ref_core`` free of any import dependency on ``climate_ref``, so both
-    :class:`climate_ref.config.ReportStoreConfig` and test doubles satisfy it.
-
-    ``s3_endpoint_url`` and ``bucket`` are non-secret routing config. Write credentials are
-    intentionally **not** part of this protocol, and are read from the environment instead.
-    """
-
-    @property
-    def url(self) -> str: ...
-
-    @property
-    def s3_endpoint_url(self) -> str: ...
-
-    @property
-    def bucket(self) -> str: ...
-
-
-def build_report_store(config: _ReportStoreConfigProtocol, *, writable: bool) -> ReportStore:
+def build_report_store(config: _StoreConfigProtocol, *, writable: bool) -> ReportStore:
     """
     Build a :class:`ReportStore` from a report-store config object.
 
@@ -295,24 +217,7 @@ def build_report_store(config: _ReportStoreConfigProtocol, *, writable: bool) ->
     if not writable or store.root is not None:
         # A local store is already writable, and a read-only store needs no credentials.
         return store
-    # Checked here rather than in S3WriteConfig, whose message names the native store's env vars.
-    if not config.s3_endpoint_url:
-        raise ValueError(
-            "Uploading a report needs an S3 endpoint URL. Set REF_REPORT_STORE_S3_ENDPOINT_URL "
-            "(e.g. https://<account>.r2.cloudflarestorage.com)."
-        )
-    if not config.bucket:
-        raise ValueError(
-            "Uploading a report needs a bucket name. Set REF_REPORT_STORE_BUCKET "
-            "(e.g. ref-baselines-reports)."
-        )
     return ReportStore(
         url=config.url,
-        write=S3WriteConfig(
-            endpoint_url=config.s3_endpoint_url,
-            bucket=config.bucket,
-            access_key_id=os.environ.get("REF_REPORT_STORE_ACCESS_KEY_ID", ""),
-            secret_access_key=os.environ.get("REF_REPORT_STORE_SECRET_ACCESS_KEY", ""),
-            profile=os.environ.get("REF_REPORT_STORE_PROFILE", ""),
-        ),
+        write=_write_config_from_env(config.s3_endpoint_url, config.bucket, "REF_REPORT_STORE"),
     )

--- a/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
@@ -200,10 +200,17 @@ class ReportStore:
         if write is None:
             return
 
-        from botocore.exceptions import ClientError  # noqa: PLC0415 - optional dependency
+        from botocore.exceptions import BotoCoreError, ClientError  # noqa: PLC0415 - optional dep
 
         try:
             write.client().head_object(Bucket=write.bucket, Key=_PREFLIGHT_PROBE_KEY)
+        except BotoCoreError as exc:
+            # Covers NoCredentialsError, where the whole chain resolved nothing, and DNS failures.
+            raise NativeStoreUnavailableError(
+                f"Report store could not be reached for bucket {write.bucket!r} at "
+                f"{write.endpoint_url}: {exc} Check REF_REPORT_STORE_PROFILE, or "
+                f"REF_REPORT_STORE_ACCESS_KEY_ID / REF_REPORT_STORE_SECRET_ACCESS_KEY."
+            ) from exc
         except ClientError as exc:
             status = _http_status(exc)
             if status == _HTTP_NOT_FOUND:

--- a/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
@@ -301,7 +301,8 @@ def build_report_store(config: _ReportStoreConfigProtocol, *, writable: bool) ->
         )
     if not config.bucket:
         raise ValueError(
-            "Uploading a report needs a bucket name. Set REF_REPORT_STORE_BUCKET (e.g. ref-baseline-reports)."
+            "Uploading a report needs a bucket name. Set REF_REPORT_STORE_BUCKET "
+            "(e.g. ref-baselines-reports)."
         )
     return ReportStore(
         url=config.url,

--- a/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
@@ -1,0 +1,298 @@
+"""
+Named-key store for hosted baseline diff reports.
+
+A diff report is a small static site, so its objects are addressed by path rather than by digest.
+That makes it the opposite of :class:`~climate_ref_core.regression.store.NativeStore`, which is
+content-addressed and must stay that way, so this is a sibling class rather than a new method on it.
+
+Reports live in their own public bucket, served at ``{url}/{key}``.
+The bucket is separate from the baselines bucket because an R2 token cannot be scoped to a prefix,
+so a token that can write reports must not also be able to overwrite baseline blobs.
+
+Write credentials are resolved from ``REF_REPORT_STORE_ACCESS_KEY_ID`` /
+``REF_REPORT_STORE_SECRET_ACCESS_KEY``, then ``REF_REPORT_STORE_PROFILE``, then boto3's default
+chain. They are never read from the persisted config.
+"""
+
+import os
+import re
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+
+from attrs import field, frozen
+from loguru import logger
+
+from .store import (
+    _AUTH_REJECTED_STATUSES,
+    _HTTP_FORBIDDEN,
+    _HTTP_NOT_FOUND,
+    _PREFLIGHT_PROBE_KEY,
+    NativeStoreUnavailableError,
+    S3WriteConfig,
+    _http_status,
+    _local_root,
+)
+
+_KEY_PATTERN = re.compile(r"[A-Za-z0-9._/-]+")
+
+
+def _validate_key(key: str) -> str:
+    """
+    Check a report key is a safe relative path and return it.
+
+    A key becomes a path under the local root, so a key that escapes the root or carries
+    shell-hostile characters is rejected before it is ever joined.
+
+    Parameters
+    ----------
+    key
+        The key to check, for example ``912/0c7e1d4abc12/index.html``.
+
+    Returns
+    -------
+    :
+        The key, unchanged.
+
+    Raises
+    ------
+    ValueError
+        If the key is empty, absolute, contains a ``..`` segment, or uses characters
+        outside ``[A-Za-z0-9._/-]``.
+    """
+    if not key or not _KEY_PATTERN.fullmatch(key):
+        raise ValueError(
+            f"Invalid report store key {key!r}: keys must be non-empty and may only contain "
+            "letters, digits, dot, underscore, hyphen and forward slash."
+        )
+    if key.startswith("/"):
+        raise ValueError(f"Invalid report store key {key!r}: keys must be relative, not absolute.")
+    if ".." in PurePosixPath(key).parts:
+        raise ValueError(f"Invalid report store key {key!r}: keys must not contain a '..' segment.")
+    return key
+
+
+@frozen
+class ReportStore:
+    """
+    Named-key store for hosted baseline diff reports.
+
+    A local store (a ``file://`` URL or a bare path) writes under its root and needs no credentials.
+    A remote store writes through an :class:`S3WriteConfig` and is served at ``{url}/{key}``.
+
+    Parameters
+    ----------
+    url
+        Where reports are served from: an ``http(s)://`` base URL, a ``file:///absolute/path``
+        URL, or a bare filesystem path.
+    write
+        The S3 endpoint, bucket and credentials a remote store writes with.
+        ``None`` leaves a remote store read-only.
+        A local store ignores it and is always writable.
+    """
+
+    url: str
+    write: S3WriteConfig | None = None
+    root: Path | None = field(init=False)
+    """The local store root, or ``None`` when this store is remote."""
+
+    @root.default
+    def _resolve_root(self) -> Path | None:
+        """Resolve the local root once at construction, which also validates the URL."""
+        return _local_root(self.url)
+
+    def url_for(self, key: str) -> str:
+        """
+        Return the public URL a key is served at.
+
+        Parameters
+        ----------
+        key
+            The key, relative and slash-separated.
+
+        Returns
+        -------
+        :
+            An ``http(s)://`` URL for a remote store, or a ``file://`` URL for a local one.
+
+        Raises
+        ------
+        ValueError
+            If the key is not a safe relative path.
+        """
+        _validate_key(key)
+        root = self.root
+        if root is not None:
+            return (root / key).absolute().as_uri()
+        return f"{self.url.rstrip('/')}/{key}"
+
+    def put(self, key: str, path: Path, content_type: str) -> str:
+        """
+        Store ``path`` under ``key``, overwriting whatever was there.
+
+        Reports are rewritten whenever a pull request is re-minted, so a put always replaces.
+
+        Parameters
+        ----------
+        key
+            The key to store under, relative and slash-separated.
+        path
+            The local file to store.
+        content_type
+            The MIME type the object is served with. A browser will not render an
+            uploaded page without it, since R2 defaults to a binary type.
+
+        Returns
+        -------
+        :
+            The URL the key is served at.
+
+        Raises
+        ------
+        ValueError
+            If the key is not a safe relative path.
+        NotImplementedError
+            If this is an anonymous remote store, which cannot write.
+        """
+        _validate_key(key)
+        root = self.root
+        if root is not None:
+            dest = root / key
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(path), str(dest))
+        else:
+            write = self.write
+            if write is None:
+                raise NotImplementedError(
+                    f"Report store {self.url} is a public-read store, so put() is not supported. "
+                    "Upload against a local path or a credentialed remote store."
+                )
+            write.client().upload_file(str(path), write.bucket, key, ExtraArgs={"ContentType": content_type})
+        logger.debug(f"ReportStore.put: {path} -> {key}")
+        return self.url_for(key)
+
+    def preflight(self) -> None:
+        """
+        Verify the store is reachable and usable before uploading to it.
+
+        A local store's root is created if needed and checked for writability.
+        A writable remote store performs a cheap authenticated ``HEAD`` on a sentinel key,
+        which is expected to be absent, so a bad credential is caught before the upload starts.
+
+        Raises
+        ------
+        NativeStoreUnavailableError
+            If the store cannot be reached or used, with an operator-facing message.
+        """
+        root = self.root
+        if root is not None:
+            try:
+                root.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                raise NativeStoreUnavailableError(
+                    f"Local report store root {root} could not be created: {exc}"
+                ) from exc
+            if not os.access(root, os.W_OK):
+                raise NativeStoreUnavailableError(f"Local report store root {root} is not writable.")
+            logger.debug(f"Local report store ready at {root}")
+            return
+        write = self.write
+        if write is None:
+            return
+
+        from botocore.exceptions import ClientError  # noqa: PLC0415 - optional dependency
+
+        try:
+            write.client().head_object(Bucket=write.bucket, Key=_PREFLIGHT_PROBE_KEY)
+        except ClientError as exc:
+            status = _http_status(exc)
+            if status == _HTTP_NOT_FOUND:
+                pass  # authenticated, and the probe object is simply absent, so the store is usable
+            elif status in _AUTH_REJECTED_STATUSES:
+                raise NativeStoreUnavailableError(
+                    f"Report store authentication failed (HTTP {status}) for bucket {write.bucket!r} at "
+                    f"{write.endpoint_url}: the credentials were rejected or malformed. Check "
+                    f"REF_REPORT_STORE_PROFILE, or REF_REPORT_STORE_ACCESS_KEY_ID / "
+                    f"REF_REPORT_STORE_SECRET_ACCESS_KEY."
+                ) from exc
+            elif status == _HTTP_FORBIDDEN:
+                raise NativeStoreUnavailableError(
+                    f"Report store access denied (HTTP 403) for bucket {write.bucket!r} at "
+                    f"{write.endpoint_url}: the request was forbidden. The secret key may be wrong, "
+                    f"or the token may lack object read and write on this bucket. Check the "
+                    f"credentials and the token's permissions."
+                ) from exc
+            else:
+                raise NativeStoreUnavailableError(
+                    f"Report store preflight failed (HTTP {status}) for bucket {write.bucket!r} at "
+                    f"{write.endpoint_url}: {exc}"
+                ) from exc
+        logger.info(f"Report store authenticated: bucket {write.bucket!r} at {write.endpoint_url}")
+
+
+class _ReportStoreConfigProtocol(Protocol):
+    """
+    Structural protocol for the report-store config object expected by :func:`build_report_store`.
+
+    Keeps ``climate_ref_core`` free of any import dependency on ``climate_ref``, so both
+    :class:`climate_ref.config.ReportStoreConfig` and test doubles satisfy it.
+
+    ``s3_endpoint_url`` and ``bucket`` are non-secret routing config. Write credentials are
+    intentionally **not** part of this protocol, and are read from the environment instead.
+    """
+
+    @property
+    def url(self) -> str: ...
+
+    @property
+    def s3_endpoint_url(self) -> str: ...
+
+    @property
+    def bucket(self) -> str: ...
+
+
+def build_report_store(config: _ReportStoreConfigProtocol, *, writable: bool) -> ReportStore:
+    """
+    Build a :class:`ReportStore` from a report-store config object.
+
+    With ``writable=False`` the returned store is anonymous and credential-free.
+    With ``writable=True`` and a remote URL the S3 endpoint and bucket come from the config,
+    and authentication is read from the environment
+    (``REF_REPORT_STORE_ACCESS_KEY_ID`` / ``REF_REPORT_STORE_SECRET_ACCESS_KEY``,
+    else ``REF_REPORT_STORE_PROFILE``, else boto3's default chain),
+    so secrets never live in the persisted config.
+    A local store is always readable and writable, so ``writable`` makes no difference to it.
+
+    Parameters
+    ----------
+    config
+        A config object providing ``url``, ``s3_endpoint_url`` and ``bucket``.
+        Typically ``app_config.report_store``.
+    writable
+        Whether the store must be able to write.
+
+    Returns
+    -------
+    :
+        The configured store.
+
+    Raises
+    ------
+    ValueError
+        If the URL scheme is unrecognised, or a writable remote store is requested
+        without an S3 endpoint / bucket configured.
+    """
+    store = ReportStore(url=config.url)
+    if not writable or store.root is not None:
+        # A local store is already writable, and a read-only store needs no credentials.
+        return store
+    return ReportStore(
+        url=config.url,
+        write=S3WriteConfig(
+            endpoint_url=config.s3_endpoint_url,
+            bucket=config.bucket,
+            access_key_id=os.environ.get("REF_REPORT_STORE_ACCESS_KEY_ID", ""),
+            secret_access_key=os.environ.get("REF_REPORT_STORE_SECRET_ACCESS_KEY", ""),
+            profile=os.environ.get("REF_REPORT_STORE_PROFILE", ""),
+        ),
+    )

--- a/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
@@ -286,6 +286,16 @@ def build_report_store(config: _ReportStoreConfigProtocol, *, writable: bool) ->
     if not writable or store.root is not None:
         # A local store is already writable, and a read-only store needs no credentials.
         return store
+    # Checked here rather than in S3WriteConfig, whose message names the native store's env vars.
+    if not config.s3_endpoint_url:
+        raise ValueError(
+            "Uploading a report needs an S3 endpoint URL. Set REF_REPORT_STORE_S3_ENDPOINT_URL "
+            "(e.g. https://<account>.r2.cloudflarestorage.com)."
+        )
+    if not config.bucket:
+        raise ValueError(
+            "Uploading a report needs a bucket name. Set REF_REPORT_STORE_BUCKET (e.g. ref-baseline-reports)."
+        )
     return ReportStore(
         url=config.url,
         write=S3WriteConfig(

--- a/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/report_store.py
@@ -17,11 +17,13 @@ chain. They are never read from the persisted config.
 import os
 import re
 import shutil
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Protocol
 
 from attrs import field, frozen
 from loguru import logger
+
+from climate_ref_core.paths import safe_path
 
 from .store import (
     _AUTH_REJECTED_STATUSES,
@@ -37,39 +39,39 @@ from .store import (
 _KEY_PATTERN = re.compile(r"[A-Za-z0-9._/-]+")
 
 
-def _validate_key(key: str) -> str:
+def _validate_key(key: str, base: Path | None = None) -> Path:
     """
-    Check a report key is a safe relative path and return it.
+    Check a report key is a safe relative path and return the path it names.
 
-    A key becomes a path under the local root, so a key that escapes the root or carries
-    shell-hostile characters is rejected before it is ever joined.
+    The character class is the object-key rule, narrower than a filesystem path because the key
+    also has to survive a URL. Containment is left to :func:`safe_path`, which is what the rest
+    of the regression package validates paths with.
 
     Parameters
     ----------
     key
         The key to check, for example ``912/0c7e1d4abc12/index.html``.
+    base
+        The local store root the key is joined onto, or ``None`` for a remote store,
+        where there is no directory to escape.
 
     Returns
     -------
     :
-        The key, unchanged.
+        ``base / key`` when a base is given, otherwise the key as a relative path.
 
     Raises
     ------
     ValueError
-        If the key is empty, absolute, contains a ``..`` segment, or uses characters
-        outside ``[A-Za-z0-9._/-]``.
+        If the key uses characters outside ``[A-Za-z0-9._/-]``, is empty, absolute, or
+        contains a ``..`` segment, or if it escapes ``base``.
     """
-    if not key or not _KEY_PATTERN.fullmatch(key):
+    if not _KEY_PATTERN.fullmatch(key):
         raise ValueError(
-            f"Invalid report store key {key!r}: keys must be non-empty and may only contain "
-            "letters, digits, dot, underscore, hyphen and forward slash."
+            f"Unsafe report store key {key!r}: may only contain letters, digits, dot, "
+            "underscore, hyphen and forward slash."
         )
-    if key.startswith("/"):
-        raise ValueError(f"Invalid report store key {key!r}: keys must be relative, not absolute.")
-    if ".." in PurePosixPath(key).parts:
-        raise ValueError(f"Invalid report store key {key!r}: keys must not contain a '..' segment.")
-    return key
+    return safe_path(key, base, label="report store key")
 
 
 @frozen
@@ -120,10 +122,10 @@ class ReportStore:
         ValueError
             If the key is not a safe relative path.
         """
-        _validate_key(key)
         root = self.root
         if root is not None:
-            return (root / key).absolute().as_uri()
+            return _validate_key(key, root).absolute().as_uri()
+        _validate_key(key)
         return f"{self.url.rstrip('/')}/{key}"
 
     def put(self, key: str, path: Path, content_type: str) -> str:
@@ -154,13 +156,13 @@ class ReportStore:
         NotImplementedError
             If this is an anonymous remote store, which cannot write.
         """
-        _validate_key(key)
         root = self.root
         if root is not None:
-            dest = root / key
+            dest = _validate_key(key, root)
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(str(path), str(dest))
         else:
+            _validate_key(key)
             write = self.write
             if write is None:
                 raise NotImplementedError(

--- a/packages/climate-ref-core/src/climate_ref_core/regression/store.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/store.py
@@ -213,6 +213,9 @@ class S3WriteConfig:
     profile
         Named AWS/R2 profile to authenticate with, or ``""`` for the default session.
         Ignored when explicit ``access_key_id`` / ``secret_access_key`` are supplied.
+    env_prefix
+        Prefix of the environment variables this config was resolved from, for example
+        ``REF_REPORT_STORE``. Only used to name the right variable in an error message.
     """
 
     endpoint_url: str
@@ -220,22 +223,131 @@ class S3WriteConfig:
     access_key_id: str = field(default="", repr=False)
     secret_access_key: str = field(default="", repr=False)
     profile: str = ""
+    env_prefix: str = "REF_NATIVE_STORE"
 
     def __attrs_post_init__(self) -> None:
         """Fail fast at construction (mint startup) when the routing config is missing."""
         if not self.endpoint_url:
             raise ValueError(
-                "R2 native store requires an S3 endpoint URL. Set REF_NATIVE_STORE_S3_ENDPOINT_URL "
+                f"R2 store requires an S3 endpoint URL. Set {self.env_prefix}_S3_ENDPOINT_URL "
                 "(e.g. https://<account>.eu.r2.cloudflarestorage.com)."
             )
         if not self.bucket:
             raise ValueError(
-                "R2 native store requires a bucket name. Set REF_NATIVE_STORE_BUCKET (e.g. ref-baselines)."
+                f"R2 store requires a bucket name. Set {self.env_prefix}_BUCKET (e.g. ref-baselines)."
             )
 
     def client(self) -> Any:
         """Return the cached boto3 S3 client for this endpoint and these credentials."""
         return _s3_client(self.endpoint_url, self.access_key_id, self.secret_access_key, self.profile)
+
+
+def _preflight_store(root: Path | None, write: S3WriteConfig | None, label: str) -> None:
+    """
+    Verify a store is reachable and usable before relying on it.
+
+    A local store's root is created if needed and checked for writability.
+    A writable remote store performs a cheap authenticated ``HEAD`` on a sentinel key,
+    which is expected to be absent:
+    a ``404`` means the request authenticated and the store is usable,
+    while ``401`` / ``403`` become actionable errors,
+    so a misconfigured credential is caught before the (slow) upload rather than after.
+    ``head_object`` is used rather than ``head_bucket``,
+    so the check works with least-privilege, object-scoped tokens.
+
+    An anonymous remote store has nothing to verify up front, since it has no credentials.
+
+    Parameters
+    ----------
+    root
+        The local store root, or ``None`` when the store is remote.
+    write
+        How a remote store writes, or ``None`` when it is anonymous.
+    label
+        How the store is named in an error message, for example ``"Native store"``.
+
+    Raises
+    ------
+    NativeStoreUnavailableError
+        If the store cannot be reached or used, with an operator-facing message.
+    """
+    if root is not None:
+        try:
+            root.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise NativeStoreUnavailableError(
+                f"Local {label.lower()} root {root} could not be created: {exc}"
+            ) from exc
+        if not os.access(root, os.W_OK):
+            raise NativeStoreUnavailableError(f"Local {label.lower()} root {root} is not writable.")
+        logger.debug(f"Local {label.lower()} ready at {root}")
+        return
+    if write is None:
+        return
+
+    from botocore.exceptions import BotoCoreError, ClientError  # noqa: PLC0415 - optional dependency
+
+    creds = (
+        f"Check {write.env_prefix}_PROFILE, or {write.env_prefix}_ACCESS_KEY_ID / "
+        f"{write.env_prefix}_SECRET_ACCESS_KEY."
+    )
+    where = f"for bucket {write.bucket!r} at {write.endpoint_url}"
+    try:
+        write.client().head_object(Bucket=write.bucket, Key=_PREFLIGHT_PROBE_KEY)
+    except BotoCoreError as exc:
+        # Covers NoCredentialsError, where the whole chain resolved nothing, and DNS failures.
+        raise NativeStoreUnavailableError(f"{label} could not be reached {where}: {exc} {creds}") from exc
+    except ClientError as exc:
+        status = _http_status(exc)
+        if status == _HTTP_NOT_FOUND:
+            pass  # authenticated, and the probe object is simply absent, so the store is usable
+        elif status in _AUTH_REJECTED_STATUSES:
+            raise NativeStoreUnavailableError(
+                f"{label} authentication failed (HTTP {status}) {where}: the credentials were "
+                f"rejected or malformed. {creds}"
+            ) from exc
+        elif status == _HTTP_FORBIDDEN:
+            raise NativeStoreUnavailableError(
+                f"{label} access denied (HTTP 403) {where}: the request was forbidden. The secret "
+                f"key may be wrong, or the token may lack object read and write on this bucket. "
+                f"Check the credentials and the token's permissions."
+            ) from exc
+        else:
+            raise NativeStoreUnavailableError(
+                f"{label} preflight failed (HTTP {status}) {where}: {exc}"
+            ) from exc
+    logger.info(f"{label} authenticated: bucket {write.bucket!r} at {write.endpoint_url}")
+
+
+def _write_config_from_env(endpoint_url: str, bucket: str, env_prefix: str) -> S3WriteConfig:
+    """
+    Build an :class:`S3WriteConfig` from non-secret routing plus credentials in the environment.
+
+    Credentials are read here, at build time, so they never live in the persisted config.
+
+    Parameters
+    ----------
+    endpoint_url
+        S3 API endpoint for the bucket's account, without the bucket.
+    bucket
+        Name of the bucket to write to.
+    env_prefix
+        Prefix of the credential environment variables, for example ``REF_NATIVE_STORE``.
+
+    Returns
+    -------
+    :
+        The write config, with empty credentials where the environment supplies none,
+        which falls through to the named profile and then boto3's default chain.
+    """
+    return S3WriteConfig(
+        endpoint_url=endpoint_url,
+        bucket=bucket,
+        access_key_id=os.environ.get(f"{env_prefix}_ACCESS_KEY_ID", ""),
+        secret_access_key=os.environ.get(f"{env_prefix}_SECRET_ACCESS_KEY", ""),
+        profile=os.environ.get(f"{env_prefix}_PROFILE", ""),
+        env_prefix=env_prefix,
+    )
 
 
 @frozen
@@ -421,77 +533,20 @@ class NativeStore:
         """
         Verify the store is reachable and usable before relying on it.
 
-        A local store's root is created if needed and checked for writability.
-        A writable remote store performs a cheap authenticated ``HEAD`` on a sentinel key,
-        which is expected to be absent:
-        a ``404`` means the request authenticated and the store is usable,
-        while ``401`` / ``403`` become actionable errors,
-        so a misconfigured credential is caught before the (slow) diagnostic run rather than after.
-        ``head_object`` is used rather than ``head_bucket``,
-        so the check works with least-privilege, object-scoped tokens.
-
-        An anonymous remote store has nothing to verify up front.
-        It has no credentials, and every read is hash-checked per blob.
-
         Raises
         ------
         NativeStoreUnavailableError
             If the store cannot be reached or used, with an operator-facing message.
         """
-        root = self.root
-        if root is not None:
-            try:
-                root.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
-                raise NativeStoreUnavailableError(
-                    f"Local native store root {root} could not be created: {exc}"
-                ) from exc
-            if not os.access(root, os.W_OK):
-                raise NativeStoreUnavailableError(f"Local native store root {root} is not writable.")
-            logger.debug(f"Local native store ready at {root}")
-            return
-        write = self.write
-        if write is None:
-            return
-
-        from botocore.exceptions import ClientError  # noqa: PLC0415 - optional dependency
-
-        try:
-            write.client().head_object(Bucket=write.bucket, Key=_PREFLIGHT_PROBE_KEY)
-        except ClientError as exc:
-            status = _http_status(exc)
-            if status == _HTTP_NOT_FOUND:
-                pass  # authenticated, and the probe object is simply absent, so the store is usable
-            elif status in _AUTH_REJECTED_STATUSES:
-                raise NativeStoreUnavailableError(
-                    f"Native store authentication failed (HTTP {status}) for bucket {write.bucket!r} at "
-                    f"{write.endpoint_url}: the credentials were rejected or malformed. Check "
-                    f"REF_NATIVE_STORE_PROFILE, or REF_NATIVE_STORE_ACCESS_KEY_ID / "
-                    f"REF_NATIVE_STORE_SECRET_ACCESS_KEY."
-                ) from exc
-            elif status == _HTTP_FORBIDDEN:
-                raise NativeStoreUnavailableError(
-                    f"Native store access denied (HTTP 403) for bucket {write.bucket!r} at "
-                    f"{write.endpoint_url}: the request was forbidden. The secret key may be wrong, "
-                    f"or the token may lack object read and write on this bucket. Check the "
-                    f"credentials and the token's permissions."
-                ) from exc
-            else:
-                raise NativeStoreUnavailableError(
-                    f"Native store preflight failed (HTTP {status}) for bucket {write.bucket!r} at "
-                    f"{write.endpoint_url}: {exc}"
-                ) from exc
-        logger.info(f"Native store authenticated: bucket {write.bucket!r} at {write.endpoint_url}")
+        _preflight_store(self.root, self.write, "Native store")
 
 
-class _NativeStoreConfigProtocol(Protocol):
+class _StoreConfigProtocol(Protocol):
     """
-    Structural protocol for the native-store config object expected by :func:`build_native_store`.
+    Structural protocol for the store config objects the factories accept.
 
-    Both :class:`climate_ref.config.NativeStoreConfig` and test doubles satisfy
-    this interface without an import dependency on the app package.
-
-    This keeps ``climate_ref_core`` free of any import dependency on ``climate_ref``.
+    Both :mod:`climate_ref.config` classes and test doubles satisfy it without an import
+    dependency on the app package, which keeps ``climate_ref_core`` free of one.
 
     ``s3_endpoint_url`` and ``bucket`` are non-secret routing config consumed only by a
     writable remote store. Write credentials are intentionally **not** part of this protocol.
@@ -502,22 +557,22 @@ class _NativeStoreConfigProtocol(Protocol):
     def url(self) -> str: ...
 
     @property
-    def cache_dir(self) -> Path: ...
-
-    @property
     def s3_endpoint_url(self) -> str: ...
 
     @property
     def bucket(self) -> str: ...
 
 
+class _NativeStoreConfigProtocol(_StoreConfigProtocol, Protocol):
+    """The store config plus the cache directory an anonymous native read needs."""
+
+    @property
+    def cache_dir(self) -> Path: ...
+
+
 def build_native_store(config: _NativeStoreConfigProtocol, *, writable: bool) -> NativeStore:
     """
     Build a :class:`NativeStore` from a native-store config object.
-
-    Accepts any object that exposes ``url``, ``cache_dir``, ``s3_endpoint_url`` and ``bucket``
-    (satisfying :class:`_NativeStoreConfigProtocol`), so callers pass ``config.native_store``
-    rather than the full :class:`~climate_ref.config.Config`.
 
     With ``writable=False`` the returned store is anonymous and credential-free,
     which suits the CI read and replay paths.
@@ -554,11 +609,5 @@ def build_native_store(config: _NativeStoreConfigProtocol, *, writable: bool) ->
     return NativeStore(
         url=config.url,
         cache_dir=config.cache_dir,
-        write=S3WriteConfig(
-            endpoint_url=config.s3_endpoint_url,
-            bucket=config.bucket,
-            access_key_id=os.environ.get("REF_NATIVE_STORE_ACCESS_KEY_ID", ""),
-            secret_access_key=os.environ.get("REF_NATIVE_STORE_SECRET_ACCESS_KEY", ""),
-            profile=os.environ.get("REF_NATIVE_STORE_PROFILE", ""),
-        ),
+        write=_write_config_from_env(config.s3_endpoint_url, config.bucket, "REF_NATIVE_STORE"),
     )

--- a/packages/climate-ref-core/tests/unit/regression/test_report_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_report_store.py
@@ -173,6 +173,17 @@ class TestBuildReportStore:
 
         assert store.write is None
 
+    @pytest.mark.parametrize(
+        "kwargs, expected",
+        [
+            ({"s3_endpoint_url": ""}, "REF_REPORT_STORE_S3_ENDPOINT_URL"),
+            ({"bucket": ""}, "REF_REPORT_STORE_BUCKET"),
+        ],
+    )
+    def test_missing_routing_names_the_report_store_env_var(self, kwargs, expected: str) -> None:
+        with pytest.raises(ValueError, match=expected):
+            build_report_store(_StubConfig(REMOTE_URL, **kwargs), writable=True)
+
     def test_a_local_store_is_writable_without_credentials(self, tmp_path: Path) -> None:
         store = build_report_store(_StubConfig(str(tmp_path / "reports")), writable=True)
 

--- a/packages/climate-ref-core/tests/unit/regression/test_report_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_report_store.py
@@ -94,6 +94,14 @@ class TestLocalStore:
         assert local_store.root is not None
         assert local_store.root.is_dir()
 
+    def test_preflight_reports_an_unwritable_root(
+        self, local_store: ReportStore, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("climate_ref_core.regression.report_store.os.access", return_value=False)
+
+        with pytest.raises(NativeStoreUnavailableError, match="not writable"):
+            local_store.preflight()
+
     def test_preflight_reports_an_uncreatable_root(self, tmp_path: Path) -> None:
         blocker = tmp_path / "blocker"
         blocker.write_text("not a directory", encoding="utf-8")
@@ -157,6 +165,26 @@ class TestRemoteStore:
 
         with pytest.raises(NativeStoreUnavailableError, match="REF_REPORT_STORE_ACCESS_KEY_ID"):
             store.preflight()
+
+    @pytest.mark.parametrize(
+        "code, status, expected",
+        [
+            ("AccessDenied", 403, "access denied"),
+            ("InternalError", 500, "preflight failed"),
+        ],
+    )
+    def test_preflight_reports_other_failures(
+        self, mocker: MockerFixture, code: str, status: int, expected: str
+    ) -> None:
+        client = mocker.MagicMock()
+        client.head_object.side_effect = _client_error(code, status)
+        store = self._store(mocker, client)
+
+        with pytest.raises(NativeStoreUnavailableError, match=expected):
+            store.preflight()
+
+    def test_a_read_only_remote_store_has_nothing_to_preflight(self) -> None:
+        ReportStore(url=REMOTE_URL).preflight()
 
 
 class TestBuildReportStore:

--- a/packages/climate-ref-core/tests/unit/regression/test_report_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_report_store.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 from pytest_mock import MockerFixture
 
 from climate_ref_core.regression.report_store import (
@@ -141,6 +141,14 @@ class TestRemoteStore:
         store.preflight()
 
         client.head_object.assert_called_once()
+
+    def test_preflight_reports_absent_credentials(self, mocker: MockerFixture) -> None:
+        client = mocker.MagicMock()
+        client.head_object.side_effect = NoCredentialsError()
+        store = self._store(mocker, client)
+
+        with pytest.raises(NativeStoreUnavailableError, match="REF_REPORT_STORE_ACCESS_KEY_ID"):
+            store.preflight()
 
     def test_preflight_rejects_bad_credentials(self, mocker: MockerFixture) -> None:
         client = mocker.MagicMock()

--- a/packages/climate-ref-core/tests/unit/regression/test_report_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_report_store.py
@@ -12,7 +12,7 @@ from climate_ref_core.regression.store import NativeStoreUnavailableError
 
 REMOTE_URL = "https://reports.example.com"
 S3_ENDPOINT = "https://account.r2.cloudflarestorage.com"
-BUCKET = "ref-baseline-reports"
+BUCKET = "ref-baselines-reports"
 KEY = "912/0c7e1d4abc12/index.html"
 HTML = "text/html; charset=utf-8"
 

--- a/packages/climate-ref-core/tests/unit/regression/test_report_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_report_store.py
@@ -97,7 +97,7 @@ class TestLocalStore:
     def test_preflight_reports_an_unwritable_root(
         self, local_store: ReportStore, mocker: MockerFixture
     ) -> None:
-        mocker.patch("climate_ref_core.regression.report_store.os.access", return_value=False)
+        mocker.patch("climate_ref_core.regression.store.os.access", return_value=False)
 
         with pytest.raises(NativeStoreUnavailableError, match="not writable"):
             local_store.preflight()

--- a/packages/climate-ref-core/tests/unit/regression/test_report_store.py
+++ b/packages/climate-ref-core/tests/unit/regression/test_report_store.py
@@ -1,0 +1,180 @@
+from pathlib import Path
+
+import pytest
+from botocore.exceptions import ClientError
+from pytest_mock import MockerFixture
+
+from climate_ref_core.regression.report_store import (
+    ReportStore,
+    build_report_store,
+)
+from climate_ref_core.regression.store import NativeStoreUnavailableError
+
+REMOTE_URL = "https://reports.example.com"
+S3_ENDPOINT = "https://account.r2.cloudflarestorage.com"
+BUCKET = "ref-baseline-reports"
+KEY = "912/0c7e1d4abc12/index.html"
+HTML = "text/html; charset=utf-8"
+
+
+def _client_error(code: str, status: int, operation: str = "HeadObject") -> ClientError:
+    """Build a botocore ``ClientError`` with the given S3 error code / HTTP status."""
+    return ClientError(
+        {"Error": {"Code": code, "Message": code}, "ResponseMetadata": {"HTTPStatusCode": status}},
+        operation,
+    )
+
+
+@pytest.fixture()
+def page(tmp_path: Path) -> Path:
+    p = tmp_path / "index.html"
+    p.write_text("<p>report</p>", encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def local_store(tmp_path: Path) -> ReportStore:
+    return ReportStore(url=str(tmp_path / "reports"))
+
+
+class _StubConfig:
+    """Minimal config double satisfying _ReportStoreConfigProtocol."""
+
+    def __init__(self, url: str, s3_endpoint_url: str = S3_ENDPOINT, bucket: str = BUCKET) -> None:
+        self._url = url
+        self._s3_endpoint_url = s3_endpoint_url
+        self._bucket = bucket
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @property
+    def s3_endpoint_url(self) -> str:
+        return self._s3_endpoint_url
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+
+class TestLocalStore:
+    def test_put_lands_the_file_under_the_key(self, local_store: ReportStore, page: Path) -> None:
+        url = local_store.put(KEY, page, HTML)
+
+        assert local_store.root is not None
+        landed = local_store.root / KEY
+        assert landed.read_text(encoding="utf-8") == "<p>report</p>"
+        assert url == landed.absolute().as_uri()
+        assert url.startswith("file://")
+        assert url.endswith(KEY)
+
+    def test_put_overwrites(self, local_store: ReportStore, page: Path, tmp_path: Path) -> None:
+        local_store.put(KEY, page, HTML)
+        newer = tmp_path / "newer.html"
+        newer.write_text("<p>newer</p>", encoding="utf-8")
+
+        local_store.put(KEY, newer, HTML)
+
+        assert local_store.root is not None
+        assert (local_store.root / KEY).read_text(encoding="utf-8") == "<p>newer</p>"
+
+    @pytest.mark.parametrize("key", ["../x", "a/../../x", "/abs/index.html", "a b/index.html", ""])
+    def test_put_rejects_an_unsafe_key(self, local_store: ReportStore, page: Path, key: str) -> None:
+        with pytest.raises(ValueError, match="report store key"):
+            local_store.put(key, page, HTML)
+
+    def test_url_for_is_the_root_joined_with_the_key(self, local_store: ReportStore) -> None:
+        assert local_store.root is not None
+        assert local_store.url_for(KEY) == (local_store.root / KEY).absolute().as_uri()
+
+    def test_preflight_creates_the_root(self, local_store: ReportStore) -> None:
+        local_store.preflight()
+
+        assert local_store.root is not None
+        assert local_store.root.is_dir()
+
+    def test_preflight_reports_an_uncreatable_root(self, tmp_path: Path) -> None:
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory", encoding="utf-8")
+        store = ReportStore(url=str(blocker / "reports"))
+
+        with pytest.raises(NativeStoreUnavailableError, match="could not be created"):
+            store.preflight()
+
+
+class TestRemoteStore:
+    """The credentialed R2 write path, with a mocked boto3 client."""
+
+    def _store(self, mocker: MockerFixture, client, **kwargs) -> ReportStore:
+        mocker.patch("climate_ref_core.regression.store._s3_client", return_value=client)
+        return build_report_store(_StubConfig(REMOTE_URL, **kwargs), writable=True)
+
+    def test_url_for_is_served_from_the_base_url(self) -> None:
+        store = ReportStore(url="https://h")
+
+        assert store.url_for("1/a/index.html") == "https://h/1/a/index.html"
+
+    def test_url_for_ignores_a_trailing_slash(self) -> None:
+        assert ReportStore(url="https://h/").url_for("1/a/index.html") == "https://h/1/a/index.html"
+
+    def test_put_sets_the_content_type(self, mocker: MockerFixture, page: Path) -> None:
+        client = mocker.MagicMock()
+        store = self._store(mocker, client)
+
+        url = store.put(KEY, page, HTML)
+
+        client.upload_file.assert_called_once_with(str(page), BUCKET, KEY, ExtraArgs={"ContentType": HTML})
+        assert url == f"{REMOTE_URL}/{KEY}"
+
+    def test_put_without_credentials_is_read_only(self, page: Path) -> None:
+        store = ReportStore(url=REMOTE_URL)
+
+        with pytest.raises(NotImplementedError, match="public-read store"):
+            store.put(KEY, page, HTML)
+
+    def test_preflight_accepts_a_missing_probe(self, mocker: MockerFixture) -> None:
+        client = mocker.MagicMock()
+        client.head_object.side_effect = _client_error("404", 404)
+        store = self._store(mocker, client)
+
+        store.preflight()
+
+        client.head_object.assert_called_once()
+
+    def test_preflight_rejects_bad_credentials(self, mocker: MockerFixture) -> None:
+        client = mocker.MagicMock()
+        client.head_object.side_effect = _client_error("InvalidAccessKeyId", 401)
+        store = self._store(mocker, client)
+
+        with pytest.raises(NativeStoreUnavailableError, match="REF_REPORT_STORE_ACCESS_KEY_ID"):
+            store.preflight()
+
+
+class TestBuildReportStore:
+    def test_reads_the_report_store_env_vars(self, mocker: MockerFixture, monkeypatch) -> None:
+        monkeypatch.setenv("REF_REPORT_STORE_ACCESS_KEY_ID", "report-key")
+        monkeypatch.setenv("REF_REPORT_STORE_SECRET_ACCESS_KEY", "report-secret")
+        monkeypatch.setenv("REF_REPORT_STORE_PROFILE", "report-profile")
+        monkeypatch.setenv("REF_NATIVE_STORE_ACCESS_KEY_ID", "native-key")
+        monkeypatch.setenv("REF_NATIVE_STORE_SECRET_ACCESS_KEY", "native-secret")
+        monkeypatch.setenv("REF_NATIVE_STORE_PROFILE", "native-profile")
+        factory = mocker.patch(
+            "climate_ref_core.regression.store._s3_client", return_value=mocker.MagicMock()
+        )
+
+        store = build_report_store(_StubConfig(REMOTE_URL), writable=True)
+        store.put(KEY, Path(__file__), HTML)
+
+        factory.assert_called_once_with(S3_ENDPOINT, "report-key", "report-secret", "report-profile")
+
+    def test_read_only_needs_no_credentials(self) -> None:
+        store = build_report_store(_StubConfig(REMOTE_URL), writable=False)
+
+        assert store.write is None
+
+    def test_a_local_store_is_writable_without_credentials(self, tmp_path: Path) -> None:
+        store = build_report_store(_StubConfig(str(tmp_path / "reports")), writable=True)
+
+        assert store.write is None
+        assert store.root == tmp_path / "reports"

--- a/packages/climate-ref/src/climate_ref/baseline_report/render.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/render.py
@@ -117,15 +117,12 @@ def _format_short(digest: str | None) -> str:
     return digest[:SHORT_DIGEST]
 
 
-def _build_env(*, escape: bool) -> Environment:
+def _build_env() -> Environment:
     """
-    Build a Jinja environment for the templates in this package.
+    Build the Jinja environment the templates in this package are rendered with.
 
-    Parameters
-    ----------
-    escape
-        Whether to escape values. Off for the markdown comment, where an escaped case label
-        would render as HTML entities on GitHub.
+    Escaping keys off the template name, so ``comment.md.j2`` renders unescaped.
+    It is markdown, where an escaped case label would show as HTML entities on GitHub.
 
     Returns
     -------
@@ -134,7 +131,7 @@ def _build_env(*, escape: bool) -> Environment:
     """
     env = Environment(
         loader=PackageLoader("climate_ref.baseline_report", "templates"),
-        autoescape=select_autoescape(["html", "j2"]) if escape else False,  # noqa: S701
+        autoescape=select_autoescape(enabled_extensions=("html.j2", "html")),
         trim_blocks=True,
         lstrip_blocks=True,
     )
@@ -146,8 +143,7 @@ def _build_env(*, escape: bool) -> Environment:
     return env
 
 
-_env = _build_env(escape=True)
-_text_env = _build_env(escape=False)
+_env = _build_env()
 
 
 @frozen
@@ -219,8 +215,7 @@ def _versions(case: AnalysedCase) -> str:
     if case.change.is_new:
         return "new"
     base, head = case.change.base, case.change.head
-    if base is None or head is None:  # pragma: no cover - is_new / is_removed already cover this
-        return "changed"
+    assert base is not None and head is not None
     return f"v{base.test_case_version} -> v{head.test_case_version}"
 
 
@@ -275,7 +270,7 @@ def render_comment(
         The comment's markdown, ending in the marker the CI job finds it by.
     """
     root = base_url.rstrip("/")
-    return _text_env.get_template("comment.md.j2").render(
+    return _env.get_template("comment.md.j2").render(
         report=report,
         cases=[_comment_row(case, root) for case in report.cases],
         index_url=f"{root}/index.html",

--- a/packages/climate-ref/src/climate_ref/baseline_report/render.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/render.py
@@ -117,9 +117,15 @@ def _format_short(digest: str | None) -> str:
     return digest[:SHORT_DIGEST]
 
 
-def _build_env() -> Environment:
+def _build_env(*, escape: bool) -> Environment:
     """
-    Build the Jinja environment the report is rendered with.
+    Build a Jinja environment for the templates in this package.
+
+    Parameters
+    ----------
+    escape
+        Whether to escape values. Off for the markdown comment, where an escaped case label
+        would render as HTML entities on GitHub.
 
     Returns
     -------
@@ -128,7 +134,7 @@ def _build_env() -> Environment:
     """
     env = Environment(
         loader=PackageLoader("climate_ref.baseline_report", "templates"),
-        autoescape=select_autoescape(["html", "j2"]),
+        autoescape=select_autoescape(["html", "j2"]) if escape else False,  # noqa: S701
         trim_blocks=True,
         lstrip_blocks=True,
     )
@@ -140,28 +146,8 @@ def _build_env() -> Environment:
     return env
 
 
-def _build_text_env() -> Environment:
-    """
-    Build the Jinja environment the markdown comment is rendered with.
-
-    Escaping is off, because the comment is markdown rather than HTML,
-    and a case label escaped as HTML entities would render literally on GitHub.
-
-    Returns
-    -------
-    :
-        The environment.
-    """
-    return Environment(
-        loader=PackageLoader("climate_ref.baseline_report", "templates"),
-        autoescape=False,  # noqa: S701 - markdown output, escaping would show as entities
-        trim_blocks=True,
-        lstrip_blocks=True,
-    )
-
-
-_env = _build_env()
-_text_env = _build_text_env()
+_env = _build_env(escape=True)
+_text_env = _build_env(escape=False)
 
 
 @frozen
@@ -185,17 +171,8 @@ class CommentRow:
     versions: str
     """``v3 -> v4``, or ``new`` / ``removed`` when the case only exists on one side."""
 
-    images: str
-    """The ``+a ~c -r`` shorthand for image changes, or ``none``."""
-
-    text: str
-    """The shorthand for text changes."""
-
-    netcdf: str
-    """The shorthand for NetCDF changes."""
-
-    other: str
-    """The shorthand for everything else."""
+    counts: tuple[str, ...]
+    """The ``+a ~c -r`` shorthand per file kind, in the report's column order."""
 
     url: str
     """Link to the case's page in the hosted report."""
@@ -263,14 +240,10 @@ def _comment_row(case: AnalysedCase, base_url: str) -> CommentRow:
     :
         The row.
     """
-    by_kind = {count.label: _shorthand(count) for count in case.counts}
     return CommentRow(
         label=case.change.label,
         versions=_versions(case),
-        images=by_kind["image"],
-        text=by_kind["text"],
-        netcdf=by_kind["netcdf"],
-        other=by_kind["other"],
+        counts=tuple(_shorthand(count) for count in case.counts),
         url=f"{base_url}/{case.change.label}/index.html",
     )
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/render.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/render.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from attrs import frozen
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from climate_ref.baseline_report.analyse import SHORT_DIGEST
 
 if TYPE_CHECKING:
-    from climate_ref.baseline_report.analyse import AnalysedCase, AnalysedReport
+    from collections.abc import Sequence
+
+    from climate_ref.baseline_report.analyse import AnalysedCase, AnalysedReport, KindCounts
 
 
 def _format_bytes(size: int | None) -> str:
@@ -137,7 +140,174 @@ def _build_env() -> Environment:
     return env
 
 
+def _build_text_env() -> Environment:
+    """
+    Build the Jinja environment the markdown comment is rendered with.
+
+    Escaping is off, because the comment is markdown rather than HTML,
+    and a case label escaped as HTML entities would render literally on GitHub.
+
+    Returns
+    -------
+    :
+        The environment.
+    """
+    return Environment(
+        loader=PackageLoader("climate_ref.baseline_report", "templates"),
+        autoescape=False,  # noqa: S701 - markdown output, escaping would show as entities
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+
 _env = _build_env()
+_text_env = _build_text_env()
+
+
+@frozen
+class CommentLink:
+    """One earlier report for the same pull request."""
+
+    label: str
+    """Short name for the report, typically the head sha it was built from."""
+
+    url: str
+    """Where that report is hosted."""
+
+
+@frozen
+class CommentRow:
+    """One test case's row in the pull request comment table."""
+
+    label: str
+    """The test case's label, for example ``example/diag/case``."""
+
+    versions: str
+    """``v3 -> v4``, or ``new`` / ``removed`` when the case only exists on one side."""
+
+    images: str
+    """The ``+a ~c -r`` shorthand for image changes, or ``none``."""
+
+    text: str
+    """The shorthand for text changes."""
+
+    netcdf: str
+    """The shorthand for NetCDF changes."""
+
+    other: str
+    """The shorthand for everything else."""
+
+    url: str
+    """Link to the case's page in the hosted report."""
+
+
+def _shorthand(counts: KindCounts) -> str:
+    """
+    Summarise one kind's changes as a short ``+a ~c -r`` string.
+
+    Parameters
+    ----------
+    counts
+        The tallied counts for one file kind.
+
+    Returns
+    -------
+    :
+        For example ``+1 ~2``, or ``none`` when nothing of that kind changed.
+    """
+    parts = [
+        f"+{counts.added}" if counts.added else "",
+        f"~{counts.changed}" if counts.changed else "",
+        f"-{counts.removed}" if counts.removed else "",
+    ]
+    return " ".join(p for p in parts if p) or "none"
+
+
+def _versions(case: AnalysedCase) -> str:
+    """
+    Describe how a case's version moved.
+
+    Parameters
+    ----------
+    case
+        The analysed case.
+
+    Returns
+    -------
+    :
+        ``v3 -> v4``, or ``new`` / ``removed`` when the case only exists on one side.
+    """
+    if case.change.is_removed:
+        return "removed"
+    if case.change.is_new:
+        return "new"
+    base, head = case.change.base, case.change.head
+    if base is None or head is None:  # pragma: no cover - is_new / is_removed already cover this
+        return "changed"
+    return f"v{base.test_case_version} -> v{head.test_case_version}"
+
+
+def _comment_row(case: AnalysedCase, base_url: str) -> CommentRow:
+    """
+    Build one table row from an analysed case.
+
+    Parameters
+    ----------
+    case
+        The analysed case.
+    base_url
+        Where the report is hosted, without a trailing slash.
+
+    Returns
+    -------
+    :
+        The row.
+    """
+    by_kind = {count.label: _shorthand(count) for count in case.counts}
+    return CommentRow(
+        label=case.change.label,
+        versions=_versions(case),
+        images=by_kind["image"],
+        text=by_kind["text"],
+        netcdf=by_kind["netcdf"],
+        other=by_kind["other"],
+        url=f"{base_url}/{case.change.label}/index.html",
+    )
+
+
+def render_comment(
+    report: AnalysedReport,
+    base_url: str,
+    previous: Sequence[tuple[str, str]] = (),
+) -> str:
+    """
+    Render the pull request comment as markdown.
+
+    The comment is one row per changed case and a link into the hosted report,
+    so it stays well inside GitHub's comment size limit however many files moved.
+
+    Parameters
+    ----------
+    report
+        The analysed report.
+    base_url
+        Where the report is hosted, for example ``https://reports.example/912/0c7e1d4abc12``.
+        A trailing slash is ignored.
+    previous
+        ``(label, url)`` pairs for earlier reports on the same pull request.
+
+    Returns
+    -------
+    :
+        The comment's markdown, ending in the marker the CI job finds it by.
+    """
+    root = base_url.rstrip("/")
+    return _text_env.get_template("comment.md.j2").render(
+        report=report,
+        cases=[_comment_row(case, root) for case in report.cases],
+        index_url=f"{root}/index.html",
+        previous=[CommentLink(label=label, url=url) for label, url in previous],
+    )
 
 
 def render_index(report: AnalysedReport) -> str:

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/comment.md.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/comment.md.j2
@@ -1,0 +1,19 @@
+### Regression baseline diff
+
+{% if cases %}
+{{ cases | length }} test case(s) changed against `{{ report.report.base_ref }}`. [Full report]({{ index_url }})
+
+| case | versions | images | text | netcdf | other | |
+| --- | --- | --- | --- | --- | --- | --- |
+{% for case in cases %}
+| `{{ case.label }}` | {{ case.versions }} | {{ case.images }} | {{ case.text }} | {{ case.netcdf }} | {{ case.other }} | [view]({{ case.url }}) |
+{% endfor %}
+{% else %}
+No baseline manifests changed against `{{ report.report.base_ref }}`.
+{% endif %}
+{% if previous %}
+
+_Previous reports for this pull request: {% for p in previous %}[{{ p.label }}]({{ p.url }}){{ ", " if not loop.last }}{% endfor %}_
+{% endif %}
+
+<!-- climate-ref-baseline-diff -->

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/comment.md.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/comment.md.j2
@@ -3,10 +3,10 @@
 {% if cases %}
 {{ cases | length }} test case(s) changed against `{{ report.report.base_ref }}`. [Full report]({{ index_url }})
 
-| case | versions | images | text | netcdf | other | |
-| --- | --- | --- | --- | --- | --- | --- |
+| case | versions |{% for kind in report.kinds %} {{ kind }} |{% endfor %} |
+| --- | --- |{% for kind in report.kinds %} --- |{% endfor %} --- |
 {% for case in cases %}
-| `{{ case.label }}` | {{ case.versions }} | {{ case.images }} | {{ case.text }} | {{ case.netcdf }} | {{ case.other }} | [view]({{ case.url }}) |
+| `{{ case.label }}` | {{ case.versions }} |{% for count in case.counts %} {{ count }} |{% endfor %} [view]({{ case.url }}) |
 {% endfor %}
 {% else %}
 No baseline manifests changed against `{{ report.report.base_ref }}`.

--- a/packages/climate-ref/src/climate_ref/baseline_report/upload.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/upload.py
@@ -1,0 +1,76 @@
+"""
+Push a rendered report into the report store.
+
+The store is a plain object store with no directory semantics, so every file is uploaded under an
+explicit key and the content type has to be set per object or a browser will download the page
+instead of rendering it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from climate_ref_core.regression.report_store import ReportStore
+
+CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+}
+"""Content types for the file kinds a report is made of."""
+
+DEFAULT_CONTENT_TYPE = "application/octet-stream"
+"""Served for anything else, which a browser will offer as a download."""
+
+
+def content_type_for(path: Path) -> str:
+    """
+    Return the content type a report file should be served with.
+
+    Parameters
+    ----------
+    path
+        The file, which is classified by its extension.
+
+    Returns
+    -------
+    :
+        The MIME type, or :data:`DEFAULT_CONTENT_TYPE` for an unrecognised extension.
+    """
+    return CONTENT_TYPES.get(path.suffix.lower(), DEFAULT_CONTENT_TYPE)
+
+
+def upload_site(out_dir: Path, store: ReportStore, prefix: str) -> str:
+    """
+    Upload every file under ``out_dir`` as ``prefix/<relative path>``.
+
+    Parameters
+    ----------
+    out_dir
+        The rendered site.
+    store
+        The store to upload into.
+    prefix
+        The key prefix the report is published under, for example ``912/0c7e1d4abc12``.
+        Validated by :meth:`~climate_ref_core.regression.report_store.ReportStore.put`.
+
+    Returns
+    -------
+    :
+        The URL of the report's index page, whether or not that page exists.
+    """
+    count = 0
+    for path in sorted(out_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        key = str(PurePosixPath(prefix, *path.relative_to(out_dir).parts))
+        store.put(key, path, content_type_for(path))
+        count += 1
+    logger.info(f"Uploaded {count} report file(s) under {prefix}")
+    return store.url_for(f"{prefix}/index.html")

--- a/packages/climate-ref/src/climate_ref/baseline_report/upload.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/upload.py
@@ -23,7 +23,12 @@ CONTENT_TYPES = {
     ".png": "image/png",
     ".svg": "image/svg+xml",
 }
-"""Content types for the file kinds a report is made of."""
+"""
+Content types for the file kinds a report is made of.
+
+A deliberate allowlist rather than :mod:`mimetypes`, whose answers vary with the host's
+registry, and which would not add the charset a browser needs on the text types.
+"""
 
 DEFAULT_CONTENT_TYPE = "application/octet-stream"
 """Served for anything else, which a browser will offer as a download."""

--- a/packages/climate-ref/src/climate_ref/baseline_report/upload.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/upload.py
@@ -1,7 +1,6 @@
 """
 Push a rendered report into the report store.
 
-The files are uploaded to
 The store is a plain object store with no directory semantics,
 so every file is uploaded under an explicit key.
 The content type has to be set per object, or a browser will download the page instead of rendering it.

--- a/packages/climate-ref/src/climate_ref/baseline_report/upload.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/upload.py
@@ -1,9 +1,10 @@
 """
 Push a rendered report into the report store.
 
-The store is a plain object store with no directory semantics, so every file is uploaded under an
-explicit key and the content type has to be set per object or a browser will download the page
-instead of rendering it.
+The files are uploaded to
+The store is a plain object store with no directory semantics,
+so every file is uploaded under an explicit key.
+The content type has to be set per object, or a browser will download the page instead of rendering it.
 """
 
 from __future__ import annotations
@@ -26,8 +27,8 @@ CONTENT_TYPES = {
 """
 Content types for the file kinds a report is made of.
 
-A deliberate allowlist rather than :mod:`mimetypes`, whose answers vary with the host's
-registry, and which would not add the charset a browser needs on the text types.
+A deliberate allowlist rather than :mod:`mimetypes`, whose answers vary with the host's registry,
+and which would not add the charset a browser needs on the text types.
 """
 
 DEFAULT_CONTENT_TYPE = "application/octet-stream"

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
@@ -87,7 +87,7 @@ def diff_baselines(  # noqa: PLR0913
         try:
             report_store = build_report_store(config.report_store, writable=True)
             report_store.preflight()
-            upload_site(html_dir, report_store, upload)
+            index_url = upload_site(html_dir, report_store, upload)
             base_url = report_store.url_for(upload)
         except (NotImplementedError, ValueError, ImportError, NativeStoreUnavailableError) as exc:
             logger.error(
@@ -96,7 +96,7 @@ def diff_baselines(  # noqa: PLR0913
                 "'climate-ref-core[aws]' extra."
             )
             raise typer.Exit(code=1) from exc
-        console.print(f"Uploaded the report to {base_url}/index.html")
+        console.print(f"Uploaded the report to {index_url}")
 
     if comment_output is not None:
         comment_output.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
@@ -96,7 +96,7 @@ def diff_baselines(  # noqa: PLR0913
         try:
             report_store.preflight()
             console.print(f"Uploaded the report to {upload_site(html_dir, report_store, upload)}")
-        except (ImportError, NativeStoreUnavailableError) as exc:
+        except (ImportError, ValueError, NativeStoreUnavailableError) as exc:
             logger.error(
                 f"Could not upload the report: {exc} Check REF_REPORT_STORE_ACCESS_KEY_ID / "
                 "REF_REPORT_STORE_SECRET_ACCESS_KEY and the 'climate-ref-core[aws]' extra."

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
@@ -82,23 +82,29 @@ def diff_baselines(  # noqa: PLR0913
 
     console.print(f"Wrote {len(analysed.cases)} case page(s) to {index}")
 
-    base_url = index.parent.resolve().as_uri()
+    base_url = None
     if upload is not None:
         try:
             report_store = build_report_store(config.report_store, writable=True)
-            report_store.preflight()
-            index_url = upload_site(html_dir, report_store, upload)
             base_url = report_store.url_for(upload)
-        except (NotImplementedError, ValueError, ImportError, NativeStoreUnavailableError) as exc:
+        except ValueError as exc:
             logger.error(
-                f"Could not upload the report: {exc} Check REF_REPORT_STORE_URL, and for a remote "
-                "store REF_REPORT_STORE_ACCESS_KEY_ID / REF_REPORT_STORE_SECRET_ACCESS_KEY plus the "
-                "'climate-ref-core[aws]' extra."
+                f"{exc} Set --upload to a relative key prefix such as 912/0c7e1d4abc12, and check "
+                "REF_REPORT_STORE_URL, REF_REPORT_STORE_S3_ENDPOINT_URL and REF_REPORT_STORE_BUCKET."
             )
             raise typer.Exit(code=1) from exc
-        console.print(f"Uploaded the report to {index_url}")
+        try:
+            report_store.preflight()
+            console.print(f"Uploaded the report to {upload_site(html_dir, report_store, upload)}")
+        except (ImportError, NativeStoreUnavailableError) as exc:
+            logger.error(
+                f"Could not upload the report: {exc} Check REF_REPORT_STORE_ACCESS_KEY_ID / "
+                "REF_REPORT_STORE_SECRET_ACCESS_KEY and the 'climate-ref-core[aws]' extra."
+            )
+            raise typer.Exit(code=1) from exc
 
     if comment_output is not None:
         comment_output.parent.mkdir(parents=True, exist_ok=True)
-        comment_output.write_text(render_comment(analysed, base_url), encoding="utf-8")
+        markdown = render_comment(analysed, base_url or index.parent.resolve().as_uri())
+        comment_output.write_text(markdown, encoding="utf-8")
         console.print(f"Wrote the pull request comment to {comment_output}")

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/diff.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 @app.command(name="diff")
-def diff_baselines(
+def diff_baselines(  # noqa: PLR0913
     ctx: typer.Context,
     html_dir: Annotated[Path, typer.Option(help="Directory to write the HTML report into")],
     base: Annotated[
@@ -35,6 +35,14 @@ def diff_baselines(
         bool,
         typer.Option("--no-fetch", help="Skip blob downloads and report sizes only"),
     ] = False,
+    upload: Annotated[
+        str | None,
+        typer.Option(help="Upload the report under this key prefix, e.g. 912/0c7e1d4abc12"),
+    ] = None,
+    comment_output: Annotated[
+        Path | None,
+        typer.Option(help="Write the pull request comment markdown here"),
+    ] = None,
 ) -> None:
     """
     Render an HTML report of the regression baselines changed on this branch.
@@ -49,11 +57,14 @@ def diff_baselines(
         ref test-cases diff --html-dir build/baseline-diff
         ref test-cases diff --base origin/develop --html-dir build/baseline-diff
         ref test-cases diff --html-dir build/baseline-diff --no-fetch
+        ref test-cases diff --html-dir build/baseline-diff --upload 912/0c7e1d4abc12
     """
     from climate_ref.baseline_report.analyse import analyse
     from climate_ref.baseline_report.collect import collect
-    from climate_ref.baseline_report.render import write_site
-    from climate_ref_core.regression.store import build_native_store
+    from climate_ref.baseline_report.render import render_comment, write_site
+    from climate_ref.baseline_report.upload import upload_site
+    from climate_ref_core.regression.report_store import build_report_store
+    from climate_ref_core.regression.store import NativeStoreUnavailableError, build_native_store
 
     config: Config = ctx.obj.config
     console: Console = ctx.obj.console
@@ -70,3 +81,24 @@ def diff_baselines(
         index = write_site(analysed, html_dir)
 
     console.print(f"Wrote {len(analysed.cases)} case page(s) to {index}")
+
+    base_url = index.parent.resolve().as_uri()
+    if upload is not None:
+        try:
+            report_store = build_report_store(config.report_store, writable=True)
+            report_store.preflight()
+            upload_site(html_dir, report_store, upload)
+            base_url = report_store.url_for(upload)
+        except (NotImplementedError, ValueError, ImportError, NativeStoreUnavailableError) as exc:
+            logger.error(
+                f"Could not upload the report: {exc} Check REF_REPORT_STORE_URL, and for a remote "
+                "store REF_REPORT_STORE_ACCESS_KEY_ID / REF_REPORT_STORE_SECRET_ACCESS_KEY plus the "
+                "'climate-ref-core[aws]' extra."
+            )
+            raise typer.Exit(code=1) from exc
+        console.print(f"Uploaded the report to {base_url}/index.html")
+
+    if comment_output is not None:
+        comment_output.parent.mkdir(parents=True, exist_ok=True)
+        comment_output.write_text(render_comment(analysed, base_url), encoding="utf-8")
+        console.print(f"Wrote the pull request comment to {comment_output}")

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -290,6 +290,54 @@ class NativeStoreConfig:
 
 
 @config(prefix=env_prefix)
+class ReportStoreConfig:
+    """
+    Configuration for the public store that hosts baseline diff reports.
+
+    A diff report is a small static site keyed by pull request and head sha,
+    so this store is addressed by path rather than by digest.
+    It is a different bucket to the native store because an R2 token cannot be scoped to a prefix,
+    so a token that can write reports must not also be able to overwrite baseline blobs.
+
+    Write credentials are **not** stored here: the access-key id and secret-access-key are read from
+    ``REF_REPORT_STORE_ACCESS_KEY_ID`` / ``REF_REPORT_STORE_SECRET_ACCESS_KEY``
+    (falling back to boto3's default credential chain) at upload time only,
+    so secrets never land in a serialised config.
+    """
+
+    url: str = env_field(name="REPORT_STORE_URL", default="https://reports.baselines.climate-ref.org")
+    """
+    Base URL the reports are served from.
+
+    Reports are served at ``{url}/{key}``.
+    Defaults to the production Climate-REF reports endpoint.
+
+    Set ``REF_REPORT_STORE_URL`` to a local ``file:///path/to/dir`` (or a plain filesystem path)
+    to render and inspect an upload offline.
+    """
+
+    s3_endpoint_url: str = env_field(
+        name="REPORT_STORE_S3_ENDPOINT_URL",
+        default="https://2aa5172b2bba093c516027d6fa13cdc8.r2.cloudflarestorage.com",
+    )
+    """
+    S3 API endpoint for the writable (Cloudflare R2) backend, without the bucket.
+
+    Non-secret routing config, consumed only when uploading a report.
+    Defaults to the production Climate-REF R2 account endpoint.
+    Set ``REF_REPORT_STORE_S3_ENDPOINT_URL`` to override (e.g. a staging account).
+    """
+
+    bucket: str = env_field(name="REPORT_STORE_BUCKET", default="ref-baseline-reports")
+    """
+    Name of the writable (Cloudflare R2) reports bucket.
+
+    Non-secret routing config, consumed only when uploading a report.
+    Set ``REF_REPORT_STORE_BUCKET`` to override.
+    """
+
+
+@config(prefix=env_prefix)
 class ExecutorConfig:
     """
     Configuration to define the executor to use for running diagnostics
@@ -752,6 +800,7 @@ class Config:
 
     paths: PathConfig = Factory(PathConfig)
     native_store: NativeStoreConfig = Factory(NativeStoreConfig)
+    report_store: ReportStoreConfig = Factory(ReportStoreConfig)
     db: DbConfig = Factory(DbConfig)
     executor: ExecutorConfig = Factory(ExecutorConfig)
     diagnostic_providers: list[DiagnosticProviderConfig] = Factory(default_providers)  # noqa: RUF009, RUF100

--- a/packages/climate-ref/src/climate_ref/config.py
+++ b/packages/climate-ref/src/climate_ref/config.py
@@ -328,7 +328,7 @@ class ReportStoreConfig:
     Set ``REF_REPORT_STORE_S3_ENDPOINT_URL`` to override (e.g. a staging account).
     """
 
-    bucket: str = env_field(name="REPORT_STORE_BUCKET", default="ref-baseline-reports")
+    bucket: str = env_field(name="REPORT_STORE_BUCKET", default="ref-baselines-reports")
     """
     Name of the writable (Cloudflare R2) reports bucket.
 

--- a/packages/climate-ref/tests/unit/baseline_report/test_render.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_render.py
@@ -16,7 +16,7 @@ from climate_ref.baseline_report.analyse import (
     analyse,
 )
 from climate_ref.baseline_report.collect import CaseChange, FileChange, FileKind, Report, classify
-from climate_ref.baseline_report.render import render_case, render_index, write_site
+from climate_ref.baseline_report.render import render_case, render_comment, render_index, write_site
 from climate_ref_core.regression.manifest import SCHEMA_VERSION, Manifest, NativeEntry
 from climate_ref_core.regression.store import NativeStore
 
@@ -487,3 +487,106 @@ class TestNetcdfBlock:
         html = render_case(report, report.cases[0])
 
         assert '<div class="absent">absent</div>' in html
+
+
+BASE_URL = "https://reports.example/912/0c7e1d4abc12"
+
+MARKER = "<!-- climate-ref-baseline-diff -->"
+
+
+def _rows(markdown: str) -> list[str]:
+    """Return the table's body rows."""
+    lines = [line for line in markdown.splitlines() if line.startswith("| `")]
+    return lines
+
+
+class TestComment:
+    def test_one_row_per_case(self, tmp_path):
+        report = _analysed(
+            [
+                _case_change([], label="example/diag/a", base=_manifest(1), head=_manifest(2)),
+                _case_change([], label="pmp/diag/b", base=_manifest(1), head=_manifest(2)),
+            ],
+            tmp_path,
+        )
+
+        markdown = render_comment(report, BASE_URL)
+
+        assert len(_rows(markdown)) == 2
+        assert "`example/diag/a`" in markdown
+        assert "`pmp/diag/b`" in markdown
+
+    def test_every_row_links_into_the_hosted_report(self, changed_image_case):
+        markdown = render_comment(changed_image_case, BASE_URL)
+
+        assert f"[view]({BASE_URL}/example/diag/case/index.html)" in markdown
+        assert f"[Full report]({BASE_URL}/index.html)" in markdown
+
+    def test_a_trailing_slash_on_the_base_url_is_ignored(self, changed_image_case):
+        markdown = render_comment(changed_image_case, BASE_URL + "/")
+
+        assert "//index.html" not in markdown
+
+    def test_rows_stay_small(self, changed_image_case):
+        markdown = render_comment(changed_image_case, BASE_URL)
+
+        assert all(len(row.encode("utf-8")) <= 300 for row in _rows(markdown))
+
+    def test_counts_use_the_short_form(self, tmp_path):
+        report = _analysed(
+            [
+                _case_change(
+                    [
+                        _change("added.png", None, _entry("1")),
+                        _change("moved.png", _entry("2"), _entry("3")),
+                        _change("gone.txt", _entry("4"), None),
+                    ],
+                    base=_manifest(3),
+                    head=_manifest(4),
+                )
+            ],
+            tmp_path,
+        )
+
+        row = _rows(render_comment(report, BASE_URL))[0]
+
+        assert "| v3 -> v4 |" in row
+        assert "| +1 ~1 |" in row
+        assert "| -1 |" in row
+        assert "| none |" in row
+
+    @pytest.mark.parametrize(
+        "base, head, expected",
+        [(_manifest(3), None, "removed"), (None, _manifest(4), "new")],
+    )
+    def test_a_one_sided_case_says_so(self, tmp_path, base, head, expected):
+        report = _analysed([_case_change([], base=base, head=head)], tmp_path)
+
+        assert f"| {expected} |" in _rows(render_comment(report, BASE_URL))[0]
+
+    def test_zero_cases_renders_the_no_change_message(self, tmp_path):
+        markdown = render_comment(_analysed([], tmp_path), BASE_URL)
+
+        assert "No baseline manifests changed against `origin/main`." in markdown
+        assert "| case |" not in markdown
+        assert MARKER in markdown
+
+    def test_the_marker_appears_once(self, changed_image_case):
+        assert render_comment(changed_image_case, BASE_URL).count(MARKER) == 1
+
+    def test_previous_reports_are_listed(self, changed_image_case):
+        markdown = render_comment(
+            changed_image_case,
+            BASE_URL,
+            previous=[("abc1234", "https://reports.example/912/abc1234/index.html")],
+        )
+
+        assert "[abc1234](https://reports.example/912/abc1234/index.html)" in markdown
+
+    def test_no_previous_reports_leaves_the_line_out(self, changed_image_case):
+        assert "Previous reports" not in render_comment(changed_image_case, BASE_URL)
+
+    def test_labels_are_not_html_escaped(self, tmp_path):
+        report = _analysed([_case_change([], base=_manifest(3), head=_manifest(4))], tmp_path)
+
+        assert "-&gt;" not in render_comment(report, BASE_URL)

--- a/packages/climate-ref/tests/unit/baseline_report/test_render.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_render.py
@@ -496,8 +496,7 @@ MARKER = "<!-- climate-ref-baseline-diff -->"
 
 def _rows(markdown: str) -> list[str]:
     """Return the table's body rows."""
-    lines = [line for line in markdown.splitlines() if line.startswith("| `")]
-    return lines
+    return [line for line in markdown.splitlines() if line.startswith("| `")]
 
 
 class TestComment:
@@ -563,6 +562,20 @@ class TestComment:
         report = _analysed([_case_change([], base=base, head=head)], tmp_path)
 
         assert f"| {expected} |" in _rows(render_comment(report, BASE_URL))[0]
+
+    def test_the_header_carries_a_column_per_kind(self, changed_image_case):
+        markdown = render_comment(changed_image_case, BASE_URL)
+
+        header = next(line for line in markdown.splitlines() if line.startswith("| case |"))
+        assert header.count("|") == len(changed_image_case.kinds) + 4
+        for kind in changed_image_case.kinds:
+            assert f"| {kind} |" in header
+
+    def test_every_row_has_the_same_column_count_as_the_header(self, changed_image_case):
+        markdown = render_comment(changed_image_case, BASE_URL)
+
+        header = next(line for line in markdown.splitlines() if line.startswith("| case |"))
+        assert all(row.count("|") == header.count("|") for row in _rows(markdown))
 
     def test_zero_cases_renders_the_no_change_message(self, tmp_path):
         markdown = render_comment(_analysed([], tmp_path), BASE_URL)

--- a/packages/climate-ref/tests/unit/baseline_report/test_render.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_render.py
@@ -577,6 +577,28 @@ class TestComment:
         header = next(line for line in markdown.splitlines() if line.startswith("| case |"))
         assert all(row.count("|") == header.count("|") for row in _rows(markdown))
 
+    def test_each_count_sits_under_its_own_kind(self, tmp_path):
+        report = _analysed(
+            [
+                _case_change(
+                    [_change("added.png", None, _entry("1")), _change("gone.txt", _entry("4"), None)],
+                    base=_manifest(3),
+                    head=_manifest(4),
+                )
+            ],
+            tmp_path,
+        )
+        markdown = render_comment(report, BASE_URL)
+
+        header = [
+            c.strip()
+            for c in next(line for line in markdown.splitlines() if line.startswith("| case |")).split("|")
+        ]
+        cells = [c.strip() for c in _rows(markdown)[0].split("|")]
+        assert cells[header.index("image")] == "+1"
+        assert cells[header.index("text")] == "-1"
+        assert cells[header.index("netcdf")] == "none"
+
     def test_zero_cases_renders_the_no_change_message(self, tmp_path):
         markdown = render_comment(_analysed([], tmp_path), BASE_URL)
 

--- a/packages/climate-ref/tests/unit/baseline_report/test_upload.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_upload.py
@@ -1,0 +1,86 @@
+"""Tests for pushing a rendered report into the report store."""
+
+from pathlib import Path
+
+import pytest
+from attrs import define, field
+
+from climate_ref.baseline_report.upload import DEFAULT_CONTENT_TYPE, content_type_for, upload_site
+
+PREFIX = "912/0c7e1d4abc12"
+
+
+@define
+class RecordingStore:
+    """A report store that records what was put rather than storing it."""
+
+    url: str = "https://reports.example"
+    puts: list[tuple[str, Path, str]] = field(factory=list)
+
+    def put(self, key: str, path: Path, content_type: str) -> str:
+        self.puts.append((key, path, content_type))
+        return self.url_for(key)
+
+    def url_for(self, key: str) -> str:
+        return f"{self.url}/{key}"
+
+
+@pytest.fixture
+def site(tmp_path: Path) -> Path:
+    """A three-file site with one page nested a directory deep."""
+    out = tmp_path / "site"
+    (out / "example" / "diag").mkdir(parents=True)
+    (out / "index.html").write_text("<p>index</p>", encoding="utf-8")
+    (out / "report.css").write_text("body {}", encoding="utf-8")
+    (out / "example" / "diag" / "index.html").write_text("<p>case</p>", encoding="utf-8")
+    return out
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("index.html", "text/html; charset=utf-8"),
+        ("report.CSS", "text/css; charset=utf-8"),
+        ("report.js", "text/javascript; charset=utf-8"),
+        ("plot.png", "image/png"),
+        ("plot.svg", "image/svg+xml"),
+        ("blob.bin", DEFAULT_CONTENT_TYPE),
+        ("no-extension", DEFAULT_CONTENT_TYPE),
+    ],
+)
+def test_content_type_for(name, expected):
+    assert content_type_for(Path(name)) == expected
+
+
+class TestUploadSite:
+    def test_every_file_lands_under_the_prefix(self, site):
+        store = RecordingStore()
+
+        upload_site(site, store, PREFIX)
+
+        assert sorted(key for key, _, _ in store.puts) == [
+            f"{PREFIX}/example/diag/index.html",
+            f"{PREFIX}/index.html",
+            f"{PREFIX}/report.css",
+        ]
+
+    def test_content_types_are_set(self, site):
+        store = RecordingStore()
+
+        upload_site(site, store, PREFIX)
+
+        by_key = {key: content_type for key, _, content_type in store.puts}
+        assert by_key[f"{PREFIX}/index.html"] == "text/html; charset=utf-8"
+        assert by_key[f"{PREFIX}/report.css"] == "text/css; charset=utf-8"
+
+    def test_returns_the_index_url(self, site):
+        store = RecordingStore()
+
+        assert upload_site(site, store, PREFIX) == f"https://reports.example/{PREFIX}/index.html"
+
+    def test_directories_are_not_uploaded(self, site):
+        store = RecordingStore()
+
+        upload_site(site, store, PREFIX)
+
+        assert all(path.is_file() for _, path, _ in store.puts)

--- a/packages/climate-ref/tests/unit/cli/test_test_cases.py
+++ b/packages/climate-ref/tests/unit/cli/test_test_cases.py
@@ -2930,3 +2930,98 @@ class TestDiff:
         assert page.exists()
         assert page.read_text().count("<img") == 2
         assert "example/diag/case/index.html" in (out / "index.html").read_text()
+
+    def test_upload_writes_the_report_and_the_comment(self, invoke_cli, mocker, tmp_path, monkeypatch):
+        reports = tmp_path / "reports"
+        monkeypatch.setenv("REF_REPORT_STORE_URL", str(reports))
+
+        repo = MagicMock()
+        repo.working_tree_dir = str(tmp_path)
+        repo.git.diff.return_value = ""
+        repo.head.commit.hexsha = "a" * 40
+        mocker.patch("climate_ref.cli.test_cases.diff.get_repo_for_path", return_value=repo)
+
+        comment = tmp_path / "comment.md"
+        invoke_cli(
+            [
+                "test-cases",
+                "diff",
+                "--html-dir",
+                str(tmp_path / "out"),
+                "--no-fetch",
+                "--upload",
+                "912/abc",
+                "--comment-output",
+                str(comment),
+            ]
+        )
+
+        assert (reports / "912" / "abc" / "index.html").exists()
+        assert comment.read_text().count("<!-- climate-ref-baseline-diff -->") == 1
+
+    def test_an_unsafe_upload_prefix_exits_one(self, invoke_cli, mocker, tmp_path, monkeypatch):
+        monkeypatch.setenv("REF_REPORT_STORE_URL", str(tmp_path / "reports"))
+
+        repo = MagicMock()
+        repo.working_tree_dir = str(tmp_path)
+        repo.git.diff.return_value = ""
+        repo.head.commit.hexsha = "a" * 40
+        mocker.patch("climate_ref.cli.test_cases.diff.get_repo_for_path", return_value=repo)
+
+        invoke_cli(
+            [
+                "test-cases",
+                "diff",
+                "--html-dir",
+                str(tmp_path / "out"),
+                "--no-fetch",
+                "--upload",
+                "../escape",
+            ],
+            expected_exit_code=1,
+        )
+
+    def test_the_comment_links_locally_without_upload(self, invoke_cli, mocker, tmp_path):
+        from climate_ref_core.regression.manifest import SCHEMA_VERSION, Manifest
+
+        rel_path = "packages/climate-ref-example/tests/test-data/diag/case/manifest.json"
+        manifest_path = tmp_path / rel_path
+        manifest_path.parent.mkdir(parents=True)
+        Manifest(
+            schema=SCHEMA_VERSION,
+            test_case_version=4,
+            diagnostic_version=1,
+            committed={},
+            native={},
+        ).dump(manifest_path)
+
+        repo = MagicMock()
+        repo.working_tree_dir = str(tmp_path)
+        repo.git.diff.return_value = rel_path
+        repo.git.show.return_value = json.dumps(
+            {
+                "schema": SCHEMA_VERSION,
+                "test_case_version": 3,
+                "diagnostic_version": 1,
+                "committed": {},
+                "native": {},
+            }
+        )
+        repo.head.commit.hexsha = "c" * 40
+        mocker.patch("climate_ref.cli.test_cases.diff.get_repo_for_path", return_value=repo)
+
+        out = tmp_path / "out"
+        comment = tmp_path / "comment.md"
+        invoke_cli(
+            [
+                "test-cases",
+                "diff",
+                "--html-dir",
+                str(out),
+                "--no-fetch",
+                "--comment-output",
+                str(comment),
+            ]
+        )
+
+        assert f"{out.resolve().as_uri()}/index.html" in comment.read_text()

--- a/packages/climate-ref/tests/unit/cli/test_test_cases.py
+++ b/packages/climate-ref/tests/unit/cli/test_test_cases.py
@@ -2981,6 +2981,30 @@ class TestDiff:
             expected_exit_code=1,
         )
 
+    def test_an_unusable_report_store_exits_one(self, invoke_cli, mocker, tmp_path, monkeypatch):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        monkeypatch.setenv("REF_REPORT_STORE_URL", str(blocker / "reports"))
+
+        repo = MagicMock()
+        repo.working_tree_dir = str(tmp_path)
+        repo.git.diff.return_value = ""
+        repo.head.commit.hexsha = "a" * 40
+        mocker.patch("climate_ref.cli.test_cases.diff.get_repo_for_path", return_value=repo)
+
+        invoke_cli(
+            [
+                "test-cases",
+                "diff",
+                "--html-dir",
+                str(tmp_path / "out"),
+                "--no-fetch",
+                "--upload",
+                "912/abc",
+            ],
+            expected_exit_code=1,
+        )
+
     def test_the_comment_links_locally_without_upload(self, invoke_cli, mocker, tmp_path):
         from climate_ref_core.regression.manifest import SCHEMA_VERSION, Manifest
 

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -229,7 +229,7 @@ filename = "sqlite://climate_ref.db"
             "report_store": {
                 "url": "https://reports.baselines.climate-ref.org",
                 "s3_endpoint_url": "https://2aa5172b2bba093c516027d6fa13cdc8.r2.cloudflarestorage.com",
-                "bucket": "ref-baseline-reports",
+                "bucket": "ref-baselines-reports",
             },
             "paths": {
                 "log": f"{default_path}/log",
@@ -263,7 +263,7 @@ filename = "sqlite://climate_ref.db"
 
     def test_report_store_defaults(self, config):
         assert config.report_store.url == "https://reports.baselines.climate-ref.org"
-        assert config.report_store.bucket == "ref-baseline-reports"
+        assert config.report_store.bucket == "ref-baselines-reports"
 
     def test_report_store_from_env_variables(self, monkeypatch, config):
         monkeypatch.setenv("REF_REPORT_STORE_URL", "file:///tmp/ref-reports")

--- a/packages/climate-ref/tests/unit/test_config.py
+++ b/packages/climate-ref/tests/unit/test_config.py
@@ -226,6 +226,11 @@ filename = "sqlite://climate_ref.db"
                 "bucket": "ref-baselines-public",
                 "cache_dir": str(resolve_cache_dir("native-baselines")),
             },
+            "report_store": {
+                "url": "https://reports.baselines.climate-ref.org",
+                "s3_endpoint_url": "https://2aa5172b2bba093c516027d6fa13cdc8.r2.cloudflarestorage.com",
+                "bucket": "ref-baseline-reports",
+            },
             "paths": {
                 "log": f"{default_path}/log",
                 "results": f"{default_path}/results",
@@ -255,6 +260,19 @@ filename = "sqlite://climate_ref.db"
         assert config_new.paths.log == Path("/my/test/logs")
         assert config_new.paths.results == Path("/my/test/executions")
         assert config_new.cmip6_parser == "drs"
+
+    def test_report_store_defaults(self, config):
+        assert config.report_store.url == "https://reports.baselines.climate-ref.org"
+        assert config.report_store.bucket == "ref-baseline-reports"
+
+    def test_report_store_from_env_variables(self, monkeypatch, config):
+        monkeypatch.setenv("REF_REPORT_STORE_URL", "file:///tmp/ref-reports")
+        monkeypatch.setenv("REF_REPORT_STORE_BUCKET", "staging-reports")
+
+        config_new = config.refresh()
+
+        assert config_new.report_store.url == "file:///tmp/ref-reports"
+        assert config_new.report_store.bucket == "staging-reports"
 
     def test_measure_resources_defaults_on(self, config):
         assert config.executor.measure_resources is True


### PR DESCRIPTION
Adds `--upload <prefix>` and `--comment-output <path>` to `ref test-cases diff`, so the local report from #910 can be hosted and linked from a pull request comment. The comment becomes one table row per changed case, which is what replaces the capped markdown dump `scripts/ci/mint_diff.py` posts today.

Worth a close look:

- `ReportStore` is a new sibling of `NativeStore` rather than a method on it, because reports are keyed by path and `NativeStore` must stay content-addressed. Nothing in `store.py` changed.
- Key validation in `ReportStore.put` is the security-relevant bit. It layers an object-key character class over `safe_path`, the containment primitive `manifest.py` and `capture.py` already use.
- Every remote upload sets an explicit content type. Without it R2 serves the page as a binary download.
- Reports go to their own bucket, `ref-baselines-reports`, because an R2 token cannot be scoped to a prefix. A token that can write reports must not be able to overwrite baseline blobs.
- `ReportStore.preflight` deliberately mirrors `NativeStore.preflight` rather than sharing code with it, since `store.py` is out of scope here. The copy has already picked up a `BotoCoreError` branch that `store.py` lacks, so it is worth deciding whether the two should converge later.
- `render_comment` takes a `previous` argument that nothing supplies yet. The CI slice fills it in.

The marker `<!-- climate-ref-baseline-diff -->` is the contract the CI slice will use to find and edit the sticky comment.

No workflow or docs changes here. The bucket, host, token and GitHub environment do not exist yet, so nothing in CI calls this. That is the next slice.
