### PR TITLE
feat: declare obs4REF as a fallback on every obs4MIPs data requirement

### DIFF
--- a/changelog/918.trivial.md
+++ b/changelog/918.trivial.md
@@ -1,0 +1,2 @@
+Observational data requirements now declare `obs4REF` as a fallback source type alongside the `obs4MIPs` type they ask for.
+This states explicitly what the solver already did implicitly, so nothing changes for users yet.

--- a/changelog/918.trivial.md
+++ b/changelog/918.trivial.md
@@ -1,2 +1,3 @@
-Observational data requirements now declare `obs4REF` as a fallback source type alongside the `obs4MIPs` type they ask for.
-This states explicitly what the solver already did implicitly, so nothing changes for users yet.
+Added `obs4REF` as a declared fallback source type on every observational data requirement,
+alongside the `obs4MIPs` type they already ask for.
+The solver already applied this implicitly, so nothing changed for users.

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_radiative_effects.py
@@ -28,6 +28,7 @@ _TIMERANGES = {
 def _reference_data_requirement(start_year: int, end_year: int) -> DataRequirement:
     return DataRequirement(
         source_type=SourceDatasetType.obs4MIPs,
+        fallback_source_types=(SourceDatasetType.obs4REF,),
         filters=(
             FacetFilter(
                 facets={

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/cloud_scatterplots.py
@@ -455,6 +455,7 @@ class CloudScatterplotsReference(ESMValToolDiagnostic):
     data_requirements = (
         DataRequirement(
             source_type=SourceDatasetType.obs4MIPs,
+            fallback_source_types=(SourceDatasetType.obs4REF,),
             filters=(
                 FacetFilter(
                     facets={

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/ozone.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/ozone.py
@@ -51,6 +51,7 @@ toz_data_requirement = (
         ),
         DataRequirement(
             source_type=SourceDatasetType.obs4MIPs,
+            fallback_source_types=(SourceDatasetType.obs4REF,),
             filters=(ozone_obs_filter,),
             group_by=("source_id",),
             constraints=(
@@ -89,6 +90,7 @@ toz_data_requirement = (
         ),
         DataRequirement(
             source_type=SourceDatasetType.obs4MIPs,
+            fallback_source_types=(SourceDatasetType.obs4REF,),
             filters=(ozone_obs_filter,),
             group_by=("source_id",),
             constraints=(

--- a/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/regional_historical_changes.py
+++ b/packages/climate-ref-esmvaltool/src/climate_ref_esmvaltool/diagnostics/regional_historical_changes.py
@@ -178,6 +178,7 @@ class RegionalHistoricalAnnualCycle(ESMValToolDiagnostic):
         (
             DataRequirement(
                 source_type=SourceDatasetType.obs4MIPs,
+                fallback_source_types=(SourceDatasetType.obs4REF,),
                 filters=(
                     FacetFilter(
                         facets={
@@ -464,6 +465,7 @@ class RegionalHistoricalTimeSeries(RegionalHistoricalAnnualCycle):
         (
             DataRequirement(
                 source_type=SourceDatasetType.obs4MIPs,
+                fallback_source_types=(SourceDatasetType.obs4REF,),
                 filters=(
                     FacetFilter(
                         facets={
@@ -719,6 +721,7 @@ class RegionalHistoricalTrend(ESMValToolDiagnostic):
         (
             DataRequirement(
                 source_type=SourceDatasetType.obs4MIPs,
+                fallback_source_types=(SourceDatasetType.obs4REF,),
                 filters=(
                     FacetFilter(
                         facets={

--- a/packages/climate-ref-example/src/climate_ref_example/surface_temperature.py
+++ b/packages/climate-ref-example/src/climate_ref_example/surface_temperature.py
@@ -324,6 +324,7 @@ class GlobalMeanSurfaceTemperatureBias(Diagnostic):
     # data is available alongside the reference dataset.
     _reference_requirement = DataRequirement(
         source_type=SourceDatasetType.obs4MIPs,
+        fallback_source_types=(SourceDatasetType.obs4REF,),
         filters=(
             FacetFilter(facets={"source_id": (_REFERENCE_SOURCE_ID,), "variable_id": (_REFERENCE_VARIABLE,)}),
         ),

--- a/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
+++ b/packages/climate-ref-ilamb/src/climate_ref_ilamb/standard.py
@@ -952,6 +952,7 @@ class ILAMBStandard(Diagnostic):
         # dictionary, then assume that these keys are meant to be keywords in a
         # REF data requirement.
         # obs_source names where the test data is fetched from, the registry or ESGF.
+        # It does not affect the requirement below.
         filters: dict[str, tuple[str, ...]] = {}
         obs_source = None
         for _, source in sources.items():
@@ -966,6 +967,7 @@ class ILAMBStandard(Diagnostic):
                 source_type=SourceDatasetType.obs4MIPs,
                 filters=(FacetFilter(facets=filters),),
                 group_by=tuple(filters.keys()),
+                fallback_source_types=(SourceDatasetType.obs4REF,),
             )
             if filters
             else None

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/enso.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/enso.py
@@ -218,6 +218,7 @@ class ENSO(CommandLineDiagnostic):
 
         obs_requirement = DataRequirement(
             source_type=SourceDatasetType.obs4MIPs,
+            fallback_source_types=(SourceDatasetType.obs4REF,),
             filters=(
                 FacetFilter(facets={"source_id": self.obs_sources, "variable_id": self.model_variables}),
             ),

--- a/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
+++ b/packages/climate-ref-pmp/src/climate_ref_pmp/diagnostics/variability_modes.py
@@ -90,6 +90,7 @@ class ExtratropicalModesOfVariability(CommandLineDiagnostic):
 
             obs_requirement = DataRequirement(
                 source_type=SourceDatasetType.obs4MIPs,
+                fallback_source_types=(SourceDatasetType.obs4REF,),
                 filters=(FacetFilter(facets={"source_id": (obs_source,), "variable_id": (obs_variable,)}),),
                 group_by=("source_id", "variable_id"),
             )


### PR DESCRIPTION
Adds `fallback_source_types=(SourceDatasetType.obs4REF,)` to all eleven observational data requirements, across ILAMB, PMP, ESMValTool and the example provider.

Today every one of them asks for `obs4MIPs` and is served by the obs4REF registry through an implicit fold in the solver, and nothing in the requirement says so. Declaring the fallback makes each requirement state what it actually accepts, which is what lets a later change delete the fold.

Behaviour is unchanged while the fold is still active, so this must be a no-op on solved output. The check for that is the solver and doctor snapshots in `packages/climate-ref/tests/unit/`, which are untouched and were not regenerated. The full `climate-ref` unit suite passes at 1621, as do the pmp, esmvaltool and example provider suites.

Two things are deliberately left alone. ILAMB's `obs_source` stays a test data fetch hint and does not drive the requirement, because reading it that way would change behaviour for `lai`. No committed `catalog.yaml` under `packages/*/tests/test-data/` is regenerated, so the pre-existing `activity_id: obs4REF` drift in 26 of them is untouched and still harmless.
