### PR TITLE
Skip micromamba lockfiles when running in a provider environment

### DIFF
--- a/changelog/922.improvement.md
+++ b/changelog/922.improvement.md
@@ -1,3 +1,2 @@
-Disabled micromamba's file locking for commands run inside a provider environment.
-Every worker on a host previously serialised on a single shared lock file, which could block indefinitely if a stale lock was left behind on a shared filesystem.
+Disabled micromamba's file locking for commands run inside a provider environment causing performance issues on NFS filesystems.
 Environment creation still takes the lock.

--- a/changelog/922.improvement.md
+++ b/changelog/922.improvement.md
@@ -1,0 +1,3 @@
+Disabled micromamba's file locking for commands run inside a provider environment.
+Every worker on a host previously serialised on a single shared lock file, which could block indefinitely if a stale lock was left behind on a shared filesystem.
+Environment creation still takes the lock.

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -567,7 +567,7 @@ class CondaDiagnosticProvider(CommandLineDiagnosticProvider):
     def prefix(self, path: Path) -> None:
         self._prefix = path
 
-    def _launch_env(self) -> dict[str, str]:
+    def _launch_env(self, *, use_lockfiles: bool = True) -> dict[str, str]:
         """
         Environment for a command launched in the conda environment.
 
@@ -575,10 +575,20 @@ class CondaDiagnosticProvider(CommandLineDiagnosticProvider):
         so settings applied to a worker reach every command it launches,
         with the provider's overrides on top.
         HOME falls back to the conda prefix so micromamba has a writable directory.
+
+        Parameters
+        ----------
+        use_lockfiles
+            Whether micromamba should take its file locks.
+            Disable this for commands that only read the environment.
+            An explicit ``MAMBA_USE_LOCKFILES`` in the process environment
+            or in `env_overrides` always wins.
         """
         env = {**os.environ, **self.env_overrides}
         if "HOME" not in env:
             env["HOME"] = str(self.prefix)
+        if not use_lockfiles:
+            env.setdefault("MAMBA_USE_LOCKFILES", "false")
         return env
 
     @property
@@ -753,7 +763,9 @@ class CondaDiagnosticProvider(CommandLineDiagnosticProvider):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
-                env=self._launch_env(),
+                # `micromamba run` only registers a pid under a single shared cache directory,
+                # so its lock serialises every worker on the host for no benefit.
+                env=self._launch_env(use_lockfiles=False),
             )
             logger.info("Command output: \n" + res.stdout)
             logger.info("Command execution successful")

--- a/packages/climate-ref-core/src/climate_ref_core/providers.py
+++ b/packages/climate-ref-core/src/climate_ref_core/providers.py
@@ -763,8 +763,6 @@ class CondaDiagnosticProvider(CommandLineDiagnosticProvider):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
-                # `micromamba run` only registers a pid under a single shared cache directory,
-                # so its lock serialises every worker on the host for no benefit.
                 env=self._launch_env(use_lockfiles=False),
             )
             logger.info("Command output: \n" + res.stdout)

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -276,6 +276,26 @@ class TestCondaDiagnosticProvider:
         # HOME is defaulted at launch so micromamba has a writable directory
         assert "HOME" in provider._launch_env()
 
+    def test_launch_env_disables_lockfiles_on_request(self, config) -> None:
+        provider = CondaDiagnosticProvider("provider_name", "v0.23")
+        provider.configure(config)
+
+        assert "MAMBA_USE_LOCKFILES" not in provider._launch_env()
+        assert provider._launch_env(use_lockfiles=False)["MAMBA_USE_LOCKFILES"] == "false"
+
+    def test_launch_env_keeps_an_explicit_lockfile_setting(
+        self, config, mocker: pytest_mock.MockFixture
+    ) -> None:
+        mocker.patch.object(
+            climate_ref_core.providers.os,
+            "environ",
+            {"MAMBA_USE_LOCKFILES": "true"},
+        )
+        provider = CondaDiagnosticProvider("provider_name", "v0.23")
+        provider.configure(config)
+
+        assert provider._launch_env(use_lockfiles=False)["MAMBA_USE_LOCKFILES"] == "true"
+
     def test_launch_env_merges_the_live_environment(self, config, mocker: pytest_mock.MockFixture) -> None:
         mocker.patch.object(
             climate_ref_core.providers.os,
@@ -560,6 +580,7 @@ class TestCondaDiagnosticProvider:
             assert env["existing_var"] == "existing_value"
             assert env["test_var"] == "test_value"
             assert env["HOME"] == str(provider.prefix)
+            assert env["MAMBA_USE_LOCKFILES"] == "false"
 
     def test_run_command_fails(self, mocker: pytest_mock.MockerFixture, tmp_path, provider):
         """Test that run() re-raises CalledProcessError when command fails."""

--- a/packages/climate-ref-core/tests/unit/test_providers.py
+++ b/packages/climate-ref-core/tests/unit/test_providers.py
@@ -276,7 +276,8 @@ class TestCondaDiagnosticProvider:
         # HOME is defaulted at launch so micromamba has a writable directory
         assert "HOME" in provider._launch_env()
 
-    def test_launch_env_disables_lockfiles_on_request(self, config) -> None:
+    def test_launch_env_disables_lockfiles_on_request(self, config, mocker: pytest_mock.MockFixture) -> None:
+        mocker.patch.object(climate_ref_core.providers.os, "environ", {})
         provider = CondaDiagnosticProvider("provider_name", "v0.23")
         provider.configure(config)
 


### PR DESCRIPTION
Skips micromamba's file locking for commands run inside a provider environment.

`micromamba run` takes an exclusive lock on a single shared cache directory (`$XDG_CACHE_HOME/mamba/proc`) just to register and deregister its pid. That directory is shared by every micromamba invocation on a host, so every worker serialises on one lock file. This isn't needed for every run and causes performance issues on NFS file systems.

An explicit `MAMBA_USE_LOCKFILES` wins.

A read-only `~/.cache` still breaks `micromamba run`, with or without locking, because micromamba goes on to list the proc directory it could not create. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Disabled micromamba file locking for commands run inside provider environments, helping prevent worker serialisation and indefinite waits caused by stale locks.
  - Environment creation continues to use file locking.
  - Explicit `MAMBA_USE_LOCKFILES` settings remain respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->