### PR TITLE
Keep integer and infinite values out of the noise path

### DIFF
--- a/changelog/924.fix.md
+++ b/changelog/924.fix.md
@@ -1,4 +1,1 @@
-Fixed the baseline diff report calling a real change `noise`
-when a variable holds integers or an infinite value.
-An integer difference is now always treated as real,
-and the noise threshold is scaled by the largest finite value on the base ref.
+Fixed the noise determination for integers or an infinite value.

--- a/changelog/924.fix.md
+++ b/changelog/924.fix.md
@@ -1,0 +1,4 @@
+Fixed the baseline diff report calling a real change `noise`
+when a variable holds integers or an infinite value.
+An integer difference is now always treated as real,
+and the noise threshold is scaled by the largest finite value on the base ref.

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -712,8 +712,8 @@ def _scale(values: np.ndarray | None) -> float:
     Returns
     -------
     :
-        The largest finite magnitude, or ``0.0`` when there is none. An infinite value is
-        skipped because scaling by it would tolerate every difference.
+        The largest finite magnitude, or ``0.0`` when there is none.
+        An infinite value is skipped because scaling by it would tolerate every difference.
     """
     if values is None:
         return 0.0
@@ -736,15 +736,14 @@ def _compare(
     new
         The head side, or ``None`` when absent or not numeric.
     scale
-        The base side's largest finite magnitude, which the relative difference is measured
-        against.
+        The base side's largest finite magnitude,
+        which the relative difference is measured against.
 
     Returns
     -------
     :
-        The largest absolute difference, the same relative to ``scale``, and the number of
-        cells that differ. The two differences are ``None`` when a cell moved between NaN and
-        a number, because that gap has no magnitude and the finite maximum would read as zero.
+        The largest absolute difference, the absolute relative difference to ``scale``,
+        and the number of cells that differ.
         All three are ``None`` when the sides cannot be compared.
     """
     if old is None or new is None or old.shape != new.shape:
@@ -792,8 +791,8 @@ def _stat_row(old: xr.Dataset | None, new: xr.Dataset | None, name: str) -> Stat
     min_new, max_new, mean_new, nan_new = _summarise(new_values)
     scale = _scale(old_values)
     max_abs_diff, max_rel_diff, cells_differ = _compare(old_values, new_values, scale)
+
     sides = [values for values in (old_values, new_values) if values is not None]
-    # An integer carries no rounding wobble, so any difference in one is real.
     integral = bool(sides) and all(np.issubdtype(values.dtype, np.integer) for values in sides)
     atol = 0.0 if integral else scale * NOISE_RTOL
     shape = Pair(old=shape_old, new=shape_new)

--- a/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
+++ b/packages/climate-ref/src/climate_ref/baseline_report/analyse.py
@@ -700,6 +700,27 @@ def _summarise(values: np.ndarray | None) -> tuple[float | None, float | None, f
     )
 
 
+def _scale(values: np.ndarray | None) -> float:
+    """
+    Measure the base side's magnitude, which the noise tolerance is taken as a fraction of.
+
+    Parameters
+    ----------
+    values
+        The base side, or ``None`` when the variable is absent or not numeric.
+
+    Returns
+    -------
+    :
+        The largest finite magnitude, or ``0.0`` when there is none. An infinite value is
+        skipped because scaling by it would tolerate every difference.
+    """
+    if values is None:
+        return 0.0
+    finite = np.abs(values[np.isfinite(values)])
+    return float(finite.max()) if finite.size else 0.0
+
+
 def _compare(
     old: np.ndarray | None, new: np.ndarray | None, scale: float
 ) -> tuple[float | None, float | None, int | None]:
@@ -715,7 +736,8 @@ def _compare(
     new
         The head side, or ``None`` when absent or not numeric.
     scale
-        The base side's largest magnitude, which the relative difference is measured against.
+        The base side's largest finite magnitude, which the relative difference is measured
+        against.
 
     Returns
     -------
@@ -732,8 +754,13 @@ def _compare(
     cells_differ = int(np.sum(~((old == new) | (old_nan & new_nan))))
     if np.any(old_nan != new_nan):
         return None, None, cells_differ
-    diff = np.abs(new.astype(float) - old.astype(float))
-    max_abs = 0.0 if np.isnan(diff).all() else float(np.nanmax(diff))
+    if np.issubdtype(old.dtype, np.integer) and np.issubdtype(new.dtype, np.integer):
+        # A float cast collides adjacent integers past 2**53, which would read as no change.
+        exact = np.abs(new.astype(object) - old.astype(object))
+        max_abs = float(exact.max()) if exact.size else 0.0
+    else:
+        diff = np.abs(new.astype(float) - old.astype(float))
+        max_abs = 0.0 if np.isnan(diff).all() else float(np.nanmax(diff))
     return max_abs, max_abs / max(scale, float(np.finfo(float).tiny)), cells_differ
 
 
@@ -763,9 +790,12 @@ def _stat_row(old: xr.Dataset | None, new: xr.Dataset | None, name: str) -> Stat
     new_values = _values(new_variable)
     min_old, max_old, mean_old, nan_old = _summarise(old_values)
     min_new, max_new, mean_new, nan_new = _summarise(new_values)
-    scale = max(abs(min_old), abs(max_old)) if min_old is not None and max_old is not None else 0.0
+    scale = _scale(old_values)
     max_abs_diff, max_rel_diff, cells_differ = _compare(old_values, new_values, scale)
-    atol = scale * NOISE_RTOL
+    sides = [values for values in (old_values, new_values) if values is not None]
+    # An integer carries no rounding wobble, so any difference in one is real.
+    integral = bool(sides) and all(np.issubdtype(values.dtype, np.integer) for values in sides)
+    atol = 0.0 if integral else scale * NOISE_RTOL
     shape = Pair(old=shape_old, new=shape_new)
     return StatRow(
         name=name,

--- a/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
+++ b/packages/climate-ref/tests/unit/baseline_report/test_analyse.py
@@ -424,6 +424,35 @@ class TestNetcdfDiff:
 
         assert row.cells_differ == 1
         assert row.moved is True
+        assert row.max_abs_diff == 1.0
+        assert row.severity == "changed"
+        assert row.differs is True
+
+    def test_a_large_integer_moving_by_one_is_never_noise(self, tmp_path):
+        paths = []
+        for name, cell in (("old.nc", 1_000_000_000), ("new.nc", 1_000_000_001)):
+            path = tmp_path / name
+            values = np.array([[cell, 1], [2, 3]], dtype=np.int64)
+            xr.Dataset({"count": (("lat", "lon"), values)}).to_netcdf(path)
+            paths.append(path)
+
+        row = netcdf_diff(*paths).rows[0]
+
+        assert row.atol == 0.0
+        assert row.severity == "changed"
+
+    def test_an_infinite_base_value_does_not_swallow_a_real_change(self, tmp_path):
+        paths = []
+        for name, cell in (("old.nc", np.inf), ("new.nc", 5.0)):
+            path = tmp_path / name
+            values = np.array([[cell, 1.0], [2.0, 3.0]])
+            xr.Dataset({"tas": (("lat", "lon"), values)}).to_netcdf(path)
+            paths.append(path)
+
+        row = netcdf_diff(*paths).rows[0]
+
+        assert row.atol == pytest.approx(3.0 * 1e-9)  # the largest finite base magnitude
+        assert row.severity == "changed"
 
     @pytest.mark.parametrize(
         ("old_cell", "new_cell"),


### PR DESCRIPTION
Fixes two cases where the noise threshold added in #923 swallowed a real change. CodeRabbit raised both against that PR, but it merged before I could land them.

- An integer variable took its tolerance from its own magnitude, so a count going `1000000000 -> 1000000001` was called noise. An integer carries no rounding wobble, so any difference in one is now real.
- `_compare` cast to float before measuring, so two adjacent integers past `2**53` collapsed to a difference of zero. Integral sides are now differenced exactly.
- A base variable holding `inf` scaled the tolerance to infinity, so every difference fell under it, including `inf -> 5.0`. The scale is now taken from finite base values only.

Each case has a regression test.
