### PR TITLE
perf(tests): share fixtures across workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ test-quick: clean  ## run all the tests at once
 	# A new resource_intensive test has to live under a path listed here.
 	uv run \
 		pytest tests packages \
-		-r a -v  --cov-report=term -n $(PYTEST_WORKERS) \
+		-r a -v --cov-report=term -n $(PYTEST_WORKERS) --dist=loadscope \
 		-m "not resource_intensive"
 	uv run \
 		pytest packages/climate-ref-core/tests/integration packages/climate-ref/tests/integration \

--- a/changelog/916.trivial.md
+++ b/changelog/916.trivial.md
@@ -1,0 +1,1 @@
+Reduced local test runtime by sharing expensive fixture setup between parallel pytest workers.

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -60,6 +60,21 @@ def _clone_db(target_db_url: str, template_db_path: Path) -> None:
     shutil.copy(template_db_path, target_db_path)
 
 
+def _build_cached_file(cache_path: Path, builder: Callable[[Path], None]) -> None:
+    """Build and atomically publish a file once across xdist workers."""
+    with _exclusive_file_lock(cache_path.with_suffix(".lock")):
+        if cache_path.exists():
+            return
+
+        temporary_path = cache_path.with_name(f".{cache_path.stem}.{os.getpid()}{cache_path.suffix}")
+        temporary_path.unlink(missing_ok=True)
+        try:
+            builder(temporary_path)
+            os.replace(temporary_path, cache_path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+
 @pytest.fixture(scope="session")
 def migrated_db_template(shared_session_dir: Path) -> Path:
     """
@@ -68,20 +83,14 @@ def migrated_db_template(shared_session_dir: Path) -> Path:
     This schema is reused across parallel test runners.
     """
     template_db_path = shared_session_dir / "climate_ref_template.db"
-    with _exclusive_file_lock(shared_session_dir / "climate_ref_template.lock"):
-        if not template_db_path.exists():
-            temporary_path = shared_session_dir / f".climate_ref_template.{os.getpid()}.db"
-            temporary_path.unlink(missing_ok=True)
 
-            # dimensions_cv is left unset so the CV shipped in climate_ref_core is used.
-            template_config = Config()
-            template_config.db.database_url = f"sqlite:///{temporary_path}"
-            try:
-                database = Database.from_config(template_config, run_migrations=True, skip_backup=True)
-                database.close()
-                os.replace(temporary_path, template_db_path)
-            finally:
-                temporary_path.unlink(missing_ok=True)
+    def _build(temporary_path: Path) -> None:
+        # dimensions_cv is left unset so the CV shipped in climate_ref_core is used.
+        template_config = Config()
+        template_config.db.database_url = f"sqlite:///{temporary_path}"
+        Database.from_config(template_config, run_migrations=True, skip_backup=True).close()
+
+    _build_cached_file(template_db_path, _build)
 
     return template_db_path
 
@@ -143,39 +152,30 @@ def db_seeded_template(  # noqa: PLR0913
     prepare_db,
 ) -> Path:
     template_db_path = shared_session_dir / "climate_ref_template_seeded.db"
-    with _exclusive_file_lock(shared_session_dir / "climate_ref_template_seeded.lock"):
-        if not template_db_path.exists():
-            temporary_path = shared_session_dir / f".climate_ref_template_seeded.{os.getpid()}.db"
-            temporary_path.unlink(missing_ok=True)
-            shutil.copy(migrated_db_template, temporary_path)
 
-            database = Database(f"sqlite:///{temporary_path}")
-            try:
-                # ``register_dataset`` trusts callers to validate the catalog first.
-                adapter = CMIP6DatasetAdapter()
-                cmip6_validated = adapter.validate_data_catalog(cmip6_data_catalog)
+    def _build(temporary_path: Path) -> None:
+        shutil.copy(migrated_db_template, temporary_path)
+        with Database(f"sqlite:///{temporary_path}") as database:
+            # ``register_dataset`` trusts callers to validate the catalog first.
+            adapter = CMIP6DatasetAdapter()
+            cmip6_validated = adapter.validate_data_catalog(cmip6_data_catalog)
+            with database.session.begin():
+                for _, data_catalog_dataset in cmip6_validated.groupby(adapter.slug_column):
+                    adapter.register_dataset(database, data_catalog_dataset)
+
+            for adapter_obs, catalog in (
+                (Obs4MIPsDatasetAdapter(), obs4mips_data_catalog),
+                (Obs4REFDatasetAdapter(), obs4ref_data_catalog),
+            ):
+                validated = adapter_obs.validate_data_catalog(catalog)
                 with database.session.begin():
-                    for _, data_catalog_dataset in cmip6_validated.groupby(adapter.slug_column):
-                        adapter.register_dataset(database, data_catalog_dataset)
+                    for _, data_catalog_dataset in validated.groupby(adapter_obs.slug_column):
+                        adapter_obs.register_dataset(database, data_catalog_dataset)
 
-                for adapter_obs, catalog in (
-                    (Obs4MIPsDatasetAdapter(), obs4mips_data_catalog),
-                    (Obs4REFDatasetAdapter(), obs4ref_data_catalog),
-                ):
-                    validated = adapter_obs.validate_data_catalog(catalog)
-                    with database.session.begin():
-                        for _, data_catalog_dataset in validated.groupby(adapter_obs.slug_column):
-                            adapter_obs.register_dataset(database, data_catalog_dataset)
+            with database.session.begin():
+                _register_provider(database, example_provider)
 
-                with database.session.begin():
-                    _register_provider(database, example_provider)
-            finally:
-                database.close()
-
-            try:
-                os.replace(temporary_path, template_db_path)
-            finally:
-                temporary_path.unlink(missing_ok=True)
+    _build_cached_file(template_db_path, _build)
 
     return template_db_path
 

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -1,5 +1,4 @@
 import dataclasses
-import os
 import shutil
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -14,7 +13,7 @@ from pytest_regressions.data_regression import RegressionYamlDumper
 from yaml.representer import SafeRepresenter
 
 from climate_ref.config import Config
-from climate_ref.conftest_plugin import _exclusive_file_lock
+from climate_ref.conftest_plugin import _build_cached_file
 from climate_ref.database import Database, _get_sqlite_path
 from climate_ref.datasets.cmip6 import CMIP6DatasetAdapter
 from climate_ref.datasets.cmip6_parsers import parse_cmip6_complete, parse_cmip6_drs
@@ -58,21 +57,6 @@ def _clone_db(target_db_url: str, template_db_path: Path) -> None:
 
     target_db_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(template_db_path, target_db_path)
-
-
-def _build_cached_file(cache_path: Path, builder: Callable[[Path], None]) -> None:
-    """Build and atomically publish a file once across xdist workers."""
-    with _exclusive_file_lock(cache_path.with_suffix(".lock")):
-        if cache_path.exists():
-            return
-
-        temporary_path = cache_path.with_name(f".{cache_path.stem}.{os.getpid()}{cache_path.suffix}")
-        temporary_path.unlink(missing_ok=True)
-        try:
-            builder(temporary_path)
-            os.replace(temporary_path, cache_path)
-        finally:
-            temporary_path.unlink(missing_ok=True)
 
 
 @pytest.fixture(scope="session")

--- a/packages/climate-ref/conftest.py
+++ b/packages/climate-ref/conftest.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 import shutil
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -13,6 +14,7 @@ from pytest_regressions.data_regression import RegressionYamlDumper
 from yaml.representer import SafeRepresenter
 
 from climate_ref.config import Config
+from climate_ref.conftest_plugin import _exclusive_file_lock
 from climate_ref.database import Database, _get_sqlite_path
 from climate_ref.datasets.cmip6 import CMIP6DatasetAdapter
 from climate_ref.datasets.cmip6_parsers import parse_cmip6_complete, parse_cmip6_drs
@@ -59,15 +61,27 @@ def _clone_db(target_db_url: str, template_db_path: Path) -> None:
 
 
 @pytest.fixture(scope="session")
-def migrated_db_template(tmp_path_session: Path) -> Path:
-    """Build the current database schema once for reuse by isolated test databases."""
-    template_db_path = tmp_path_session / "climate_ref_template.db"
-    # dimensions_cv is left unset so the CV shipped in climate_ref_core is used.
-    template_config = Config()
-    template_config.db.database_url = f"sqlite:///{template_db_path}"
+def migrated_db_template(shared_session_dir: Path) -> Path:
+    """
+    Build the current database schema once.
 
-    database = Database.from_config(template_config, run_migrations=True, skip_backup=True)
-    database.close()
+    This schema is reused across parallel test runners.
+    """
+    template_db_path = shared_session_dir / "climate_ref_template.db"
+    with _exclusive_file_lock(shared_session_dir / "climate_ref_template.lock"):
+        if not template_db_path.exists():
+            temporary_path = shared_session_dir / f".climate_ref_template.{os.getpid()}.db"
+            temporary_path.unlink(missing_ok=True)
+
+            # dimensions_cv is left unset so the CV shipped in climate_ref_core is used.
+            template_config = Config()
+            template_config.db.database_url = f"sqlite:///{temporary_path}"
+            try:
+                database = Database.from_config(template_config, run_migrations=True, skip_backup=True)
+                database.close()
+                os.replace(temporary_path, template_db_path)
+            finally:
+                temporary_path.unlink(missing_ok=True)
 
     return template_db_path
 
@@ -121,40 +135,47 @@ def prepare_db(cmip7_aft_cv):
 
 @pytest.fixture(scope="session")
 def db_seeded_template(  # noqa: PLR0913
-    tmp_path_session: Path,
+    shared_session_dir: Path,
     migrated_db_template: Path,
     cmip6_data_catalog,
     obs4mips_data_catalog,
     obs4ref_data_catalog,
     prepare_db,
 ) -> Path:
-    template_db_path = tmp_path_session / "climate_ref_template_seeded.db"
-    shutil.copy(migrated_db_template, template_db_path)
+    template_db_path = shared_session_dir / "climate_ref_template_seeded.db"
+    with _exclusive_file_lock(shared_session_dir / "climate_ref_template_seeded.lock"):
+        if not template_db_path.exists():
+            temporary_path = shared_session_dir / f".climate_ref_template_seeded.{os.getpid()}.db"
+            temporary_path.unlink(missing_ok=True)
+            shutil.copy(migrated_db_template, temporary_path)
 
-    database = Database(f"sqlite:///{template_db_path}")
+            database = Database(f"sqlite:///{temporary_path}")
+            try:
+                # ``register_dataset`` trusts callers to validate the catalog first.
+                adapter = CMIP6DatasetAdapter()
+                cmip6_validated = adapter.validate_data_catalog(cmip6_data_catalog)
+                with database.session.begin():
+                    for _, data_catalog_dataset in cmip6_validated.groupby(adapter.slug_column):
+                        adapter.register_dataset(database, data_catalog_dataset)
 
-    # Seed the CMIP6 sample datasets. ``register_dataset`` trusts callers to
-    # have already validated the catalog, so do that here before iterating.
-    adapter = CMIP6DatasetAdapter()
-    cmip6_validated = adapter.validate_data_catalog(cmip6_data_catalog)
-    with database.session.begin():
-        for instance_id, data_catalog_dataset in cmip6_validated.groupby(adapter.slug_column):
-            adapter.register_dataset(database, data_catalog_dataset)
+                for adapter_obs, catalog in (
+                    (Obs4MIPsDatasetAdapter(), obs4mips_data_catalog),
+                    (Obs4REFDatasetAdapter(), obs4ref_data_catalog),
+                ):
+                    validated = adapter_obs.validate_data_catalog(catalog)
+                    with database.session.begin():
+                        for _, data_catalog_dataset in validated.groupby(adapter_obs.slug_column):
+                            adapter_obs.register_dataset(database, data_catalog_dataset)
 
-    # Seed the obs4MIPs and obs4REF sample datasets
-    for adapter_obs, catalog in (
-        (Obs4MIPsDatasetAdapter(), obs4mips_data_catalog),
-        (Obs4REFDatasetAdapter(), obs4ref_data_catalog),
-    ):
-        validated = adapter_obs.validate_data_catalog(catalog)
-        with database.session.begin():
-            for instance_id, data_catalog_dataset in validated.groupby(adapter_obs.slug_column):
-                adapter_obs.register_dataset(database, data_catalog_dataset)
+                with database.session.begin():
+                    _register_provider(database, example_provider)
+            finally:
+                database.close()
 
-    with database.session.begin():
-        _register_provider(database, example_provider)
-
-    database.close()
+            try:
+                os.replace(temporary_path, template_db_path)
+            finally:
+                temporary_path.unlink(missing_ok=True)
 
     return template_db_path
 

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -131,6 +131,22 @@ def _exclusive_file_lock(path: Path) -> Generator[None]:
             fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
+def _build_cached_file[T](cache_path: Path, builder: Callable[[Path], T]) -> T | None:
+    """Build and atomically publish a file once across xdist workers."""
+    with _exclusive_file_lock(cache_path.with_suffix(".lock")):
+        if cache_path.exists():
+            return None
+
+        temporary_path = cache_path.with_name(f".{cache_path.name}.{os.getpid()}.tmp")
+        temporary_path.unlink(missing_ok=True)
+        try:
+            result = builder(temporary_path)
+            os.replace(temporary_path, cache_path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+        return result
+
+
 def _run_once(marker_path: Path, action: Callable[[], None]) -> None:
     """Run an action once across xdist workers in the current pytest run."""
     with _exclusive_file_lock(marker_path.with_suffix(".lock")):
@@ -142,17 +158,13 @@ def _run_once(marker_path: Path, action: Callable[[], None]) -> None:
 
 def _load_or_create_dataframe(cache_path: Path, builder: Callable[[], pd.DataFrame]) -> pd.DataFrame:
     """Build and cache a DataFrame once across xdist workers."""
-    dataframe: pd.DataFrame | None = None
-    with _exclusive_file_lock(cache_path.with_suffix(".lock")):
-        if not cache_path.exists():
-            dataframe = builder()
-            temporary_path = cache_path.with_name(f".{cache_path.name}.{os.getpid()}.tmp")
-            try:
-                dataframe.to_pickle(temporary_path)
-                os.replace(temporary_path, cache_path)
-            finally:
-                temporary_path.unlink(missing_ok=True)
 
+    def _build(temporary_path: Path) -> pd.DataFrame:
+        dataframe = builder()
+        dataframe.to_pickle(temporary_path)
+        return dataframe
+
+    dataframe = _build_cached_file(cache_path, _build)
     if dataframe is not None:
         return dataframe
 

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -30,7 +30,6 @@ import atexit
 import fcntl
 import os
 import re
-import tempfile
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from functools import lru_cache
@@ -112,13 +111,6 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 @pytest.fixture(scope="session")
-def tmp_path_session() -> Iterator[Path]:
-    """Session-scoped temporary directory."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield Path(tmpdir)
-
-
-@pytest.fixture(scope="session")
 def shared_session_dir(tmp_path_factory: pytest.TempPathFactory, request: pytest.FixtureRequest) -> Path:
     """Temporary directory shared by every xdist worker in this pytest run."""
     base_temp = tmp_path_factory.getbasetemp()
@@ -150,19 +142,22 @@ def _run_once(marker_path: Path, action: Callable[[], None]) -> None:
 
 def _load_or_create_dataframe(cache_path: Path, builder: Callable[[], pd.DataFrame]) -> pd.DataFrame:
     """Build and cache a DataFrame once across xdist workers."""
+    dataframe: pd.DataFrame | None = None
     with _exclusive_file_lock(cache_path.with_suffix(".lock")):
-        if cache_path.exists():
-            # This is a trusted, run-local cache created by the fixture below.
-            return cast(pd.DataFrame, pd.read_pickle(cache_path))  # noqa: S301
+        if not cache_path.exists():
+            dataframe = builder()
+            temporary_path = cache_path.with_name(f".{cache_path.name}.{os.getpid()}.tmp")
+            try:
+                dataframe.to_pickle(temporary_path)
+                os.replace(temporary_path, cache_path)
+            finally:
+                temporary_path.unlink(missing_ok=True)
 
-        dataframe = builder()
-        temporary_path = cache_path.with_name(f".{cache_path.name}.{os.getpid()}.tmp")
-        try:
-            dataframe.to_pickle(temporary_path)
-            os.replace(temporary_path, cache_path)
-        finally:
-            temporary_path.unlink(missing_ok=True)
+    if dataframe is not None:
         return dataframe
+
+    # This is a trusted, run-local cache created by the fixture above.
+    return cast(pd.DataFrame, pd.read_pickle(cache_path))  # noqa: S301
 
 
 @pytest.fixture
@@ -283,9 +278,7 @@ def obs4mips_data_catalog(sample_data: None, sample_data_dir: Path, shared_sessi
 
 
 @pytest.fixture(scope="session")
-def obs4ref_data_catalog(
-    sample_data: None, sample_data_dir: Path, shared_session_dir: Path
-) -> pd.DataFrame:
+def obs4ref_data_catalog(sample_data: None, sample_data_dir: Path, shared_session_dir: Path) -> pd.DataFrame:
     """obs4REF sample data catalog."""
     return _load_or_create_dataframe(
         shared_session_dir / "obs4ref-data-catalog.pkl",

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -27,11 +27,12 @@ Provided fixtures
 from __future__ import annotations
 
 import atexit
+import fcntl
 import os
 import re
 import tempfile
-from collections.abc import Callable, Iterator
-from contextlib import ExitStack
+from collections.abc import Callable, Generator, Iterator
+from contextlib import ExitStack, contextmanager
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
@@ -117,6 +118,53 @@ def tmp_path_session() -> Iterator[Path]:
         yield Path(tmpdir)
 
 
+@pytest.fixture(scope="session")
+def shared_session_dir(tmp_path_factory: pytest.TempPathFactory, request: pytest.FixtureRequest) -> Path:
+    """Temporary directory shared by every xdist worker in this pytest run."""
+    base_temp = tmp_path_factory.getbasetemp()
+    if hasattr(request.config, "workerinput"):
+        return base_temp.parent
+    return base_temp
+
+
+@contextmanager
+def _exclusive_file_lock(path: Path) -> Generator[None]:
+    """Hold an advisory process lock for a shared test artifact."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def _run_once(marker_path: Path, action: Callable[[], None]) -> None:
+    """Run an action once across xdist workers in the current pytest run."""
+    with _exclusive_file_lock(marker_path.with_suffix(".lock")):
+        if marker_path.exists():
+            return
+        action()
+        marker_path.touch()
+
+
+def _load_or_create_dataframe(cache_path: Path, builder: Callable[[], pd.DataFrame]) -> pd.DataFrame:
+    """Build and cache a DataFrame once across xdist workers."""
+    with _exclusive_file_lock(cache_path.with_suffix(".lock")):
+        if cache_path.exists():
+            # This is a trusted, run-local cache created by the fixture below.
+            return cast(pd.DataFrame, pd.read_pickle(cache_path))  # noqa: S301
+
+        dataframe = builder()
+        temporary_path = cache_path.with_name(f".{cache_path.name}.{os.getpid()}.tmp")
+        try:
+            dataframe.to_pickle(temporary_path)
+            os.replace(temporary_path, cache_path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+        return dataframe
+
+
 @pytest.fixture
 def caplog(caplog: LogCaptureFixture) -> Iterator[LogCaptureFixture]:
     """Capture logs from the loguru default logger."""
@@ -200,33 +248,49 @@ def esgf_data_catalog_trimmed(
 
 
 @pytest.fixture(scope="session")
-def sample_data() -> None:
+def sample_data(shared_session_dir: Path) -> None:
     """Download sample data if not already present."""
     if os.environ.get("REF_TEST_DATA_DIR"):
         logger.warning("Not fetching sample data. Using custom test data directory")
         return
-    logger.disable("climate_ref_core.dataset_registry")
-    fetch_sample_data(force_cleanup=False, symlink=False)
-    logger.enable("climate_ref_core.dataset_registry")
+
+    def _fetch() -> None:
+        logger.disable("climate_ref_core.dataset_registry")
+        try:
+            fetch_sample_data(force_cleanup=False, symlink=False)
+        finally:
+            logger.enable("climate_ref_core.dataset_registry")
+
+    _run_once(shared_session_dir / "sample-data.ready", _fetch)
 
 
 @pytest.fixture(scope="session")
-def cmip6_data_catalog(sample_data: None, sample_data_dir: Path) -> pd.DataFrame:
+def cmip6_data_catalog(sample_data: None, sample_data_dir: Path, shared_session_dir: Path) -> pd.DataFrame:
     """CMIP6 sample data catalog."""
-    adapter = CMIP6DatasetAdapter()
-    return adapter.find_local_datasets(sample_data_dir / "CMIP6")
+    return _load_or_create_dataframe(
+        shared_session_dir / "cmip6-data-catalog.pkl",
+        lambda: CMIP6DatasetAdapter().find_local_datasets(sample_data_dir / "CMIP6"),
+    )
 
 
 @pytest.fixture(scope="session")
-def obs4mips_data_catalog(sample_data: None, sample_data_dir: Path) -> pd.DataFrame:
+def obs4mips_data_catalog(sample_data: None, sample_data_dir: Path, shared_session_dir: Path) -> pd.DataFrame:
     """obs4MIPs sample data catalog."""
-    return Obs4MIPsDatasetAdapter().find_local_datasets(sample_data_dir / "obs4MIPs")
+    return _load_or_create_dataframe(
+        shared_session_dir / "obs4mips-data-catalog.pkl",
+        lambda: Obs4MIPsDatasetAdapter().find_local_datasets(sample_data_dir / "obs4MIPs"),
+    )
 
 
 @pytest.fixture(scope="session")
-def obs4ref_data_catalog(sample_data: None, sample_data_dir: Path) -> pd.DataFrame:
+def obs4ref_data_catalog(
+    sample_data: None, sample_data_dir: Path, shared_session_dir: Path
+) -> pd.DataFrame:
     """obs4REF sample data catalog."""
-    return Obs4REFDatasetAdapter().find_local_datasets(sample_data_dir / "obs4REF")
+    return _load_or_create_dataframe(
+        shared_session_dir / "obs4ref-data-catalog.pkl",
+        lambda: Obs4REFDatasetAdapter().find_local_datasets(sample_data_dir / "obs4REF"),
+    )
 
 
 @pytest.fixture(scope="session")

--- a/packages/climate-ref/tests/unit/test_conftest_plugin.py
+++ b/packages/climate-ref/tests/unit/test_conftest_plugin.py
@@ -1,11 +1,18 @@
 """Tests for the shared pytest plugin shipped with ``climate_ref``."""
 
+import os
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from climate_ref.config import BUNDLED_IGNORE_DATASETS, DEFAULT_IGNORE_DATASETS_FILENAME, Config
-from climate_ref.conftest_plugin import _use_local_ignore_datasets_file, packaged_ignore_datasets_file
+from climate_ref.conftest_plugin import (
+    _load_or_create_dataframe,
+    _run_once,
+    _use_local_ignore_datasets_file,
+    packaged_ignore_datasets_file,
+)
 from climate_ref_core.data import ResourceOrigin
 
 # The canonical copy, served over `DEFAULT_IGNORE_DATASETS_URL` from the default branch.
@@ -40,3 +47,40 @@ def test_use_local_ignore_datasets_file_disables_fetching():
     assert cfg.ignore_datasets_resource.origin == ResourceOrigin.override
     # An empty URL short-circuits `refresh_ignore_datasets_file`, keeping tests offline.
     assert cfg.ignore_datasets_url == ""
+
+
+def test_run_once_reuses_completion_marker(tmp_path):
+    calls = []
+
+    _run_once(tmp_path / "artifact.ready", lambda: calls.append("called"))
+    _run_once(tmp_path / "artifact.ready", lambda: calls.append("called"))
+
+    assert calls == ["called"]
+
+
+def test_run_once_retries_after_failure(tmp_path):
+    marker_path = tmp_path / "artifact.ready"
+
+    def fail():
+        raise RuntimeError("failed")
+
+    with pytest.raises(RuntimeError, match="failed"):
+        _run_once(marker_path, fail)
+
+    assert not marker_path.exists()
+
+
+def test_load_or_create_dataframe_reuses_cache(tmp_path):
+    calls = []
+    expected = pd.DataFrame({"value": [1, 2]})
+
+    def build():
+        calls.append(os.getpid())
+        return expected
+
+    first = _load_or_create_dataframe(tmp_path / "catalog.pkl", build)
+    second = _load_or_create_dataframe(tmp_path / "catalog.pkl", build)
+
+    pd.testing.assert_frame_equal(first, expected)
+    pd.testing.assert_frame_equal(second, expected)
+    assert calls == [os.getpid()]


### PR DESCRIPTION
Shares sample-data downloads, catalog parsing, migrated schemas, and seeded database templates across xdist workers using locked run-local artifacts. Tests still clone SQLite templates per test, so writable state remains isolated.

Uses `loadscope` for the local parallel target. With four workers, the climate-ref unit suite fell from 65.14 seconds on main to 41.05 seconds on this branch and passed all 1,744 tests.
