### PR TITLE
Mark tiny baseline diffs as noise rather than as changes

### DIFF
--- a/changelog/923.improvement.md
+++ b/changelog/923.improvement.md
@@ -1,1 +1,5 @@
-Baseline diff reports now shade a NetCDF variable amber and tag it `noise` when every difference is within `1e-9` of the variable's own magnitude, instead of shading it as a real change. This keeps the last-bit wobble of a run reproduced on different hardware from burying the rows that actually moved.
+Baseline diff reports now shade a NetCDF variable amber and tag it `noise`
+when every difference is within `1e-9` of the base ref's own magnitude,
+instead of shading it as a real change.
+This keeps the last-bit wobble of a run reproduced on different hardware
+from burying the rows that actually moved.

--- a/changelog/923.improvement.md
+++ b/changelog/923.improvement.md
@@ -1,2 +1,5 @@
 Baseline diff reports now shade a NetCDF variable amber and tag it `noise`
-when the relative difference is than 1e-9.
+when every difference is at most `1e-9` times the base ref's own magnitude,
+instead of shading it as a real change.
+This keeps the last-bit wobble of a run reproduced on different hardware
+from burying the rows that actually moved.

--- a/changelog/923.improvement.md
+++ b/changelog/923.improvement.md
@@ -1,5 +1,2 @@
 Baseline diff reports now shade a NetCDF variable amber and tag it `noise`
-when every difference is at most `1e-9` times the base ref's own magnitude,
-instead of shading it as a real change.
-This keeps the last-bit wobble of a run reproduced on different hardware
-from burying the rows that actually moved.
+when the relative difference is than 1e-9.

--- a/changelog/923.improvement.md
+++ b/changelog/923.improvement.md
@@ -1,0 +1,1 @@
+Baseline diff reports now shade a NetCDF variable amber and tag it `noise` when every difference is within `1e-9` of the variable's own magnitude, instead of shading it as a real change. This keeps the last-bit wobble of a run reproduced on different hardware from burying the rows that actually moved.

--- a/changelog/923.improvement.md
+++ b/changelog/923.improvement.md
@@ -1,5 +1,5 @@
 Baseline diff reports now shade a NetCDF variable amber and tag it `noise`
-when every difference is within `1e-9` of the base ref's own magnitude,
+when every difference is at most `1e-9` times the base ref's own magnitude,
 instead of shading it as a real change.
 This keeps the last-bit wobble of a run reproduced on different hardware
 from burying the rows that actually moved.

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -49,6 +49,11 @@ MAX_DECODED_BYTES = 500_000_000
 # Unified-diff lines kept per file before the rest is elided.
 MAX_DIFF_LINES = 5000
 
+# A difference this small relative to the variable's own magnitude reads as numerical noise.
+# Double precision carries about 16 significant digits, so this leaves several digits of headroom
+# for a real change to sit above.
+NOISE_REL_TOLERANCE = 1e-9
+
 
 @frozen
 class DiffLine:
@@ -85,16 +90,21 @@ class Pair[T]:
     new: T | None
     """The value on HEAD, or ``None`` when it could not be computed."""
 
+    tolerance: float = 0.0
+    """How far a numeric pair may move before it reads as changed. Zero compares exactly."""
+
     @property
     def changed(self) -> bool:
         """
-        Whether the two sides differ.
+        Whether the two sides differ by more than :attr:`tolerance`.
 
         Returns
         -------
         :
             ``True`` when the value moved, which is what emphasises it in the table.
         """
+        if isinstance(self.old, float) and isinstance(self.new, float):
+            return abs(self.new - self.old) > self.tolerance
         return self.old != self.new
 
 
@@ -133,16 +143,37 @@ class StatRow:
     """Whether anything about this variable changed, which is what shades its row."""
 
     @property
-    def differs(self) -> bool:
+    def severity(self) -> str:
         """
-        Whether the cell by cell comparison found a change.
+        How much weight the row deserves.
+
+        A run reproduced on different hardware moves the last bits of nearly every cell, so a
+        row that only moved that far is called out as noise rather than as a change.
 
         Returns
         -------
         :
-            ``True`` when at least one cell moved, which is what emphasises the diff columns.
+            ``changed`` when the move is larger than :data:`NOISE_REL_TOLERANCE` or cannot be
+            measured, ``noise`` when it is smaller, and ``same`` when nothing moved.
         """
-        return bool(self.cells_differ)
+        if not self.moved:
+            return "same"
+        if self.max_rel_diff is None or self.max_rel_diff > NOISE_REL_TOLERANCE:
+            return "changed"
+        return "noise"
+
+    @property
+    def differs(self) -> bool:
+        """
+        Whether the cell by cell comparison found a change worth reading.
+
+        Returns
+        -------
+        :
+            ``True`` when at least one cell moved further than the noise tolerance, which is
+            what emphasises the diff columns.
+        """
+        return bool(self.cells_differ) and self.severity == "changed"
 
 
 @frozen
@@ -724,13 +755,14 @@ def _stat_row(old: xr.Dataset | None, new: xr.Dataset | None, name: str) -> Stat
     min_new, max_new, mean_new, nan_new = _summarise(new_values)
     scale = max(abs(min_old), abs(max_old)) if min_old is not None and max_old is not None else 0.0
     max_abs_diff, max_rel_diff, cells_differ = _compare(old_values, new_values, scale)
+    tolerance = scale * NOISE_REL_TOLERANCE
     shape = Pair(old=shape_old, new=shape_new)
     return StatRow(
         name=name,
         shape=shape,
-        minimum=Pair(old=min_old, new=min_new),
-        maximum=Pair(old=max_old, new=max_new),
-        mean=Pair(old=mean_old, new=mean_new),
+        minimum=Pair(old=min_old, new=min_new, tolerance=tolerance),
+        maximum=Pair(old=max_old, new=max_new, tolerance=tolerance),
+        mean=Pair(old=mean_old, new=mean_new, tolerance=tolerance),
         nan=Pair(old=nan_old, new=nan_new),
         max_abs_diff=max_abs_diff,
         max_rel_diff=max_rel_diff,

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -51,7 +51,7 @@ MAX_DIFF_LINES = 5000
 
 # A difference this small relative to the base ref's magnitude reads as numerical noise.
 # Double precision carries about 16 significant digits, so a real change has room to sit above.
-NOISE_REL_TOLERANCE = 1e-9
+NOISE_RTOL = 1e-9
 
 
 @frozen
@@ -89,24 +89,24 @@ class Pair[T]:
     new: T | None
     """The value on HEAD, or ``None`` when it could not be computed."""
 
-    tolerance: float = 0.0
+    atol: float = 0.0
     """How far a numeric pair may move before it reads as changed. Zero compares exactly."""
 
     @property
     def changed(self) -> bool:
         """
-        Whether the two sides differ by more than :attr:`tolerance`.
+        Whether the two sides differ by more than :attr:`atol`.
 
         Returns
         -------
         :
-            ``True`` when the value moved further than :attr:`tolerance`, which is what
+            ``True`` when the value moved further than :attr:`atol`, which is what
             emphasises it in the table.
         """
         if self.old == self.new:
             return False
         if isinstance(self.old, float) and isinstance(self.new, float):
-            return not abs(self.new - self.old) <= self.tolerance
+            return not abs(self.new - self.old) <= self.atol
         return True
 
 
@@ -141,11 +141,11 @@ class StatRow:
     cells_differ: int | None
     """Cells that changed, counting NaN as equal to NaN."""
 
-    tolerance: float
+    atol: float
     """
     How far a value may move before it counts as changed.
 
-    :data:`NOISE_REL_TOLERANCE` scaled by the base ref's own magnitude, so one number governs
+    :data:`NOISE_RTOL` scaled by the base ref's own magnitude, so one number governs
     both the row's verdict and which of its statistics are emphasised.
     """
 
@@ -163,12 +163,12 @@ class StatRow:
         Returns
         -------
         :
-            ``changed`` when the move is larger than :attr:`tolerance` or cannot be measured,
+            ``changed`` when the move is larger than :attr:`atol` or cannot be measured,
             ``noise`` when it is smaller, and ``same`` when nothing moved.
         """
         if not self.moved:
             return "same"
-        if self.max_abs_diff is None or self.max_abs_diff > self.tolerance:
+        if self.max_abs_diff is None or self.max_abs_diff > self.atol:
             return "changed"
         return "noise"
 
@@ -180,7 +180,7 @@ class StatRow:
         Returns
         -------
         :
-            ``True`` when at least one cell moved further than the noise tolerance, which is
+            ``True`` when at least one cell moved further than :attr:`atol`, which is
             what emphasises the diff columns.
         """
         return bool(self.cells_differ) and self.severity == "changed"
@@ -765,19 +765,19 @@ def _stat_row(old: xr.Dataset | None, new: xr.Dataset | None, name: str) -> Stat
     min_new, max_new, mean_new, nan_new = _summarise(new_values)
     scale = max(abs(min_old), abs(max_old)) if min_old is not None and max_old is not None else 0.0
     max_abs_diff, max_rel_diff, cells_differ = _compare(old_values, new_values, scale)
-    tolerance = scale * NOISE_REL_TOLERANCE
+    atol = scale * NOISE_RTOL
     shape = Pair(old=shape_old, new=shape_new)
     return StatRow(
         name=name,
         shape=shape,
-        minimum=Pair(old=min_old, new=min_new, tolerance=tolerance),
-        maximum=Pair(old=max_old, new=max_new, tolerance=tolerance),
-        mean=Pair(old=mean_old, new=mean_new, tolerance=tolerance),
+        minimum=Pair(old=min_old, new=min_new, atol=atol),
+        maximum=Pair(old=max_old, new=max_new, atol=atol),
+        mean=Pair(old=mean_old, new=mean_new, atol=atol),
         nan=Pair(old=nan_old, new=nan_new),
         max_abs_diff=max_abs_diff,
         max_rel_diff=max_rel_diff,
         cells_differ=cells_differ,
-        tolerance=tolerance,
+        atol=atol,
         moved=(cells_differ or 0) > 0 or shape.changed,
     )
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -141,6 +141,14 @@ class StatRow:
     cells_differ: int | None
     """Cells that changed, counting NaN as equal to NaN."""
 
+    tolerance: float
+    """
+    How far a value may move before it counts as changed.
+
+    :data:`NOISE_REL_TOLERANCE` scaled by the base ref's own magnitude, so one number governs
+    both the row's verdict and which of its statistics are emphasised.
+    """
+
     moved: bool
     """Whether anything about this variable changed, however small the change."""
 
@@ -155,12 +163,12 @@ class StatRow:
         Returns
         -------
         :
-            ``changed`` when the move is larger than :data:`NOISE_REL_TOLERANCE` or cannot be
-            measured, ``noise`` when it is smaller, and ``same`` when nothing moved.
+            ``changed`` when the move is larger than :attr:`tolerance` or cannot be measured,
+            ``noise`` when it is smaller, and ``same`` when nothing moved.
         """
         if not self.moved:
             return "same"
-        if self.max_rel_diff is None or self.max_rel_diff > NOISE_REL_TOLERANCE:
+        if self.max_abs_diff is None or self.max_abs_diff > self.tolerance:
             return "changed"
         return "noise"
 
@@ -769,6 +777,7 @@ def _stat_row(old: xr.Dataset | None, new: xr.Dataset | None, name: str) -> Stat
         max_abs_diff=max_abs_diff,
         max_rel_diff=max_rel_diff,
         cells_differ=cells_differ,
+        tolerance=tolerance,
         moved=(cells_differ or 0) > 0 or shape.changed,
     )
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -13,7 +13,7 @@ from collections import Counter
 from contextlib import ExitStack
 from itertools import islice
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import xarray as xr
@@ -49,9 +49,8 @@ MAX_DECODED_BYTES = 500_000_000
 # Unified-diff lines kept per file before the rest is elided.
 MAX_DIFF_LINES = 5000
 
-# A difference this small relative to the variable's own magnitude reads as numerical noise.
-# Double precision carries about 16 significant digits, so this leaves several digits of headroom
-# for a real change to sit above.
+# A difference this small relative to the base ref's magnitude reads as numerical noise.
+# Double precision carries about 16 significant digits, so a real change has room to sit above.
 NOISE_REL_TOLERANCE = 1e-9
 
 
@@ -101,11 +100,14 @@ class Pair[T]:
         Returns
         -------
         :
-            ``True`` when the value moved, which is what emphasises it in the table.
+            ``True`` when the value moved further than :attr:`tolerance`, which is what
+            emphasises it in the table.
         """
+        if self.old == self.new:
+            return False
         if isinstance(self.old, float) and isinstance(self.new, float):
-            return abs(self.new - self.old) > self.tolerance
-        return self.old != self.new
+            return not abs(self.new - self.old) <= self.tolerance
+        return True
 
 
 @frozen
@@ -140,10 +142,10 @@ class StatRow:
     """Cells that changed, counting NaN as equal to NaN."""
 
     moved: bool
-    """Whether anything about this variable changed, which is what shades its row."""
+    """Whether anything about this variable changed, however small the change."""
 
     @property
-    def severity(self) -> str:
+    def severity(self) -> Literal["same", "noise", "changed"]:
         """
         How much weight the row deserves.
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/render.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/render.py
@@ -140,7 +140,7 @@ def _build_env() -> Environment:
     env.filters["num"] = _format_num
     env.filters["dash"] = _format_dash
     env.filters["short"] = _format_short
-    env.globals["noise_tolerance"] = _format_num(NOISE_REL_TOLERANCE)
+    env.globals["noise_tolerance"] = NOISE_REL_TOLERANCE
     return env
 
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/render.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/render.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from attrs import frozen
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from climate_ref.baseline_report.analyse import NOISE_REL_TOLERANCE, SHORT_DIGEST
+from climate_ref.baseline_report.analyse import NOISE_RTOL, SHORT_DIGEST
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -140,7 +140,7 @@ def _build_env() -> Environment:
     env.filters["num"] = _format_num
     env.filters["dash"] = _format_dash
     env.filters["short"] = _format_short
-    env.globals["noise_tolerance"] = NOISE_REL_TOLERANCE
+    env.globals["noise_rtol"] = NOISE_RTOL
     return env
 
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/render.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/render.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from attrs import frozen
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from climate_ref.baseline_report.analyse import SHORT_DIGEST
+from climate_ref.baseline_report.analyse import NOISE_REL_TOLERANCE, SHORT_DIGEST
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -140,6 +140,7 @@ def _build_env() -> Environment:
     env.filters["num"] = _format_num
     env.filters["dash"] = _format_dash
     env.filters["short"] = _format_short
+    env.globals["noise_tolerance"] = _format_num(NOISE_REL_TOLERANCE)
     return env
 
 

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -149,7 +149,7 @@ was {{ file.change.old.size | bytes -}}
 {% for row in file.netcdf.rows %}
 <tr{% if row.severity != "same" %} class="{{ row.severity }}"{% endif %}>
 <td><code>{{ row.name }}</code>
-{%- if row.severity == "noise" %} <span class="pill noise" title="Every difference is within {{ noise_tolerance }} of the base ref's own magnitude, so this reads as numerical noise">noise</span>{% endif %}</td>
+{%- if row.severity == "noise" %} <span class="pill noise" title="Every difference is within {{ noise_tolerance | num }} of the base ref's own magnitude, so this reads as numerical noise">noise</span>{% endif %}</td>
 <td>{{ pair_cell(row.shape.old | dash, row.shape.new | dash, row.shape.changed) }}</td>
 <td>{{ pair_cell(row.minimum.old | num, row.minimum.new | num, row.minimum.changed) }}</td>
 <td>{{ pair_cell(row.maximum.old | num, row.maximum.new | num, row.maximum.changed) }}</td>

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -147,8 +147,9 @@ was {{ file.change.old.size | bytes -}}
 </thead>
 <tbody>
 {% for row in file.netcdf.rows %}
-<tr{% if row.moved %} class="moved"{% endif %}>
-<td><code>{{ row.name }}</code></td>
+<tr{% if row.severity != "same" %} class="{{ row.severity }}"{% endif %}>
+<td><code>{{ row.name }}</code>
+{%- if row.severity == "noise" %} <span class="pill noise" title="Every difference is within {{ noise_tolerance }} of the variable's own magnitude, so this reads as numerical noise">noise</span>{% endif %}</td>
 <td>{{ pair_cell(row.shape.old | dash, row.shape.new | dash, row.shape.changed) }}</td>
 <td>{{ pair_cell(row.minimum.old | num, row.minimum.new | num, row.minimum.changed) }}</td>
 <td>{{ pair_cell(row.maximum.old | num, row.maximum.new | num, row.maximum.changed) }}</td>

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -149,7 +149,9 @@ was {{ file.change.old.size | bytes -}}
 {% for row in file.netcdf.rows %}
 <tr{% if row.severity != "same" %} class="{{ row.severity }}"{% endif %}>
 <td><code>{{ row.name }}</code>
-{%- if row.severity == "noise" %} <span class="pill noise" title="Every difference is within {{ noise_tolerance | num }} of the base ref's own magnitude, so this reads as numerical noise">noise</span>{% endif %}</td>
+{%- if row.severity == "noise" %} <span class="pill noise"
+title="Every difference is at most {{ noise_tolerance | num }} times the base ref's own magnitude,
+so this reads as numerical noise">noise</span>{% endif %}</td>
 <td>{{ pair_cell(row.shape.old | dash, row.shape.new | dash, row.shape.changed) }}</td>
 <td>{{ pair_cell(row.minimum.old | num, row.minimum.new | num, row.minimum.changed) }}</td>
 <td>{{ pair_cell(row.maximum.old | num, row.maximum.new | num, row.maximum.changed) }}</td>

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -149,7 +149,7 @@ was {{ file.change.old.size | bytes -}}
 {% for row in file.netcdf.rows %}
 <tr{% if row.severity != "same" %} class="{{ row.severity }}"{% endif %}>
 <td><code>{{ row.name }}</code>
-{%- if row.severity == "noise" %} <span class="pill noise" title="Every difference is within {{ noise_tolerance }} of the variable's own magnitude, so this reads as numerical noise">noise</span>{% endif %}</td>
+{%- if row.severity == "noise" %} <span class="pill noise" title="Every difference is within {{ noise_tolerance }} of the base ref's own magnitude, so this reads as numerical noise">noise</span>{% endif %}</td>
 <td>{{ pair_cell(row.shape.old | dash, row.shape.new | dash, row.shape.changed) }}</td>
 <td>{{ pair_cell(row.minimum.old | num, row.minimum.new | num, row.minimum.changed) }}</td>
 <td>{{ pair_cell(row.maximum.old | num, row.maximum.new | num, row.maximum.changed) }}</td>

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/macros.html.j2
@@ -150,7 +150,7 @@ was {{ file.change.old.size | bytes -}}
 <tr{% if row.severity != "same" %} class="{{ row.severity }}"{% endif %}>
 <td><code>{{ row.name }}</code>
 {%- if row.severity == "noise" %} <span class="pill noise"
-title="Every difference is at most {{ noise_tolerance | num }} times the base ref's own magnitude,
+title="Every difference is at most {{ noise_rtol | num }} times the base ref's own magnitude,
 so this reads as numerical noise">noise</span>{% endif %}</td>
 <td>{{ pair_cell(row.shape.old | dash, row.shape.new | dash, row.shape.changed) }}</td>
 <td>{{ pair_cell(row.minimum.old | num, row.minimum.new | num, row.minimum.changed) }}</td>

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/report.css
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/report.css
@@ -9,7 +9,9 @@
   --add-fg: #14532d;
   --remove-bg: #fbe4e4;
   --remove-fg: #7f1d1d;
-  --moved-bg: #fdeeee;
+  --changed-bg: #fdeeee;
+  --noise-bg: #fdf4e3;
+  --noise-fg: #7a5200;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -23,7 +25,9 @@
     --add-fg: #86e29b;
     --remove-bg: #3a1c1c;
     --remove-fg: #f2a1a1;
-    --moved-bg: #2c1717;
+    --changed-bg: #2c1717;
+    --noise-bg: #2b2415;
+    --noise-fg: #e0bd72;
   }
 }
 
@@ -179,8 +183,18 @@ summary {
   font-size: 0.9em;
 }
 
-tr.moved {
-  background: var(--moved-bg);
+tr.changed {
+  background: var(--changed-bg);
+}
+
+/* Moved, but only within the noise tolerance, so it should not read as a real difference. */
+tr.noise {
+  background: var(--noise-bg);
+}
+
+.pill.noise {
+  background: var(--noise-bg);
+  color: var(--noise-fg);
 }
 
 /* A baseline file name can be long and has no spaces to break on. */

--- a/packages/climate-ref/src/climate_ref/baseline_report/templates/report.css
+++ b/packages/climate-ref/src/climate_ref/baseline_report/templates/report.css
@@ -193,7 +193,6 @@ tr.noise {
 }
 
 .pill.noise {
-  background: var(--noise-bg);
   color: var(--noise-fg);
 }
 
@@ -249,7 +248,7 @@ tr.noise {
   font-weight: 600;
 }
 
-/* Marks a file that lives in git, so a reviewer can find it in the pull request's own diff. */
+/* A small inline tag, used for a file that lives in git and for a noise row. */
 .pill {
   background: var(--panel);
   border: 1px solid var(--rule);

--- a/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
@@ -308,6 +308,7 @@ class TestNetcdfDiff:
         assert {line.kind for line in diff.header} == {"context"}
         assert len(diff.header) == len(diff.header_old) == len(diff.header_new)
         assert diff.rows[0].moved is False
+        assert diff.rows[0].severity == "same"
         assert diff.rows[0].cells_differ == 0
         assert diff.rows[0].max_abs_diff == 0.0
 
@@ -356,19 +357,6 @@ class TestNetcdfDiff:
         assert row.differs is True
         assert row.maximum.changed is True
 
-    def test_an_unmeasurable_move_is_never_called_noise(self, tmp_path, base_nc):
-        new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-
-        row = netcdf_diff(base_nc, new).rows[0]
-
-        assert row.max_rel_diff is None
-        assert row.severity == "changed"
-
-    def test_an_unchanged_variable_has_no_severity(self, tmp_path, base_nc):
-        new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0], [3.0, 4.0]])
-
-        assert netcdf_diff(base_nc, new).rows[0].severity == "same"
-
     def test_a_changed_shape_cannot_be_compared_cell_by_cell(self, tmp_path, base_nc):
         new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
@@ -380,6 +368,7 @@ class TestNetcdfDiff:
         assert row.shape.new == "2x3"
         assert row.shape.changed is True
         assert row.moved is True
+        assert row.severity == "changed"  # an unmeasurable move is never called noise
 
     def test_a_nan_in_the_same_cell_on_both_sides_is_not_a_change(self, tmp_path):
         old = _write_nc(tmp_path / "old.nc", [[1.0, np.nan], [3.0, 4.0]])

--- a/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
@@ -346,9 +346,9 @@ class TestNetcdfDiff:
         assert row.moved is True
         assert row.severity == "noise"
         assert row.differs is False
-        assert row.maximum.changed is False  # the move is inside the tolerance
+        assert row.maximum.changed is False  # the move is inside atol
 
-    def test_a_difference_just_above_the_tolerance_still_counts(self, tmp_path, base_nc):
+    def test_a_difference_just_above_atol_still_counts(self, tmp_path, base_nc):
         new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0], [3.0, 4.0 + 1e-7]])
 
         row = netcdf_diff(base_nc, new).rows[0]

--- a/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
@@ -334,6 +334,40 @@ class TestNetcdfDiff:
         assert row.differs is True
         assert row.maximum.changed is True  # 4.0 -> 4.5
         assert row.minimum.changed is False
+        assert row.severity == "changed"
+
+    def test_a_last_bit_difference_reads_as_noise(self, tmp_path, base_nc):
+        new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0], [3.0, 4.0 + 1e-14]])
+
+        row = netcdf_diff(base_nc, new).rows[0]
+
+        assert row.cells_differ == 1
+        assert row.moved is True
+        assert row.severity == "noise"
+        assert row.differs is False
+        assert row.maximum.changed is False  # the move is inside the tolerance
+
+    def test_a_difference_just_above_the_tolerance_still_counts(self, tmp_path, base_nc):
+        new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0], [3.0, 4.0 + 1e-7]])
+
+        row = netcdf_diff(base_nc, new).rows[0]
+
+        assert row.severity == "changed"
+        assert row.differs is True
+        assert row.maximum.changed is True
+
+    def test_an_unmeasurable_move_is_never_called_noise(self, tmp_path, base_nc):
+        new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+        row = netcdf_diff(base_nc, new).rows[0]
+
+        assert row.max_rel_diff is None
+        assert row.severity == "changed"
+
+    def test_an_unchanged_variable_has_no_severity(self, tmp_path, base_nc):
+        new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0], [3.0, 4.0]])
+
+        assert netcdf_diff(base_nc, new).rows[0].severity == "same"
 
     def test_a_changed_shape_cannot_be_compared_cell_by_cell(self, tmp_path, base_nc):
         new = _write_nc(tmp_path / "new.nc", [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])

--- a/packages/climate-ref/tests/unit/baseline_report/test_render.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_render.py
@@ -398,7 +398,7 @@ def _netcdf_case(tmp_path, diff, name="out.nc"):
 
 
 class TestNetcdfBlock:
-    def test_only_the_moved_row_is_shaded(self, tmp_path):
+    def test_only_the_changed_row_is_shaded(self, tmp_path):
         diff = _netcdf_diff(
             header=(DiffLine(kind="add", text="+ title: b"),),
             rows=(
@@ -410,7 +410,7 @@ class TestNetcdfBlock:
 
         html = render_case(report, report.cases[0])
 
-        assert html.count('<tr class="moved">') == 1
+        assert html.count('<tr class="changed">') == 1
         assert [attrs.get("class") for attrs in _tags(html, "table")] == ["stats"]
         assert "0.5" in html
         assert "0.125" in html
@@ -436,6 +436,27 @@ class TestNetcdfBlock:
         assert "1 -> 1" in html  # the min did not, so it stays plain
         assert "<strong>0.5</strong>" in html  # and so do the three diff columns
         assert html.count("<strong>") == 4
+
+    def test_a_noise_row_is_shaded_apart_and_emphasises_nothing(self, tmp_path):
+        diff = _netcdf_diff(
+            rows=(
+                _stat_row(
+                    "tas",
+                    moved=True,
+                    maximum=Pair(4.0, 4.0 + 1e-13, tolerance=4e-9),
+                    max_abs_diff=1e-13,
+                    max_rel_diff=2.5e-14,
+                    cells_differ=1,
+                ),
+            ),
+        )
+        report = _netcdf_case(tmp_path, diff)
+
+        html = render_case(report, report.cases[0])
+
+        assert '<tr class="noise">' in html
+        assert '<span class="pill noise"' in html
+        assert "<strong>" not in html
 
     def test_an_unchanged_row_emphasises_nothing(self, tmp_path):
         report = _netcdf_case(tmp_path, _netcdf_diff(rows=(_stat_row("tas", moved=False),)))

--- a/packages/climate-ref/tests/unit/baseline_report/test_render.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_render.py
@@ -376,7 +376,7 @@ def _stat_row(name, *, moved, **overrides):
         max_abs_diff=0.0,
         max_rel_diff=0.0,
         cells_differ=0,
-        tolerance=0.0,
+        atol=0.0,
     )
     fields.update(overrides)
     return StatRow(name=name, moved=moved, **fields)
@@ -444,11 +444,11 @@ class TestNetcdfBlock:
                 _stat_row(
                     "tas",
                     moved=True,
-                    maximum=Pair(4.0, 4.0 + 1e-13, tolerance=4e-9),
+                    maximum=Pair(4.0, 4.0 + 1e-13, atol=4e-9),
                     max_abs_diff=1e-13,
                     max_rel_diff=2.5e-14,
                     cells_differ=1,
-                    tolerance=4e-9,
+                    atol=4e-9,
                 ),
             ),
         )

--- a/packages/climate-ref/tests/unit/baseline_report/test_render.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_render.py
@@ -376,6 +376,7 @@ def _stat_row(name, *, moved, **overrides):
         max_abs_diff=0.0,
         max_rel_diff=0.0,
         cells_differ=0,
+        tolerance=0.0,
     )
     fields.update(overrides)
     return StatRow(name=name, moved=moved, **fields)
@@ -447,6 +448,7 @@ class TestNetcdfBlock:
                     max_abs_diff=1e-13,
                     max_rel_diff=2.5e-14,
                     cells_differ=1,
+                    tolerance=4e-9,
                 ),
             ),
         )


### PR DESCRIPTION
Marks NetCDF statistics that only moved within floating point noise as a warning in the baseline diff report, rather than as a difference. A run reproduced on different hardware moves the last bits of nearly every cell, so almost every row was shaded red and the rows that actually moved were buried.

- A row whose largest relative difference is at or below `1e-9` is shaded amber and tagged `noise`, and its individual statistics are no longer emphasised.
- A move that cannot be measured, such as a changed shape or a changed NaN pattern, still reads as a real change.
- `Pair` gained a tolerance so a mean like `-6.98e-18 -> 8.37e-18` stops reading as moved. The tolerance is scaled by the base ref's own magnitude, so it means nothing for a variable that is entirely zero.
- The row class renamed from `moved` to `changed`, matching the three severities.

Two limits worth naming. The threshold is a module constant with no override, and I'm open to a different value, `1e-9` just leaves several digits of headroom under double precision. The file and case tallies are untouched, so a NetCDF whose every row is noise still counts as changed in the summary. That rollup felt like a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Baseline diff reports now identify numerical differences within the noise tolerance as **noise**.
  - Noise-only differences are shaded amber and labelled with a **noise** tag, helping distinguish them from material changes.
  - Differences exceeding the tolerance continue to be reported and highlighted as changed.

- **Bug Fixes**
  - Insignificant floating-point differences no longer appear as meaningful changes in NetCDF comparison reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->