### PR TITLE
docs: tighten the baseline diff report notes

### DIFF
--- a/.github/workflows/regression-diff-report.yaml
+++ b/.github/workflows/regression-diff-report.yaml
@@ -1,8 +1,6 @@
 # Build and host the HTML diff of the regression baselines changed on a branch.
 #
-# Called by the mint workflow after it pushes regenerated manifests, and dispatched by hand
-# after a manual mint. Reads native blobs from the public store and writes only to the
-# reports bucket, so it needs the reports token and nothing else.
+# Called by the mint workflow after it pushes regenerated manifests, or run by hand after a manual mint.
 name: Regression baselines (diff report)
 
 on:

--- a/.github/workflows/regression-mint.yaml
+++ b/.github/workflows/regression-mint.yaml
@@ -36,7 +36,7 @@ on:
         default: false
 
 # `contents` to commit the regenerated manifest/bundle back to the dispatched branch,
-# `pull-requests` so the called diff-report workflow can post on the branch's open pull request.
+# `pull-requests` so the diff-report workflow can post to the branch's PR.
 permissions:
   contents: write
   pull-requests: write
@@ -70,7 +70,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          # Full history so the mint can resolve the committed baselines against the default branch.
           fetch-depth: 0
       - uses: ./.github/actions/setup
         with:
@@ -134,9 +133,8 @@ jobs:
             exit 0
           fi
           git commit -m "chore(regression): mint native baselines for ${PROVIDER}"
-          # Pushed with GITHUB_TOKEN, so GitHub will NOT start new workflow runs for this
-          # commit: the PR gate does not auto-replay the freshly minted baseline. Push a
-          # follow-up commit (or re-run the PR gate) to verify it. See docs/background/regression-baselines.md.
+          # Pushed with GITHUB_TOKEN, so GitHub will NOT start new workflow runs for this commit.
+          # See docs/background/regression-baselines.md.
           #
           # The branch may have advanced (e.g. mint of another diagnostic).
           # Different diagnostics touch disjoint test-data paths, so the rebase does not conflict.

--- a/changelog/917.trivial.md
+++ b/changelog/917.trivial.md
@@ -1,0 +1,1 @@
+Tightened the wording in the regression baseline diff report docs.

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -257,8 +257,8 @@ Since this is a public project we have to be careful about when this is run to n
 | Workflow | Trigger | Credentials | What it does |
 | --- | --- | --- | --- |
 | `regression-pr-gate.yaml` | every pull request | none | Runs the coupling gate, then `replay`s every case it routes to `replay`. |
-| `regression-mint.yaml` | manual dispatch | R2 write | `mint`s native baselines and commits the regenerated manifest back to the branch. |
-| `regression-diff-report.yaml` | called by the mint + manual | R2 write (reports bucket) | Builds the HTML diff of the changed baselines and links it from a sticky pull-request comment. |
+| `regression-mint.yaml` | manual dispatch | R2 write (baselines bucket) | `mint`s native baselines and commits the regenerated manifest back to the branch. |
+| `regression-diff-report.yaml` | called by the mint + manual | R2 write (reports bucket) | Builds the HTML diff of the changed baselines and posts comment to a PR. |
 | `regression-drift.yaml` | nightly + manual | none | `replay`s every baseline to catch silent drift. |
 
 ### PR gate (`regression-pr-gate.yaml`)
@@ -321,8 +321,7 @@ Once the commit is pushed, the mint calls `regression-diff-report.yaml` to publi
 
 ### Diff report (`regression-diff-report.yaml`)
 
-Reviewing a minted baseline means looking at what actually moved, which a JSON manifest does not show.
-So this workflow builds an HTML report of every test case whose baseline changed against the base branch:
+To aid in the review process, we generate an HTML report of every test case whose baseline changed against the base branch with:
 
 - Images are shown two-up, the old beside the new.
 - Text outputs get a coloured line diff.
@@ -331,8 +330,7 @@ So this workflow builds an HTML report of every test case whose baseline changed
 The report is uploaded to the public reports bucket and served at
 `https://reports.baselines.climate-ref.org/<pr>/<sha>/index.html`.
 The workflow then posts a short comment on the branch's open pull request linking to it.
-The comment carries a hidden marker, so a later run edits that same comment rather than stacking a new one.
-A run on a branch with no open pull request uploads under `branch/<name>/<sha>/` and writes the summary to the job log only.
+If the branch doesn't have an open PR, the summary is written to the job log instead.
 
 The mint workflow calls this automatically.
 After minting on a workstation and pushing the result by hand, dispatch it yourself:
@@ -348,16 +346,12 @@ uv run ref test-cases diff --base origin/main --html-dir out/
 ```
 
 !!! note "Required repository configuration"
-    Create a `baseline-reports` Environment (Settings -> Environments) with **no required reviewers**,
-    so a mint run does not stop for a second approval, and add two secrets to it
-    holding an R2 token scoped to the `ref-baselines-reports` bucket:
+    This workflow requires a R2 user with read/write permissions to the bucket.
 
     - `R2_REPORTS_ACCESS_KEY_ID` -> `REF_REPORT_STORE_ACCESS_KEY_ID`
     - `R2_REPORTS_SECRET_ACCESS_KEY` -> `REF_REPORT_STORE_SECRET_ACCESS_KEY`
 
-    The reports live in their own bucket because an R2 token cannot be scoped write-only or to a prefix.
-    A token that could write reports into the baselines bucket could also overwrite a baseline.
-    The endpoint, bucket and public URL default to the production R2 account
+    The endpoint, bucket and public URL default to a separate bucket from the baselines
     (`REF_REPORT_STORE_S3_ENDPOINT_URL` / `REF_REPORT_STORE_BUCKET` / `REF_REPORT_STORE_URL` override them).
 
 ### Nightly drift (`regression-drift.yaml`)


### PR DESCRIPTION
Tightens the wording in the diff report docs and the workflow comments now that #915 has landed.

- Shortens the header comment on `regression-diff-report.yaml` and two comments in `regression-mint.yaml`.
- Names the bucket each workflow writes to in the workflow table.
- Trims the diff report section and the required configuration admonition.

No behaviour changes. Docs and comments only.
