### PR TITLE
feat(baseline-report): diff the committed artefacts

### DIFF
--- a/changelog/919.feature.md
+++ b/changelog/919.feature.md
@@ -1,0 +1,3 @@
+Diff the committed regression artefacts in the `ref test-cases diff` report, alongside the native outputs.
+Each one carries an "in PR" pill, because those bytes also appear in the pull request's own file list.
+Every case page also lists the folder structure of its captured baseline, including the files that did not move.

--- a/changelog/919.feature.md
+++ b/changelog/919.feature.md
@@ -1,3 +1,4 @@
 Diff the committed regression artefacts in the `ref test-cases diff` report, alongside the native outputs.
 Each one carries an "in PR" pill, because those bytes also appear in the pull request's own file list.
-Every case page also lists the folder structure of its captured baseline, including the files that did not move.
+Every case page also lists the folder structure of its captured baseline, the committed bundle included,
+showing the files that did not move as well as the ones that did.

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -326,7 +326,8 @@ To aid in the review process, we generate an HTML report of every test case whos
 - Images are shown two-up, the old beside the new.
 - Text outputs get a coloured line diff.
 - A changed NetCDF gets a header diff plus one row of statistics per variable, shaded only where the values moved.
-- Committed bundle artefacts get the same line diff, marked with an "in PR" pill because those bytes are also in the pull request's own file list.
+- Committed bundle artefacts get the same line diff,
+  marked with an "in PR" pill because those bytes are also in the pull request's own file list.
 - Each case page lists the folder structure of its captured baseline, including the files that did not move.
 
 The report is uploaded to the public reports bucket and served at

--- a/docs/background/regression-baselines.md
+++ b/docs/background/regression-baselines.md
@@ -326,6 +326,8 @@ To aid in the review process, we generate an HTML report of every test case whos
 - Images are shown two-up, the old beside the new.
 - Text outputs get a coloured line diff.
 - A changed NetCDF gets a header diff plus one row of statistics per variable, shaded only where the values moved.
+- Committed bundle artefacts get the same line diff, marked with an "in PR" pill because those bytes are also in the pull request's own file list.
+- Each case page lists the folder structure of its captured baseline, including the files that did not move.
 
 The report is uploaded to the public reports bucket and served at
 `https://reports.baselines.climate-ref.org/<pr>/<sha>/index.html`.

--- a/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/__init__.py
@@ -29,6 +29,7 @@ from climate_ref_core.regression.gate import (
 )
 from climate_ref_core.regression.manifest import (
     COMMITTED_BUNDLE_FILES,
+    COMMITTED_DIRNAME,
     SCHEMA_VERSION,
     Manifest,
     NativeEntry,
@@ -50,6 +51,7 @@ from climate_ref_core.regression.store import (
 
 __all__ = [
     "COMMITTED_BUNDLE_FILES",
+    "COMMITTED_DIRNAME",
     "SCHEMA_VERSION",
     "Action",
     "GateDecision",

--- a/packages/climate-ref-core/src/climate_ref_core/regression/manifest.py
+++ b/packages/climate-ref-core/src/climate_ref_core/regression/manifest.py
@@ -62,6 +62,10 @@ def _validate_digest(digest: str) -> str:
     return digest
 
 
+COMMITTED_DIRNAME = "regression"
+"""The directory a test case's committed bundle sits in, both in git and in an output slot."""
+
+
 COMMITTED_BUNDLE_FILES: tuple[str, ...] = (
     "series.json",
     "diagnostic.json",

--- a/packages/climate-ref-core/src/climate_ref_core/testing.py
+++ b/packages/climate-ref-core/src/climate_ref_core/testing.py
@@ -27,7 +27,7 @@ from climate_ref_core.datasets import (
 )
 from climate_ref_core.esgf.base import ESGFRequest
 from climate_ref_core.paths import safe_path
-from climate_ref_core.regression.manifest import Manifest
+from climate_ref_core.regression.manifest import COMMITTED_DIRNAME, Manifest
 
 if TYPE_CHECKING:
     from _pytest.mark.structures import ParameterSet
@@ -231,7 +231,7 @@ class TestCasePaths:
     @property
     def regression(self) -> Path:
         """Path to regression/ directory."""
-        return self.root / "regression"
+        return self.root / COMMITTED_DIRNAME
 
     @property
     def manifest(self) -> Path:

--- a/packages/climate-ref/src/climate_ref/baseline_report/__init__.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/__init__.py
@@ -8,8 +8,9 @@ remain fetchable by digest, so the change can be reviewed without checking anyth
 
 The pipeline runs in three stages:
 
-- :mod:`~climate_ref.baseline_report.collect` reads the manifests either side of the base ref.
-- :mod:`~climate_ref.baseline_report.analyse` fetches text blobs and builds the diffs.
+- :mod:`~climate_ref.baseline_report.collect` reads the repository either side of the base ref,
+  both the manifests and the committed bundle they track.
+- :mod:`~climate_ref.baseline_report.analyse` fetches native blobs and builds the diffs.
 - :mod:`~climate_ref.baseline_report.render` writes the static site.
 
 Python decides and templates place, so no module here builds HTML.

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import difflib
 import io
 import json
-import os.path
 from collections import Counter
 from contextlib import ExitStack
 from itertools import islice
@@ -1098,7 +1097,9 @@ def baseline_tree(case: CaseChange) -> tuple[TreeNode, ...]:
     previous: tuple[str, ...] = ()
     for path in sorted(entries):
         *directories, filename = PurePosixPath(path).parts
-        shared = len(os.path.commonprefix([previous, tuple(directories)]))
+        shared = 0
+        while shared < min(len(previous), len(directories)) and previous[shared] == directories[shared]:
+            shared += 1
         for depth in range(shared, len(directories)):
             rows.append(TreeNode(name=directories[depth], depth=depth, is_dir=True, size=None, status=None))
         previous = tuple(directories)

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -25,6 +25,7 @@ from climate_ref.baseline_report.collect import (
     FileChange,
     FileKind,
     Report,
+    change_status,
 )
 
 if TYPE_CHECKING:
@@ -247,7 +248,10 @@ class TreeNode:
     """Whether the row is a directory rather than a file."""
 
     size: int | None
-    """The file's size on HEAD, or on the base ref when it was removed."""
+    """The file's size on HEAD, or on the base ref when it was removed.
+
+    ``None`` for a directory and for a committed artefact, whose manifest entry has no size.
+    """
 
     status: str | None
     """``added``, ``changed`` or ``removed``, or ``None`` when the file did not move."""
@@ -1057,20 +1061,52 @@ def _file_status(old: NativeEntry | None, new: NativeEntry | None) -> str | None
     :
         ``added``, ``removed``, ``changed``, or ``None`` when the digest is the same.
     """
-    if old is None:
-        return "added"
-    if new is None:
-        return "removed"
-    return "changed" if old.sha256 != new.sha256 else None
+    if old is not None and new is not None and old.sha256 == new.sha256:
+        return None
+    return change_status(old, new)
+
+
+def _baseline_entries(case: CaseChange) -> dict[str, tuple[int | None, str | None]]:
+    """
+    Gather every file the baseline captures, keyed by its path within the test case.
+
+    The committed bundle sits under ``regression/``, which is where a run writes it, so the
+    listing matches the layout on disk rather than splitting the capture by where it is stored.
+
+    Parameters
+    ----------
+    case
+        The collected case.
+
+    Returns
+    -------
+    :
+        ``{path: (size, status)}``. The size is ``None`` for a committed artefact, whose
+        manifest entry carries only a digest.
+    """
+    old_native = case.base.native if case.base else {}
+    new_native = case.head.native if case.head else {}
+    entries: dict[str, tuple[int | None, str | None]] = {}
+    for name in set(old_native) | set(new_native):
+        old, new = old_native.get(name), new_native.get(name)
+        entry = new or old
+        entries[name] = (entry.size if entry else None, _file_status(old, new))
+
+    old_committed = case.base.committed if case.base else {}
+    new_committed = case.head.committed if case.head else {}
+    for name in set(old_committed) | set(new_committed):
+        old_digest, new_digest = old_committed.get(name), new_committed.get(name)
+        status = None if old_digest == new_digest else change_status(old_digest, new_digest)
+        entries[f"regression/{name}"] = (None, status)
+    return entries
 
 
 def baseline_tree(case: CaseChange) -> tuple[TreeNode, ...]:
     """
-    Flatten the captured baseline's native files into an indented folder listing.
+    Flatten the captured baseline's files into an indented folder listing.
 
-    Every curated file is listed, not only the ones that moved, because the listing is what
-    tells a reviewer what the baseline actually holds. A file dropped by the mint is kept in
-    the listing so its absence is visible rather than silent.
+    Every captured file is listed, not only the ones that moved, because the listing is what
+    tells a reviewer what the baseline actually holds.
 
     Parameters
     ----------
@@ -1082,28 +1118,26 @@ def baseline_tree(case: CaseChange) -> tuple[TreeNode, ...]:
     :
         One row per directory and file, in path order.
     """
-    old_native = case.base.native if case.base else {}
-    new_native = case.head.native if case.head else {}
+    entries = _baseline_entries(case)
     rows: list[TreeNode] = []
-    seen: list[str] = []
-    for name in sorted(set(old_native) | set(new_native)):
-        parts = PurePosixPath(name).parts
+    open_dirs: list[str] = []
+    for path in sorted(entries):
+        parts = PurePosixPath(path).parts
         for depth, part in enumerate(parts[:-1]):
-            if depth < len(seen) and seen[depth] == part:
+            if depth < len(open_dirs) and open_dirs[depth] == part:
                 continue
-            del seen[depth:]
-            seen.append(part)
+            del open_dirs[depth:]
+            open_dirs.append(part)
             rows.append(TreeNode(name=part, depth=depth, is_dir=True, size=None, status=None))
-        del seen[len(parts) - 1 :]
-        old, new = old_native.get(name), new_native.get(name)
-        entry = new or old
+        del open_dirs[len(parts) - 1 :]
+        size, status = entries[path]
         rows.append(
             TreeNode(
                 name=parts[-1],
                 depth=len(parts) - 1,
                 is_dir=False,
-                size=entry.size if entry else None,
-                status=_file_status(old, new),
+                size=size,
+                status=status,
             )
         )
     return tuple(rows)

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import difflib
 import io
 import json
+import os.path
 from collections import Counter
 from contextlib import ExitStack
 from itertools import islice
@@ -25,8 +26,8 @@ from climate_ref.baseline_report.collect import (
     FileChange,
     FileKind,
     Report,
-    change_status,
 )
+from climate_ref_core.regression.manifest import COMMITTED_DIRNAME
 
 if TYPE_CHECKING:
     from climate_ref_core.regression.manifest import NativeEntry
@@ -333,6 +334,25 @@ def blob_url(store: NativeStore, digest: str) -> str:
     return f"{store.url.rstrip('/')}/{digest}"
 
 
+def _decode(path: Path | None) -> str | None:
+    """
+    Decode a fetched blob, replacing any byte that is not valid UTF-8.
+
+    Parameters
+    ----------
+    path
+        The blob, or ``None`` when the file is absent on that side.
+
+    Returns
+    -------
+    :
+        The blob's text, or ``None`` when there is no blob.
+    """
+    if path is None:
+        return None
+    return path.read_bytes().decode("utf-8", errors="replace")
+
+
 def _text_lines(text: str | None, name: str) -> list[str]:
     """
     Split text into diffable lines.
@@ -360,27 +380,6 @@ def _text_lines(text: str | None, name: str) -> list[str]:
         except json.JSONDecodeError:
             pass
     return text.splitlines()
-
-
-def _as_lines(path: Path | None, name: str) -> list[str]:
-    """
-    Decode a blob into diffable lines.
-
-    Parameters
-    ----------
-    path
-        The fetched blob, or ``None`` when the file is absent on that side.
-    name
-        The file's name, used to decide whether it is JSON.
-
-    Returns
-    -------
-    :
-        The lines to diff.
-    """
-    if path is None:
-        return []
-    return _text_lines(path.read_bytes().decode("utf-8", errors="replace"), name)
 
 
 def _classify_line(line: str) -> str:
@@ -515,8 +514,8 @@ def text_diff(old: Path | None, new: Path | None, name: str) -> TextDiff:
         The diff, or a note explaining why there is not one.
     """
     return _build_text_diff(
-        _as_lines(old, name),
-        _as_lines(new, name),
+        _text_lines(_decode(old), name),
+        _text_lines(_decode(new), name),
         has_old=old is not None,
         has_new=new is not None,
     )
@@ -1045,33 +1044,13 @@ def _counts(files: tuple[AnalysedFile, ...]) -> tuple[KindCounts, ...]:
     )
 
 
-def _file_status(old: NativeEntry | None, new: NativeEntry | None) -> str | None:
-    """
-    Describe how one native file moved between the two manifests.
-
-    Parameters
-    ----------
-    old
-        The entry on the base ref, or ``None``.
-    new
-        The entry on HEAD, or ``None``.
-
-    Returns
-    -------
-    :
-        ``added``, ``removed``, ``changed``, or ``None`` when the digest is the same.
-    """
-    if old is not None and new is not None and old.sha256 == new.sha256:
-        return None
-    return change_status(old, new)
-
-
 def _baseline_entries(case: CaseChange) -> dict[str, tuple[int | None, str | None]]:
     """
     Gather every file the baseline captures, keyed by its path within the test case.
 
-    The committed bundle sits under ``regression/``, which is where a run writes it, so the
+    The committed bundle sits under its own directory, which is where a run writes it, so the
     listing matches the layout on disk rather than splitting the capture by where it is stored.
+    Statuses come from the collected case, which is what decided that a file moved at all.
 
     Parameters
     ----------
@@ -1081,23 +1060,19 @@ def _baseline_entries(case: CaseChange) -> dict[str, tuple[int | None, str | Non
     Returns
     -------
     :
-        ``{path: (size, status)}``. The size is ``None`` for a committed artefact, whose
-        manifest entry carries only a digest.
+        ``{path: (size, status)}``, where the status is ``None`` for a file that did not move.
+        The size is ``None`` for a committed artefact, whose manifest entry carries only a digest.
     """
-    old_native = case.base.native if case.base else {}
-    new_native = case.head.native if case.head else {}
-    entries: dict[str, tuple[int | None, str | None]] = {}
-    for name in set(old_native) | set(new_native):
-        old, new = old_native.get(name), new_native.get(name)
-        entry = new or old
-        entries[name] = (entry.size if entry else None, _file_status(old, new))
+    moved = {file.name: file.status for file in case.files}
+    native = {**(case.base.native if case.base else {}), **(case.head.native if case.head else {})}
+    entries: dict[str, tuple[int | None, str | None]] = {
+        name: (entry.size, moved.get(name)) for name, entry in native.items()
+    }
 
-    old_committed = case.base.committed if case.base else {}
-    new_committed = case.head.committed if case.head else {}
-    for name in set(old_committed) | set(new_committed):
-        old_digest, new_digest = old_committed.get(name), new_committed.get(name)
-        status = None if old_digest == new_digest else change_status(old_digest, new_digest)
-        entries[f"regression/{name}"] = (None, status)
+    moved_committed = {artefact.name: artefact.status for artefact in case.committed}
+    committed = {**(case.base.committed if case.base else {}), **(case.head.committed if case.head else {})}
+    for name in committed:
+        entries[f"{COMMITTED_DIRNAME}/{name}"] = (None, moved_committed.get(name))
     return entries
 
 
@@ -1120,21 +1095,18 @@ def baseline_tree(case: CaseChange) -> tuple[TreeNode, ...]:
     """
     entries = _baseline_entries(case)
     rows: list[TreeNode] = []
-    open_dirs: list[str] = []
+    previous: tuple[str, ...] = ()
     for path in sorted(entries):
-        parts = PurePosixPath(path).parts
-        for depth, part in enumerate(parts[:-1]):
-            if depth < len(open_dirs) and open_dirs[depth] == part:
-                continue
-            del open_dirs[depth:]
-            open_dirs.append(part)
-            rows.append(TreeNode(name=part, depth=depth, is_dir=True, size=None, status=None))
-        del open_dirs[len(parts) - 1 :]
+        *directories, filename = PurePosixPath(path).parts
+        shared = len(os.path.commonprefix([previous, tuple(directories)]))
+        for depth in range(shared, len(directories)):
+            rows.append(TreeNode(name=directories[depth], depth=depth, is_dir=True, size=None, status=None))
+        previous = tuple(directories)
         size, status = entries[path]
         rows.append(
             TreeNode(
-                name=parts[-1],
-                depth=len(parts) - 1,
+                name=filename,
+                depth=len(directories),
                 is_dir=False,
                 size=size,
                 status=status,

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -19,7 +19,13 @@ import numpy as np
 import xarray as xr
 from attrs import frozen
 
-from climate_ref.baseline_report.collect import CaseChange, FileChange, FileKind, Report
+from climate_ref.baseline_report.collect import (
+    CaseChange,
+    CommittedChange,
+    FileChange,
+    FileKind,
+    Report,
+)
 
 if TYPE_CHECKING:
     from climate_ref_core.regression.manifest import NativeEntry
@@ -217,6 +223,37 @@ class KindCounts:
 
 
 @frozen
+class AnalysedCommitted:
+    """One committed regression artefact, with its diff."""
+
+    change: CommittedChange
+    """The underlying change."""
+
+    text: TextDiff
+    """The diff between the two committed versions."""
+
+
+@frozen
+class TreeNode:
+    """One row of the captured baseline's folder listing."""
+
+    name: str
+    """The directory or file name at this level."""
+
+    depth: int
+    """How deep the entry sits, so a template can indent it."""
+
+    is_dir: bool
+    """Whether the row is a directory rather than a file."""
+
+    size: int | None
+    """The file's size on HEAD, or on the base ref when it was removed."""
+
+    status: str | None
+    """``added``, ``changed`` or ``removed``, or ``None`` when the file did not move."""
+
+
+@frozen
 class AnalysedCase:
     """One test case, with its files analysed and tallied."""
 
@@ -240,6 +277,12 @@ class AnalysedCase:
 
     others: tuple[AnalysedFile, ...]
     """Every remaining file, which renders as a table row."""
+
+    committed: tuple[AnalysedCommitted, ...]
+    """The committed artefacts that moved, in name order."""
+
+    tree: tuple[TreeNode, ...]
+    """The captured baseline's native files, as a flattened folder listing."""
 
     back_link: str
     """Relative link from this case's page back to the index, one ``..`` per label segment."""
@@ -286,12 +329,38 @@ def blob_url(store: NativeStore, digest: str) -> str:
     return f"{store.url.rstrip('/')}/{digest}"
 
 
-def _as_lines(path: Path | None, name: str) -> list[str]:
+def _text_lines(text: str | None, name: str) -> list[str]:
     """
-    Decode a blob into diffable lines.
+    Split text into diffable lines.
 
     JSON is re-serialised with indentation first, because a minified bundle would otherwise
     diff as a single unreadable line.
+
+    Parameters
+    ----------
+    text
+        The content, or ``None`` when the file is absent on that side.
+    name
+        The file's name, used to decide whether it is JSON.
+
+    Returns
+    -------
+    :
+        The lines to diff.
+    """
+    if text is None:
+        return []
+    if Path(name).suffix.lower() == ".json":
+        try:
+            text = json.dumps(json.loads(text), indent=2, sort_keys=True)
+        except json.JSONDecodeError:
+            pass
+    return text.splitlines()
+
+
+def _as_lines(path: Path | None, name: str) -> list[str]:
+    """
+    Decode a blob into diffable lines.
 
     Parameters
     ----------
@@ -307,13 +376,7 @@ def _as_lines(path: Path | None, name: str) -> list[str]:
     """
     if path is None:
         return []
-    text = path.read_bytes().decode("utf-8", errors="replace")
-    if Path(name).suffix.lower() == ".json":
-        try:
-            text = json.dumps(json.loads(text), indent=2, sort_keys=True)
-        except json.JSONDecodeError:
-            pass
-    return text.splitlines()
+    return _text_lines(path.read_bytes().decode("utf-8", errors="replace"), name)
 
 
 def _classify_line(line: str) -> str:
@@ -372,6 +435,63 @@ def _diff_lines(
     return tuple(DiffLine(kind=_classify_line(line), text=line) for line in kept), sum(1 for _ in raw)
 
 
+def _build_text_diff(old_lines: list[str], new_lines: list[str], *, has_old: bool, has_new: bool) -> TextDiff:
+    """
+    Build a :class:`TextDiff` from two already decoded sides.
+
+    Parameters
+    ----------
+    old_lines
+        The base side's lines, empty when it is absent.
+    new_lines
+        The head side's lines, empty when it is absent.
+    has_old
+        Whether the file exists on the base ref, which labels the diff header.
+    has_new
+        Whether the file exists on HEAD, which labels the diff header.
+
+    Returns
+    -------
+    :
+        The diff, or a note when the two sides decode identically.
+    """
+    lines, elided = _diff_lines(
+        old_lines,
+        new_lines,
+        fromfile="old" if has_old else "(absent)",
+        tofile="new" if has_new else "(absent)",
+    )
+    if not lines:
+        return TextDiff(lines=(), note="identical after decoding", elided=0)
+    return TextDiff(lines=lines, note=None, elided=elided)
+
+
+def committed_diff(change: CommittedChange) -> TextDiff:
+    """
+    Build the unified diff of one committed regression artefact.
+
+    Parameters
+    ----------
+    change
+        The artefact that moved, carrying both sides' content.
+
+    Returns
+    -------
+    :
+        The diff, or a note explaining why there is not one.
+    """
+    if change.old is not None and change.old_text is None:
+        return TextDiff(lines=(), note="could not read the base version from git", elided=0)
+    if change.new is not None and change.new_text is None:
+        return TextDiff(lines=(), note="could not read the working tree version", elided=0)
+    return _build_text_diff(
+        _text_lines(change.old_text, change.name),
+        _text_lines(change.new_text, change.name),
+        has_old=change.old is not None,
+        has_new=change.new is not None,
+    )
+
+
 def text_diff(old: Path | None, new: Path | None, name: str) -> TextDiff:
     """
     Build the unified diff between two fetched blobs.
@@ -390,15 +510,12 @@ def text_diff(old: Path | None, new: Path | None, name: str) -> TextDiff:
     :
         The diff, or a note explaining why there is not one.
     """
-    lines, elided = _diff_lines(
+    return _build_text_diff(
         _as_lines(old, name),
         _as_lines(new, name),
-        fromfile="old" if old is not None else "(absent)",
-        tofile="new" if new is not None else "(absent)",
+        has_old=old is not None,
+        has_new=new is not None,
     )
-    if not lines:
-        return TextDiff(lines=(), note="identical after decoding", elided=0)
-    return TextDiff(lines=lines, note=None, elided=elided)
 
 
 def _header(dataset: xr.Dataset | None) -> list[str]:
@@ -924,6 +1041,74 @@ def _counts(files: tuple[AnalysedFile, ...]) -> tuple[KindCounts, ...]:
     )
 
 
+def _file_status(old: NativeEntry | None, new: NativeEntry | None) -> str | None:
+    """
+    Describe how one native file moved between the two manifests.
+
+    Parameters
+    ----------
+    old
+        The entry on the base ref, or ``None``.
+    new
+        The entry on HEAD, or ``None``.
+
+    Returns
+    -------
+    :
+        ``added``, ``removed``, ``changed``, or ``None`` when the digest is the same.
+    """
+    if old is None:
+        return "added"
+    if new is None:
+        return "removed"
+    return "changed" if old.sha256 != new.sha256 else None
+
+
+def baseline_tree(case: CaseChange) -> tuple[TreeNode, ...]:
+    """
+    Flatten the captured baseline's native files into an indented folder listing.
+
+    Every curated file is listed, not only the ones that moved, because the listing is what
+    tells a reviewer what the baseline actually holds. A file dropped by the mint is kept in
+    the listing so its absence is visible rather than silent.
+
+    Parameters
+    ----------
+    case
+        The collected case.
+
+    Returns
+    -------
+    :
+        One row per directory and file, in path order.
+    """
+    old_native = case.base.native if case.base else {}
+    new_native = case.head.native if case.head else {}
+    rows: list[TreeNode] = []
+    seen: list[str] = []
+    for name in sorted(set(old_native) | set(new_native)):
+        parts = PurePosixPath(name).parts
+        for depth, part in enumerate(parts[:-1]):
+            if depth < len(seen) and seen[depth] == part:
+                continue
+            del seen[depth:]
+            seen.append(part)
+            rows.append(TreeNode(name=part, depth=depth, is_dir=True, size=None, status=None))
+        del seen[len(parts) - 1 :]
+        old, new = old_native.get(name), new_native.get(name)
+        entry = new or old
+        rows.append(
+            TreeNode(
+                name=parts[-1],
+                depth=len(parts) - 1,
+                is_dir=False,
+                size=entry.size if entry else None,
+                status=_file_status(old, new),
+            )
+        )
+    return tuple(rows)
+
+
 def analyse(report: Report, store: NativeStore, *, fetch: bool, workdir: Path) -> AnalysedReport:
     """
     Build everything the templates need from a collected report.
@@ -962,6 +1147,10 @@ def analyse(report: Report, store: NativeStore, *, fetch: bool, workdir: Path) -
                 texts=_of_kind(files, FileKind.TEXT),
                 netcdfs=_of_kind(files, FileKind.NETCDF),
                 others=_of_kind(files, FileKind.OTHER),
+                committed=tuple(
+                    AnalysedCommitted(change=change, text=committed_diff(change)) for change in case.committed
+                ),
+                tree=baseline_tree(case),
                 back_link="/".join([*[".."] * depth, "index.html"]),
             )
         )

--- a/packages/climate-ref/src/climate_ref/baseline_report/collect.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/collect.py
@@ -66,7 +66,7 @@ def classify(name: str) -> FileKind:
     return FileKind.OTHER
 
 
-def change_status(old: object | None, new: object | None) -> str:
+def change_status(old: str | NativeEntry | None, new: str | NativeEntry | None) -> str:
     """
     Describe which sides of the change an entry is present on.
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/collect.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/collect.py
@@ -65,6 +65,29 @@ def classify(name: str) -> FileKind:
     return FileKind.OTHER
 
 
+def change_status(old: object | None, new: object | None) -> str:
+    """
+    Describe which sides of the change an entry is present on.
+
+    Parameters
+    ----------
+    old
+        The entry on the base ref, or ``None`` when it is absent there.
+    new
+        The entry on HEAD, or ``None`` when it is absent there.
+
+    Returns
+    -------
+    :
+        ``added``, ``removed`` or ``changed``.
+    """
+    if old is None:
+        return "added"
+    if new is None:
+        return "removed"
+    return "changed"
+
+
 @frozen
 class FileChange:
     """One native output file that was added, removed, or changed by the mint."""
@@ -84,11 +107,7 @@ class FileChange:
     @property
     def status(self) -> str:
         """``added``, ``removed`` or ``changed``."""
-        if self.old is None:
-            return "added"
-        if self.new is None:
-            return "removed"
-        return "changed"
+        return change_status(self.old, self.new)
 
 
 @frozen
@@ -120,11 +139,7 @@ class CommittedChange:
     @property
     def status(self) -> str:
         """``added``, ``removed`` or ``changed``."""
-        if self.old is None:
-            return "added"
-        if self.new is None:
-            return "removed"
-        return "changed"
+        return change_status(self.old, self.new)
 
 
 @frozen
@@ -208,9 +223,30 @@ def changed_manifests(repo: Repo, base: str) -> list[str]:
     return sorted(line for line in out.splitlines() if line.strip())
 
 
+def _read_text(path: Path) -> str | None:
+    """
+    Read a file from the working tree, or ``None`` when it cannot be read.
+
+    Parameters
+    ----------
+    path
+        The file to read.
+
+    Returns
+    -------
+    :
+        The file's text, decoded with replacement so odd bytes cost a character rather
+        than the report, or ``None`` when the file is missing or unreadable.
+    """
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
 def show_at_ref(repo: Repo, ref: str, rel_path: str) -> str | None:
     """
-    Read a file's content as it exists at ``ref``, or ``None`` when absent there.
+    Read a file's content as it exists at ``ref``, or ``None`` when it cannot be read there.
 
     Parameters
     ----------
@@ -224,13 +260,14 @@ def show_at_ref(repo: Repo, ref: str, rel_path: str) -> str | None:
     Returns
     -------
     :
-        The file's text, or ``None`` when the path does not exist at ``ref``.
+        The file's text, or ``None`` when the path does not exist at ``ref`` or does not
+        decode as UTF-8.
     """
     from git import GitCommandError  # noqa: PLC0415
 
     try:
         return str(repo.git.show(f"{ref}:{rel_path}"))
-    except GitCommandError:
+    except (GitCommandError, UnicodeDecodeError):
         return None
 
 
@@ -333,7 +370,7 @@ def _committed_changes(
     base: str,
     rel_path: str,
     base_manifest: Manifest | None,
-    head: Manifest | None,
+    head_manifest: Manifest | None,
 ) -> tuple[CommittedChange, ...]:
     """
     Pair up the committed regression artefacts whose digest moved.
@@ -351,7 +388,7 @@ def _committed_changes(
         Repo-relative path of the case's ``manifest.json``.
     base_manifest
         The manifest on the base ref, or ``None``.
-    head
+    head_manifest
         The manifest on HEAD, or ``None``.
 
     Returns
@@ -360,14 +397,13 @@ def _committed_changes(
         One entry per changed artefact, in name order.
     """
     old = base_manifest.committed if base_manifest else {}
-    new = head.committed if head else {}
+    new = head_manifest.committed if head_manifest else {}
     root = Path(repo.working_tree_dir or ".")
     out = []
     for name in sorted(set(old) | set(new)):
         if old.get(name) == new.get(name):
             continue
         artefact_path = _committed_path(rel_path, name)
-        head_path = root / artefact_path
         out.append(
             CommittedChange(
                 name=name,
@@ -375,9 +411,7 @@ def _committed_changes(
                 old=old.get(name),
                 new=new.get(name),
                 old_text=show_at_ref(repo, base, artefact_path) if name in old else None,
-                new_text=head_path.read_text(encoding="utf-8", errors="replace")
-                if name in new and head_path.exists()
-                else None,
+                new_text=_read_text(root / artefact_path) if name in new else None,
             )
         )
     return tuple(out)

--- a/packages/climate-ref/src/climate_ref/baseline_report/collect.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/collect.py
@@ -1,7 +1,8 @@
 """
-Read the manifests either side of a base ref and pair up every native file that moved.
+Read the baselines either side of a base ref and pair up everything that moved.
 
-Collection performs no network access. Fetching blobs and building diffs is
+Collection reads only the repository, both the manifests and the committed bundle they track.
+Fetching native blobs from the store and building diffs is
 :mod:`~climate_ref.baseline_report.analyse`'s job.
 """
 
@@ -14,7 +15,7 @@ from typing import TYPE_CHECKING
 from attrs import frozen
 from loguru import logger
 
-from climate_ref_core.regression.manifest import Manifest, NativeEntry
+from climate_ref_core.regression.manifest import COMMITTED_DIRNAME, Manifest, NativeEntry
 
 if TYPE_CHECKING:
     from git import Repo
@@ -362,7 +363,7 @@ def _committed_path(manifest_rel_path: str, name: str) -> str:
     :
         The path as it appears in the pull request's file list.
     """
-    return (PurePosixPath(manifest_rel_path).parent / "regression" / name).as_posix()
+    return (PurePosixPath(manifest_rel_path).parent / COMMITTED_DIRNAME / name).as_posix()
 
 
 def _committed_changes(

--- a/packages/climate-ref/src/climate_ref/baseline_report/collect.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/collect.py
@@ -8,7 +8,7 @@ Collection performs no network access. Fetching blobs and building diffs is
 from __future__ import annotations
 
 import enum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from attrs import frozen
@@ -92,6 +92,42 @@ class FileChange:
 
 
 @frozen
+class CommittedChange:
+    """One committed regression artefact whose digest moved.
+
+    Unlike a native output these bytes are tracked in git, so both sides are read from the
+    repository rather than fetched from the store.
+    """
+
+    name: str
+    """Path of the artefact relative to the test case's ``regression/`` directory."""
+
+    rel_path: str
+    """Repo-relative path of the artefact, which is where it appears in the pull request."""
+
+    old: str | None
+    """The digest on the base ref, or ``None`` when the artefact is new."""
+
+    new: str | None
+    """The digest on HEAD, or ``None`` when the artefact was removed."""
+
+    old_text: str | None
+    """The artefact's content on the base ref, or ``None`` when it could not be read."""
+
+    new_text: str | None
+    """The artefact's content on HEAD, or ``None`` when it could not be read."""
+
+    @property
+    def status(self) -> str:
+        """``added``, ``removed`` or ``changed``."""
+        if self.old is None:
+            return "added"
+        if self.new is None:
+            return "removed"
+        return "changed"
+
+
+@frozen
 class CaseChange:
     """Everything that changed for a single test case."""
 
@@ -110,8 +146,8 @@ class CaseChange:
     files: tuple[FileChange, ...]
     """Every native file that moved, in name order."""
 
-    committed: tuple[str, ...]
-    """Committed artefacts whose digest moved, described one per entry."""
+    committed: tuple[CommittedChange, ...]
+    """Committed artefacts whose digest moved, in name order."""
 
     metadata: tuple[str, ...]
     """Scalar manifest fields that moved, described one per entry."""
@@ -172,6 +208,32 @@ def changed_manifests(repo: Repo, base: str) -> list[str]:
     return sorted(line for line in out.splitlines() if line.strip())
 
 
+def show_at_ref(repo: Repo, ref: str, rel_path: str) -> str | None:
+    """
+    Read a file's content as it exists at ``ref``, or ``None`` when absent there.
+
+    Parameters
+    ----------
+    repo
+        The repository to read from.
+    ref
+        The git ref to read the file at.
+    rel_path
+        Repo-relative path of the file.
+
+    Returns
+    -------
+    :
+        The file's text, or ``None`` when the path does not exist at ``ref``.
+    """
+    from git import GitCommandError  # noqa: PLC0415
+
+    try:
+        return str(repo.git.show(f"{ref}:{rel_path}"))
+    except GitCommandError:
+        return None
+
+
 def load_at_ref(repo: Repo, ref: str, rel_path: str) -> Manifest | None:
     """
     Load a manifest as it exists at ``ref``, or ``None`` when absent there.
@@ -190,11 +252,8 @@ def load_at_ref(repo: Repo, ref: str, rel_path: str) -> Manifest | None:
     :
         The parsed manifest, or ``None`` when the path does not exist at ``ref``.
     """
-    from git import GitCommandError  # noqa: PLC0415
-
-    try:
-        text = repo.git.show(f"{ref}:{rel_path}")
-    except GitCommandError:
+    text = show_at_ref(repo, ref, rel_path)
+    if text is None:
         return None
     return Manifest.loads(text, source=f"{ref}:{rel_path}")
 
@@ -250,13 +309,47 @@ def _metadata_changes(base: Manifest | None, head: Manifest | None) -> tuple[str
     return tuple(changes)
 
 
-def _committed_changes(base: Manifest | None, head: Manifest | None) -> tuple[str, ...]:
+def _committed_path(manifest_rel_path: str, name: str) -> str:
     """
-    Name the committed regression artefacts whose digest moved.
+    Build the repo-relative path of a committed artefact.
 
     Parameters
     ----------
+    manifest_rel_path
+        Repo-relative path of the case's ``manifest.json``.
+    name
+        The artefact's path relative to the case's ``regression/`` directory.
+
+    Returns
+    -------
+    :
+        The path as it appears in the pull request's file list.
+    """
+    return (PurePosixPath(manifest_rel_path).parent / "regression" / name).as_posix()
+
+
+def _committed_changes(
+    repo: Repo,
+    base: str,
+    rel_path: str,
+    base_manifest: Manifest | None,
+    head: Manifest | None,
+) -> tuple[CommittedChange, ...]:
+    """
+    Pair up the committed regression artefacts whose digest moved.
+
+    Both sides are read out of the repository, the base one at ``base`` and the head one from
+    the working tree, so a committed artefact needs no store access to diff.
+
+    Parameters
+    ----------
+    repo
+        The repository to read from.
     base
+        The git ref to compare against.
+    rel_path
+        Repo-relative path of the case's ``manifest.json``.
+    base_manifest
         The manifest on the base ref, or ``None``.
     head
         The manifest on HEAD, or ``None``.
@@ -264,20 +357,29 @@ def _committed_changes(base: Manifest | None, head: Manifest | None) -> tuple[st
     Returns
     -------
     :
-        One description per changed artefact, in name order.
+        One entry per changed artefact, in name order.
     """
-    old = base.committed if base else {}
+    old = base_manifest.committed if base_manifest else {}
     new = head.committed if head else {}
+    root = Path(repo.working_tree_dir or ".")
     out = []
     for name in sorted(set(old) | set(new)):
         if old.get(name) == new.get(name):
             continue
-        if name not in old:
-            out.append(f"{name} (added)")
-        elif name not in new:
-            out.append(f"{name} (removed)")
-        else:
-            out.append(name)
+        artefact_path = _committed_path(rel_path, name)
+        head_path = root / artefact_path
+        out.append(
+            CommittedChange(
+                name=name,
+                rel_path=artefact_path,
+                old=old.get(name),
+                new=new.get(name),
+                old_text=show_at_ref(repo, base, artefact_path) if name in old else None,
+                new_text=head_path.read_text(encoding="utf-8", errors="replace")
+                if name in new and head_path.exists()
+                else None,
+            )
+        )
     return tuple(out)
 
 
@@ -328,7 +430,7 @@ def build_case_change(repo: Repo, base: str, rel_path: str) -> CaseChange | None
         base=base_manifest,
         head=head,
         files=tuple(files),
-        committed=_committed_changes(base_manifest, head),
+        committed=_committed_changes(repo, base, rel_path, base_manifest, head),
         metadata=_metadata_changes(base_manifest, head),
     )
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/case.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/case.html.j2
@@ -11,13 +11,20 @@
 {% endfor %}
 </ul>
 {% endif %}
-{% if case.change.committed %}
-<h3>Committed artefacts changed</h3>
-<ul class="committed">
-{% for name in case.change.committed %}
-<li><code>{{ name }}</code></li>
+{% if case.committed %}
+<details open>
+<summary>Committed artefacts</summary>
+{% for item in case.committed %}
+{{ m.committed_block(item) }}
 {% endfor %}
-</ul>
+</details>
+{% endif %}
+
+{% if case.tree %}
+<details>
+<summary>Captured baseline</summary>
+{{ m.tree_rows(case.tree) }}
+</details>
 {% endif %}
 
 {% if case.images %}

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -196,7 +196,7 @@ was {{ file.change.old.size | bytes -}}
 <code class="dir">{{ node.name }}/</code>
 {% else %}
 <code>{{ node.name }}</code>
-<span class="size">{{ node.size | bytes }}</span>
+{% if node.size is not none %}<span class="size">{{ node.size | bytes }}</span>{% endif %}
 {% if node.status %}<span class="status {{ node.status }}">{{ node.status }}</span>{% endif %}
 {% endif %}
 </li>

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -50,6 +50,17 @@ was {{ file.change.old.size | bytes -}}
 </pre>
 {%- endmacro %}
 
+{% macro diff_body(text) %}
+{% if text.note %}
+<p class="note">{{ text.note }}</p>
+{% else %}
+{{ diff_lines(text.lines) }}
+{% if text.elided %}
+<p class="note">{{ text.elided }} further diff line(s) elided.</p>
+{% endif %}
+{% endif %}
+{% endmacro %}
+
 {% macro text_block(file) %}
 <section class="file">
 <h3>
@@ -62,14 +73,7 @@ was {{ file.change.old.size | bytes -}}
 </span>
 {{ blob_links(file) }}
 </h3>
-{% if file.text.note %}
-<p class="note">{{ file.text.note }}</p>
-{% else %}
-{{ diff_lines(file.text.lines) }}
-{% if file.text.elided %}
-<p class="note">{{ file.text.elided }} further diff line(s) elided.</p>
-{% endif %}
-{% endif %}
+{{ diff_body(file.text) }}
 </section>
 {% endmacro %}
 
@@ -177,14 +181,7 @@ was {{ file.change.old.size | bytes -}}
 </span>
 </h3>
 <p class="path"><code>{{ item.change.rel_path }}</code></p>
-{% if item.text.note %}
-<p class="note">{{ item.text.note }}</p>
-{% else %}
-{{ diff_lines(item.text.lines) }}
-{% if item.text.elided %}
-<p class="note">{{ item.text.elided }} further diff line(s) elided.</p>
-{% endif %}
-{% endif %}
+{{ diff_body(item.text) }}
 </section>
 {% endmacro %}
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -164,3 +164,42 @@ was {{ file.change.old.size | bytes -}}
 {% endif %}
 </section>
 {% endmacro %}
+
+{% macro committed_block(item) %}
+<section class="file">
+<h3>
+<code>{{ item.change.name }}</code>
+<span class="pill" title="Tracked in git, so this file is part of the pull request">in PR</span>
+<span class="status {{ item.change.status }}">{{ item.change.status }}</span>
+<span class="digests">
+{% if item.change.old %}{{ item.change.old | short }}{% endif %}
+{%- if item.change.new %} -> {{ item.change.new | short }}{% endif %}
+</span>
+</h3>
+<p class="path"><code>{{ item.change.rel_path }}</code></p>
+{% if item.text.note %}
+<p class="note">{{ item.text.note }}</p>
+{% else %}
+{{ diff_lines(item.text.lines) }}
+{% if item.text.elided %}
+<p class="note">{{ item.text.elided }} further diff line(s) elided.</p>
+{% endif %}
+{% endif %}
+</section>
+{% endmacro %}
+
+{% macro tree_rows(nodes) %}
+<ul class="tree">
+{% for node in nodes %}
+<li style="--depth: {{ node.depth }}">
+{% if node.is_dir %}
+<code class="dir">{{ node.name }}/</code>
+{% else %}
+<code>{{ node.name }}</code>
+<span class="size">{{ node.size | bytes }}</span>
+{% if node.status %}<span class="status {{ node.status }}">{{ node.status }}</span>{% endif %}
+{% endif %}
+</li>
+{% endfor %}
+</ul>
+{% endmacro %}

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/report.css
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/report.css
@@ -234,3 +234,36 @@ tr.moved {
 .stats strong {
   font-weight: 600;
 }
+
+/* Marks a file that lives in git, so a reviewer can find it in the pull request's own diff. */
+.pill {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.75em;
+  letter-spacing: 0.04em;
+  padding: 0.05rem 0.5rem;
+  text-transform: uppercase;
+  vertical-align: 0.1em;
+}
+
+.path {
+  color: var(--muted);
+  font-size: 0.85em;
+  margin: 0 0 0.5rem;
+}
+
+.tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tree li {
+  padding-left: calc(var(--depth) * 1.25rem);
+}
+
+.tree .dir {
+  font-weight: 600;
+}

--- a/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
+++ b/packages/climate-ref/src/climate_ref/cli/test_cases/_stages.py
@@ -30,6 +30,7 @@ from climate_ref_core.diagnostics import ExecutionDefinition
 from climate_ref_core.output_files import PlaceholderMap, copy_execution_outputs
 from climate_ref_core.regression import (
     COMMITTED_BUNDLE_FILES,
+    COMMITTED_DIRNAME,
     Tolerance,
     assert_bundle_regression,
     materialise_native,
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
     from climate_ref_core.regression.store import NativeStore
     from climate_ref_core.testing import TestCase, TestCasePaths
 
-SLOT_REGRESSION_DIRNAME = "regression"
+SLOT_REGRESSION_DIRNAME = COMMITTED_DIRNAME
 
 
 class StageError(Exception):

--- a/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
@@ -562,13 +562,13 @@ class TestCommittedDiff:
         assert case.committed[0].text.note is None
 
 
-def _manifest(native):
-    """Build a manifest carrying only the native entries a tree is built from."""
+def _manifest(native, committed=None):
+    """Build a manifest carrying only what a tree is built from."""
     return Manifest(
         schema=SCHEMA_VERSION,
         test_case_version=1,
         diagnostic_version=1,
-        committed={},
+        committed=committed or {},
         native=native,
     )
 
@@ -614,3 +614,22 @@ class TestBaselineTree:
 
     def test_a_case_with_no_manifests_has_no_tree(self):
         assert baseline_tree(_report([]).cases[0]) == ()
+
+    def test_the_committed_bundle_is_listed_under_regression(self):
+        entry = NativeEntry(sha256="1" * 64, size=10)
+        case = _report(
+            [],
+            base=_manifest({"plot.png": entry}, {"series.json": "a" * 64}),
+            head=_manifest({"plot.png": entry}, {"series.json": "b" * 64}),
+        ).cases[0]
+
+        assert [(node.name, node.depth, node.is_dir, node.status) for node in baseline_tree(case)] == [
+            ("plot.png", 0, False, None),
+            ("regression", 0, True, None),
+            ("series.json", 1, False, "changed"),
+        ]
+
+    def test_a_committed_artefact_has_no_size(self):
+        case = _report([], head=_manifest({}, {"series.json": "a" * 64})).cases[0]
+
+        assert baseline_tree(case)[-1].size is None

--- a/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
@@ -576,10 +576,11 @@ def _manifest(native, committed=None):
 class TestBaselineTree:
     def test_directories_are_emitted_once_before_their_files(self):
         entry = NativeEntry(sha256="1" * 64, size=10)
+        added = NativeEntry(sha256="2" * 64, size=10)
         case = _report(
-            [],
+            [_file_change("plots/b.png", None, added)],
             base=_manifest({"plots/a.png": entry}),
-            head=_manifest({"plots/a.png": entry, "plots/b.png": evolve(entry, sha256="2" * 64)}),
+            head=_manifest({"plots/a.png": entry, "plots/b.png": added}),
         ).cases[0]
 
         assert [(node.name, node.depth, node.is_dir, node.status) for node in baseline_tree(case)] == [
@@ -606,7 +607,11 @@ class TestBaselineTree:
 
     def test_a_removed_file_keeps_its_place_in_the_listing(self):
         entry = NativeEntry(sha256="1" * 64, size=10)
-        case = _report([], base=_manifest({"gone.png": entry}), head=_manifest({})).cases[0]
+        case = _report(
+            [_file_change("gone.png", entry, None)],
+            base=_manifest({"gone.png": entry}),
+            head=_manifest({}),
+        ).cases[0]
 
         assert [(node.name, node.status, node.size) for node in baseline_tree(case)] == [
             ("gone.png", "removed", 10)
@@ -619,6 +624,7 @@ class TestBaselineTree:
         entry = NativeEntry(sha256="1" * 64, size=10)
         case = _report(
             [],
+            committed=[_committed()],
             base=_manifest({"plot.png": entry}, {"series.json": "a" * 64}),
             head=_manifest({"plot.png": entry}, {"series.json": "b" * 64}),
         ).cases[0]

--- a/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
@@ -12,18 +12,21 @@ from climate_ref.baseline_report.analyse import (
     MAX_FETCH_BYTES,
     NETCDF_FETCH_BYTES,
     analyse,
+    baseline_tree,
     blob_url,
+    committed_diff,
     netcdf_diff,
     text_diff,
 )
 from climate_ref.baseline_report.collect import (
     CaseChange,
+    CommittedChange,
     FileChange,
     FileKind,
     Report,
     classify,
 )
-from climate_ref_core.regression.manifest import NativeEntry
+from climate_ref_core.regression.manifest import SCHEMA_VERSION, Manifest, NativeEntry
 from climate_ref_core.regression.store import NativeStore
 
 
@@ -37,15 +40,15 @@ def _file_change(name, old, new):
     return FileChange(name=name, old=old, new=new, kind=classify(name))
 
 
-def _report(files):
+def _report(files, committed=(), base=None, head=None):
     """Wrap file changes in a single-case report."""
     case = CaseChange(
         label="example/diag/case",
         rel_path="packages/climate-ref-example/tests/test-data/diag/case/manifest.json",
-        base=None,
-        head=None,
+        base=base,
+        head=head,
         files=tuple(files),
-        committed=(),
+        committed=tuple(committed),
         metadata=(),
     )
     return Report(base_ref="origin/main", head_sha="a" * 40, cases=(case,))
@@ -506,3 +509,108 @@ class TestAnalyseNetcdf:
         file = analyse(report, store, fetch=False, workdir=tmp_path).cases[0].files[0]
 
         assert file.netcdf.note == "fetching disabled"
+
+
+def _committed(**kwargs):
+    """Build one committed artefact change, defaulting to a changed ``series.json``."""
+    fields = {
+        "name": "series.json",
+        "rel_path": "packages/climate-ref-example/tests/test-data/diag/case/regression/series.json",
+        "old": "a" * 64,
+        "new": "b" * 64,
+        "old_text": '{"value": 1}',
+        "new_text": '{"value": 2}',
+    }
+    fields.update(kwargs)
+    return CommittedChange(**fields)
+
+
+class TestCommittedDiff:
+    def test_json_is_pretty_printed_before_diffing(self):
+        diff = committed_diff(_committed())
+
+        assert diff.note is None
+        # A minified bundle would otherwise diff as one unreadable line.
+        assert '-  "value": 1' in [line.text for line in diff.lines]
+        assert '+  "value": 2' in [line.text for line in diff.lines]
+
+    def test_an_added_artefact_diffs_against_nothing(self):
+        diff = committed_diff(_committed(old=None, old_text=None))
+
+        assert diff.note is None
+        assert diff.lines[0].text == "--- (absent)"
+
+    def test_an_unreadable_base_side_leaves_a_note(self):
+        diff = committed_diff(_committed(old_text=None))
+
+        assert diff.note == "could not read the base version from git"
+
+    def test_an_unreadable_head_side_leaves_a_note(self):
+        diff = committed_diff(_committed(new_text=None))
+
+        assert diff.note == "could not read the working tree version"
+
+    def test_the_diff_reaches_the_analysed_case(self, tmp_path):
+        store = MagicMock(spec=NativeStore)
+        store.url = "https://store"
+        store.root = None
+        report = _report([], committed=[_committed()])
+
+        case = analyse(report, store, fetch=False, workdir=tmp_path).cases[0]
+
+        assert [item.change.name for item in case.committed] == ["series.json"]
+        assert case.committed[0].text.note is None
+
+
+def _manifest(native):
+    """Build a manifest carrying only the native entries a tree is built from."""
+    return Manifest(
+        schema=SCHEMA_VERSION,
+        test_case_version=1,
+        diagnostic_version=1,
+        committed={},
+        native=native,
+    )
+
+
+class TestBaselineTree:
+    def test_directories_are_emitted_once_before_their_files(self):
+        entry = NativeEntry(sha256="1" * 64, size=10)
+        case = _report(
+            [],
+            base=_manifest({"plots/a.png": entry}),
+            head=_manifest({"plots/a.png": entry, "plots/b.png": evolve(entry, sha256="2" * 64)}),
+        ).cases[0]
+
+        assert [(node.name, node.depth, node.is_dir, node.status) for node in baseline_tree(case)] == [
+            ("plots", 0, True, None),
+            ("a.png", 1, False, None),
+            ("b.png", 1, False, "added"),
+        ]
+
+    def test_a_nested_directory_is_only_reopened_when_it_changes(self):
+        entry = NativeEntry(sha256="1" * 64, size=10)
+        case = _report(
+            [],
+            head=_manifest({"a/b/one.nc": entry, "a/c/two.nc": entry, "top.png": entry}),
+        ).cases[0]
+
+        assert [(node.name, node.depth, node.is_dir) for node in baseline_tree(case)] == [
+            ("a", 0, True),
+            ("b", 1, True),
+            ("one.nc", 2, False),
+            ("c", 1, True),
+            ("two.nc", 2, False),
+            ("top.png", 0, False),
+        ]
+
+    def test_a_removed_file_keeps_its_place_in_the_listing(self):
+        entry = NativeEntry(sha256="1" * 64, size=10)
+        case = _report([], base=_manifest({"gone.png": entry}), head=_manifest({})).cases[0]
+
+        assert [(node.name, node.status, node.size) for node in baseline_tree(case)] == [
+            ("gone.png", "removed", 10)
+        ]
+
+    def test_a_case_with_no_manifests_has_no_tree(self):
+        assert baseline_tree(_report([]).cases[0]) == ()

--- a/packages/climate-ref/tests/unit/baseline_report/test_collect.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_collect.py
@@ -21,6 +21,15 @@ def _digest(char: str) -> str:
     return char * 64
 
 
+def _init_repo(repo_dir):
+    """Initialise a repository that can commit without the caller's git identity."""
+    repo = Repo.init(repo_dir)
+    with repo.config_writer() as writer:
+        writer.set_value("user", "name", "test")
+        writer.set_value("user", "email", "test@example.com")
+    return repo
+
+
 def _write_committed(repo_dir, rel_path, name, text):
     """Write a committed regression artefact alongside the manifest at ``rel_path``."""
     path = repo_dir / rel_path / "regression" / name
@@ -46,10 +55,7 @@ def _write_manifest(repo_dir, rel_path, *, version, native, committed=None, cata
 @pytest.fixture
 def repo(tmp_path):
     """A git repository with one manifest committed twice, the second time with changes."""
-    repo = Repo.init(tmp_path)
-    with repo.config_writer() as writer:
-        writer.set_value("user", "name", "test")
-        writer.set_value("user", "email", "test@example.com")
+    repo = _init_repo(tmp_path)
 
     _write_manifest(
         tmp_path,
@@ -142,10 +148,7 @@ class TestCollect:
         assert [(c.name, c.status) for c in case.committed] == [("series.json", "changed")]
 
     def test_new_case_has_no_base(self, tmp_path):
-        repo = Repo.init(tmp_path)
-        with repo.config_writer() as writer:
-            writer.set_value("user", "name", "test")
-            writer.set_value("user", "email", "test@example.com")
+        repo = _init_repo(tmp_path)
         (tmp_path / "README.md").write_text("seed")
         repo.git.add("-A")
         repo.index.commit("seed")
@@ -180,12 +183,9 @@ class TestCollect:
 
 class TestCommittedChanges:
     @pytest.fixture
-    def repo(self, tmp_path):
+    def committed_repo(self, tmp_path):
         """A repository whose committed ``series.json`` moved between the two commits."""
-        repo = Repo.init(tmp_path)
-        with repo.config_writer() as writer:
-            writer.set_value("user", "name", "test")
-            writer.set_value("user", "email", "test@example.com")
+        repo = _init_repo(tmp_path)
 
         case_dir = str(Path(MANIFEST_PATH).parent)
         _write_manifest(
@@ -214,8 +214,8 @@ class TestCommittedChanges:
         repo.index.commit("head")
         return repo
 
-    def test_both_sides_are_read_out_of_the_repository(self, repo):
-        case = collect(repo, "HEAD~1").cases[0]
+    def test_both_sides_are_read_out_of_the_repository(self, committed_repo):
+        case = collect(committed_repo, "HEAD~1").cases[0]
 
         assert [(c.name, c.status) for c in case.committed] == [
             ("diagnostic.json", "added"),
@@ -227,24 +227,24 @@ class TestCommittedChanges:
         assert changed.new_text == '{"value": 2}'
         assert changed.rel_path == f"{Path(MANIFEST_PATH).parent.as_posix()}/regression/series.json"
 
-    def test_an_added_artefact_has_no_base_side(self, repo):
-        added = collect(repo, "HEAD~1").cases[0].committed[0]
+    def test_an_added_artefact_has_no_base_side(self, committed_repo):
+        added = collect(committed_repo, "HEAD~1").cases[0].committed[0]
 
         assert added.old is None
         assert added.old_text is None
         assert added.new_text == '{"new": true}'
 
-    def test_a_removed_artefact_has_no_head_side(self, repo):
-        removed = collect(repo, "HEAD~1").cases[0].committed[1]
+    def test_a_removed_artefact_has_no_head_side(self, committed_repo):
+        removed = collect(committed_repo, "HEAD~1").cases[0].committed[1]
 
         assert removed.new is None
         assert removed.new_text is None
         assert removed.old_text == "{}"
 
-    def test_an_artefact_missing_from_the_working_tree_leaves_no_text(self, repo, tmp_path):
+    def test_an_artefact_missing_from_the_working_tree_leaves_no_text(self, committed_repo, tmp_path):
         (tmp_path / Path(MANIFEST_PATH).parent / "regression" / "series.json").unlink()
 
-        changed = collect(repo, "HEAD~1").cases[0].committed[-1]
+        changed = collect(committed_repo, "HEAD~1").cases[0].committed[-1]
 
         assert changed.new is not None
         assert changed.new_text is None

--- a/packages/climate-ref/tests/unit/baseline_report/test_collect.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_collect.py
@@ -240,3 +240,11 @@ class TestCommittedChanges:
         assert removed.new is None
         assert removed.new_text is None
         assert removed.old_text == "{}"
+
+    def test_an_artefact_missing_from_the_working_tree_leaves_no_text(self, repo, tmp_path):
+        (tmp_path / Path(MANIFEST_PATH).parent / "regression" / "series.json").unlink()
+
+        changed = collect(repo, "HEAD~1").cases[0].committed[-1]
+
+        assert changed.new is not None
+        assert changed.new_text is None

--- a/packages/climate-ref/tests/unit/baseline_report/test_collect.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_collect.py
@@ -1,5 +1,7 @@
 """Tests for collecting the manifest changes on a branch."""
 
+from pathlib import Path
+
 import pytest
 from git import Repo
 
@@ -17,6 +19,13 @@ MANIFEST_PATH = "packages/climate-ref-example/tests/test-data/global-mean-timese
 def _digest(char: str) -> str:
     """Build a valid sha256 digest from a single repeated hex character."""
     return char * 64
+
+
+def _write_committed(repo_dir, rel_path, name, text):
+    """Write a committed regression artefact alongside the manifest at ``rel_path``."""
+    path = repo_dir / rel_path / "regression" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
 
 
 def _write_manifest(repo_dir, rel_path, *, version, native, committed=None, catalog_hash=None):
@@ -130,7 +139,7 @@ class TestCollect:
         case = collect(repo, "HEAD~1").cases[0]
 
         assert case.metadata == ("test_case_version: 3 -> 4",)
-        assert case.committed == ("series.json",)
+        assert [(c.name, c.status) for c in case.committed] == [("series.json", "changed")]
 
     def test_new_case_has_no_base(self, tmp_path):
         repo = Repo.init(tmp_path)
@@ -167,3 +176,67 @@ class TestCollect:
         repo.index.commit("break the manifest")
 
         assert collect(repo, "HEAD~1").cases == ()
+
+
+class TestCommittedChanges:
+    @pytest.fixture
+    def repo(self, tmp_path):
+        """A repository whose committed ``series.json`` moved between the two commits."""
+        repo = Repo.init(tmp_path)
+        with repo.config_writer() as writer:
+            writer.set_value("user", "name", "test")
+            writer.set_value("user", "email", "test@example.com")
+
+        case_dir = str(Path(MANIFEST_PATH).parent)
+        _write_manifest(
+            tmp_path,
+            MANIFEST_PATH,
+            version=3,
+            native={},
+            committed={"series.json": _digest("a"), "output.json": _digest("c")},
+        )
+        _write_committed(tmp_path, case_dir, "series.json", '{"value": 1}')
+        _write_committed(tmp_path, case_dir, "output.json", "{}")
+        repo.git.add("-A")
+        repo.index.commit("base")
+
+        _write_manifest(
+            tmp_path,
+            MANIFEST_PATH,
+            version=4,
+            native={},
+            committed={"series.json": _digest("b"), "diagnostic.json": _digest("d")},
+        )
+        _write_committed(tmp_path, case_dir, "series.json", '{"value": 2}')
+        _write_committed(tmp_path, case_dir, "diagnostic.json", '{"new": true}')
+        (tmp_path / case_dir / "regression" / "output.json").unlink()
+        repo.git.add("-A")
+        repo.index.commit("head")
+        return repo
+
+    def test_both_sides_are_read_out_of_the_repository(self, repo):
+        case = collect(repo, "HEAD~1").cases[0]
+
+        assert [(c.name, c.status) for c in case.committed] == [
+            ("diagnostic.json", "added"),
+            ("output.json", "removed"),
+            ("series.json", "changed"),
+        ]
+        changed = case.committed[-1]
+        assert changed.old_text == '{"value": 1}'
+        assert changed.new_text == '{"value": 2}'
+        assert changed.rel_path == f"{Path(MANIFEST_PATH).parent.as_posix()}/regression/series.json"
+
+    def test_an_added_artefact_has_no_base_side(self, repo):
+        added = collect(repo, "HEAD~1").cases[0].committed[0]
+
+        assert added.old is None
+        assert added.old_text is None
+        assert added.new_text == '{"new": true}'
+
+    def test_a_removed_artefact_has_no_head_side(self, repo):
+        removed = collect(repo, "HEAD~1").cases[0].committed[1]
+
+        assert removed.new is None
+        assert removed.new_text is None
+        assert removed.old_text == "{}"

--- a/packages/climate-ref/tests/unit/baseline_report/test_render.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_render.py
@@ -15,7 +15,14 @@ from climate_ref.baseline_report.analyse import (
     TextDiff,
     analyse,
 )
-from climate_ref.baseline_report.collect import CaseChange, FileChange, FileKind, Report, classify
+from climate_ref.baseline_report.collect import (
+    CaseChange,
+    CommittedChange,
+    FileChange,
+    FileKind,
+    Report,
+    classify,
+)
 from climate_ref.baseline_report.render import render_case, render_comment, render_index, write_site
 from climate_ref_core.regression.manifest import SCHEMA_VERSION, Manifest, NativeEntry
 from climate_ref_core.regression.store import NativeStore
@@ -72,7 +79,19 @@ def _change(name: str, old: NativeEntry | None, new: NativeEntry | None) -> File
     return FileChange(name=name, old=old, new=new, kind=classify(name))
 
 
-def _case_change(changes, label="example/diag/case", base=None, head=None) -> CaseChange:
+def _committed_change() -> CommittedChange:
+    """Build one changed committed artefact."""
+    return CommittedChange(
+        name="series.json",
+        rel_path="packages/climate-ref-example/tests/test-data/diag/case/regression/series.json",
+        old="a" * 64,
+        new="b" * 64,
+        old_text='{"value": 1}',
+        new_text='{"value": 2}',
+    )
+
+
+def _case_change(changes, label="example/diag/case", base=None, head=None, committed=None) -> CaseChange:
     """Build one collected case."""
     return CaseChange(
         label=label,
@@ -80,7 +99,7 @@ def _case_change(changes, label="example/diag/case", base=None, head=None) -> Ca
         base=base,
         head=head,
         files=tuple(changes),
-        committed=("series.json",),
+        committed=(_committed_change(),) if committed is None else tuple(committed),
         metadata=("test_case_version: 3 -> 4",),
     )
 
@@ -226,7 +245,7 @@ class TestCasePage:
             elided=0,
         )
         report = _analysed(
-            [_case_change([_change("series.csv", _entry("1"), _entry("2"))])],
+            [_case_change([_change("series.csv", _entry("1"), _entry("2"))], committed=())],
             tmp_path,
             diffs={"series.csv": diff},
         )
@@ -241,7 +260,7 @@ class TestCasePage:
         assert spans == ["header", "hunk", "remove", "add"]
 
     def test_a_note_replaces_the_diff(self, tmp_path):
-        report = _analysed([_case_change([_change("series.csv", None, _entry("2"))])], tmp_path)
+        report = _analysed([_case_change([_change("series.csv", None, _entry("2"))], committed=())], tmp_path)
 
         html = render_case(report, report.cases[0])
 
@@ -302,6 +321,34 @@ class TestCasePage:
 
         assert "test_case_version: 3 -&gt; 4" in html
         assert "series.json" in html
+
+    def test_a_committed_artefact_is_diffed_and_pilled(self, changed_image_case):
+        html = render_case(changed_image_case, changed_image_case.cases[0])
+
+        assert '<span class="pill"' in html
+        assert "in PR" in html
+        # The diff of the two committed versions, not just the file's name.
+        assert "-  &#34;value&#34;: 1" in html
+        assert "+  &#34;value&#34;: 2" in html
+        assert "test-data/diag/case/regression/series.json" in html
+
+    def test_the_captured_baseline_is_listed_as_a_tree(self, tmp_path):
+        base = evolve(_manifest(3), native={"plots/kept.png": _entry("1")})
+        head = evolve(
+            _manifest(4),
+            native={"plots/kept.png": _entry("1"), "plots/plot.png": _entry("2", 20)},
+        )
+        report = _analysed(
+            [_case_change([_change("plots/plot.png", None, _entry("2", 20))], base=base, head=head)],
+            tmp_path,
+        )
+
+        html = render_case(report, report.cases[0])
+
+        assert "Captured baseline" in html
+        assert '<code class="dir">plots/</code>' in html
+        # An unchanged file is listed too, so the page describes the whole baseline.
+        assert "kept.png" in html
 
 
 class TestWriteSite:


### PR DESCRIPTION
Diffs the committed bundle artefacts in the baseline diff report, alongside the native outputs. The report already named the artefacts whose digest moved, but a reviewer had to go and find the change themselves.

Both sides are read out of git, the base one with `git show` and the head one from the working tree, so a committed artefact needs no store access to diff. That also means these diffs render when `--no-fetch` is set, unlike the native ones.

Each committed artefact carries an "in PR" pill and its repo path, because those bytes also appear in the pull request's own file list and the two views should not be confused.

Adds a "Captured baseline" listing to each case page as well, showing the folder structure of the native files the manifest holds. Files that did not move are listed too, so the page describes the whole baseline rather than only the delta.
